### PR TITLE
fix: Docker publish now runs from target branch, not feature branch

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Determine Docker tags
         id: docker-tags
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BRANCH_NAME: ${{ github.ref_name }}
           SEMVER: ${{ steps.gitversion.outputs.semVer }}
           MAJOR: ${{ steps.gitversion.outputs.major }}
           MINOR: ${{ steps.gitversion.outputs.minor }}
@@ -134,7 +134,7 @@ jobs:
           # Convert repository name to lowercase for Docker
           REPO_LOWER="${REPO,,}"
 
-          if [ "${BASE_REF}" == "master" ]; then
+          if [ "${BRANCH_NAME}" == "master" ]; then
             # Master branch: latest + semver
             TAGS="${REGISTRY}/${REPO_LOWER}:latest"
             TAGS="${TAGS},${REGISTRY}/${REPO_LOWER}:${SEMVER}"
@@ -161,7 +161,7 @@ jobs:
         env:
           TAGS: ${{ steps.docker-tags.outputs.tags }}
           VERSION: ${{ steps.gitversion.outputs.semVer }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BRANCH_NAME: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
         run: |
           # Convert repository name to lowercase for Docker
@@ -180,7 +180,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Pull commands:**" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          if [ "${BASE_REF}" == "master" ]; then
+          if [ "${BRANCH_NAME}" == "master" ]; then
             echo "# Stable (latest)" >> $GITHUB_STEP_SUMMARY
             echo "docker pull ${REGISTRY}/${REPO_LOWER}:latest" >> $GITHUB_STEP_SUMMARY
           else


### PR DESCRIPTION
## Summary

Fixes Docker images being built from the wrong branch context after PR merge.

## Problem
When PR #61 was merged, the workflow ran against the feature branch (`fix/ci-duplicate-runs-on-merge`) instead of the target branch (`develop`). This happened because:
- `pull_request[closed]` event runs in the context of the source branch (feature branch)
- Feature branches get deleted after merge
- Docker images were being built from the wrong branch context

## Solution
Split workflow triggers to separate build validation from Docker publishing:

**Before:**
- Single `pull_request` trigger with `[opened, synchronize, closed]`
- Build and Docker publish both ran on `closed` event (feature branch context)

**After:**  
- `pull_request` trigger: `[opened, synchronize, ready_for_review]` - Runs Build and Test only
- `push` trigger: `[develop, master]` - Runs Docker Publish only

## Benefits
✅ Build validation runs during PR review (feature branch context - correct)  
✅ Docker images publish from target branch after merge (develop/master - correct)  
✅ No duplicate runs (build doesn't run twice)  
✅ Docker images built from the actual merged code, not deleted feature branch  

## Changes
- Added `push` trigger back for develop/master branches
- Removed `closed` from pull_request types  
- Updated build-and-test condition: Only run on pull_request events
- Updated publish-docker condition: Only run on push events to develop/master

🤖 Generated with Claude Code