### PR TITLE
fix: Config save error - replace SetValues() with manual property copying

### DIFF
--- a/TelegramGroupsAdmin.Configuration/Repositories/ConfigRepository.cs
+++ b/TelegramGroupsAdmin.Configuration/Repositories/ConfigRepository.cs
@@ -22,7 +22,7 @@ public class ConfigRepository(AppDbContext context) : IConfigRepository
         {
             // Update existing record - manually copy properties to avoid Id modification error
             // DO NOT use SetValues() - it tries to copy Id which is a key property
-            existing.ChatId = config.ChatId;
+            // NOTE: ChatId is NOT copied - we queried by ChatId, so it's already the same value (immutable natural key)
             existing.SpamDetectionConfig = config.SpamDetectionConfig;
             existing.WelcomeConfig = config.WelcomeConfig;
             existing.LogConfig = config.LogConfig;
@@ -39,7 +39,7 @@ public class ConfigRepository(AppDbContext context) : IConfigRepository
             existing.OpenAIConfig = config.OpenAIConfig;
             existing.SendGridConfig = config.SendGridConfig;
             existing.UpdatedAt = DateTimeOffset.UtcNow;
-            // NOTE: Id and CreatedAt are NOT copied - they are immutable
+            // Immutable properties NOT copied: Id (primary key), ChatId (natural key used for query), CreatedAt (database default)
         }
         else
         {


### PR DESCRIPTION
## Problems Fixed

This PR addresses **three related issues** with config save/load:

### 1. ⚠️ **CRITICAL: Global Config Not Persisting** (Newly Discovered)

**Symptom:** User saves global welcome config, sees "Configuration saved globally" success message, but refreshing the page resets everything back to defaults.

**Root Cause:** `WelcomeSystemConfig.razor` was passing `ChatId = null` to `ConfigService.GetAsync/SaveAsync` for global config. This caused:

- **Load Issue**: Query becomes `WHERE ChatId == NULL` which **NEVER matches in SQL** (NULL comparisons return UNKNOWN, not true). Global config row has `ChatId = 0`, so query returns nothing → loads defaults.

- **Save Issue**: `UpsertAsync` looks for existing record with `WHERE ChatId == NULL`, finds nothing, tries to INSERT with `ChatId = NULL` instead of updating the existing `ChatId = 0` row.

**Why It Appeared To Work:** Save completed without exception and showed success message, but data was either duplicated or not found on reload.

**Solution:** Convert `null` ChatId to `0` before calling ConfigService:
```csharp
// Line 269 - Load
var config = await ConfigService.GetAsync<WelcomeConfig>(ConfigType.Welcome, ChatId ?? 0);

// Line 329 - Save  
await ConfigService.SaveAsync(ConfigType.Welcome, ChatId ?? 0, _config);
```

### 2. 🐛 **SetValues() Modifying Primary Key**

**Original Error:**
```
The property 'ConfigRecordDto.Id' is part of a key and so cannot be modified or marked as modified.
```

**Root Cause:** `ConfigRepository.UpsertAsync` used `SetValues()` which copies ALL properties including the immutable `Id` primary key.

**Solution:** Replace `SetValues()` with manual property copying, explicitly excluding `Id` and `CreatedAt`.

### 3. ✅ **Redundant ChatId Copy** (Claude Code Review)

**Issue:** Copying `ChatId` in `UpsertAsync` is redundant since we queried by `ChatId` (values already match) and semantically wrong (ChatId is the natural key).

**Solution:** Removed `existing.ChatId = config.ChatId;` line.

---

## Files Changed

- `TelegramGroupsAdmin.Configuration/Repositories/ConfigRepository.cs` - Manual property copying (fixes #1, #2)
- `TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor` - Null → 0 conversion (fixes #3, **CRITICAL**)

## Testing

✅ Build passes (0 warnings, 0 errors)  
✅ Ready for testing:
  1. Save global welcome config → Should persist
  2. Refresh page → Should load saved values (not defaults)
  3. Switch between DM/Chat modes → Should save/load correctly

## Impact

Fixes config persistence for:
- ✅ Global welcome message config  
- ✅ Global spam detection config
- ✅ All other global/chat-specific configs

---

**⚠️ Note:** The null → 0 fix is **CRITICAL** - without it, all global config saves appear successful but don't persist. Users would experience data loss on every page refresh.