### PR TITLE
fix: Fix edit message text binding and add edit history tracking

### DIFF
--- a/TelegramGroupsAdmin/Components/Pages/Messages.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Messages.razor
@@ -125,19 +125,19 @@
                 </div>
 
                 @* Message Input (Phase 1: Bot messages) *@
-                <ChatInput IsEnabled="_isFeatureAvailable"
+                <ChatInput IsEnabled="@_isFeatureAvailable"
                            PlaceholderText="@GetChatInputPlaceholder()"
                            MaxMessageLength="@GetMaxMessageLength()"
-                           CurrentText="_editingOriginalText"
+                           CurrentText="@_editingOriginalText"
                            IsEditMode="@(_isEditingMessageId.HasValue)"
-                           ReplyToMessageId="_replyToMessageId"
+                           ReplyToMessageId="@_replyToMessageId"
                            ReplyToUser="@GetReplyToUser()"
                            ReplyToText="@GetReplyToText()"
-                           OnSendMessage="SendMessageAsync"
-                           OnEditMessage="EditMessageAsync"
-                           OnCancelEdit="CancelEdit"
-                           OnCancelReply="CancelReply"
-                           OnReplyPreviewClick="HandleReplyClick" />
+                           OnSendMessage="@SendMessageAsync"
+                           OnEditMessage="@EditMessageAsync"
+                           OnCancelEdit="@CancelEdit"
+                           OnCancelReply="@CancelReply"
+                           OnReplyPreviewClick="@HandleReplyClick" />
             }
         }
         else


### PR DESCRIPTION
## Summary

Fixes two critical bugs in bot message editing functionality:

1. **UI Bug**: ChatInput parameters missing `@` symbols caused literal field names to display
2. **Data Bug**: Edit history not being saved to `message_edits` table

## Changes

### Messages.razor
- **Fixed Razor binding syntax**: Added missing `@` symbols to all ChatInput parameters
  - `IsEnabled`, `CurrentText`, `ReplyToMessageId`
  - All event callbacks: `OnSendMessage`, `OnEditMessage`, `OnCancelEdit`, `OnCancelReply`, `OnReplyPreviewClick`
- **Bug symptom**: Input field displayed `"_editingOriginalText"` instead of actual message text
- **Fix**: Now properly evaluates C# expressions instead of treating them as literal strings

### BotMessageService.cs
- **Added edit history tracking** to `EditAndUpdateMessageAsync()`
- **New dependency**: `IMessageEditService` for managing edit records
- **Process flow**:
  1. Retrieve old message from database (for edit history)
  2. Edit message via Telegram Bot API
  3. Extract URLs and calculate content hashes (old + new)
  4. Save edit record to `message_edits` table
  5. Update `messages` table with new text, URLs, hash, and edit date
- **Pattern consistency**: Follows same logic as `MessageEditProcessor` (hash calculation, URL extraction)
- **Result**: Edit count badge will now appear in UI after bot edits

## Testing

- [x] Build succeeds without warnings
- [ ] Manual testing: Edit a bot message and verify:
  - Input field shows actual message text (not field name)
  - Edit saves successfully to Telegram
  - Edit appears in `message_edits` table
  - Message shows edit count badge in UI

## Related

Fixes bugs discovered after merging PR #75 (Phase 1: Send & Edit Messages as Bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>