### PR TITLE
fix: Enable scrolling in Messages page chat sidebar

### DIFF
--- a/TelegramGroupsAdmin/Components/Pages/Messages.razor.css
+++ b/TelegramGroupsAdmin/Components/Pages/Messages.razor.css
@@ -57,12 +57,6 @@
     color: rgba(255, 255, 255, 0.4);
 }
 
-.chat-list {
-    flex: 1;
-    overflow-y: auto;
-    overflow-x: hidden;
-}
-
 /* Main Chat View */
 .telegram-main {
     flex: 1;
@@ -133,23 +127,19 @@
 }
 
 /* Scrollbar Styling (Telegram-like) */
-.chat-list::-webkit-scrollbar,
 .messages-container::-webkit-scrollbar {
     width: 6px;
 }
 
-.chat-list::-webkit-scrollbar-track,
 .messages-container::-webkit-scrollbar-track {
     background: transparent;
 }
 
-.chat-list::-webkit-scrollbar-thumb,
 .messages-container::-webkit-scrollbar-thumb {
     background: rgba(255, 255, 255, 0.2);
     border-radius: 3px;
 }
 
-.chat-list::-webkit-scrollbar-thumb:hover,
 .messages-container::-webkit-scrollbar-thumb:hover {
     background: rgba(255, 255, 255, 0.3);
 }

--- a/TelegramGroupsAdmin/Components/Shared/ChatList.razor.css
+++ b/TelegramGroupsAdmin/Components/Shared/ChatList.razor.css
@@ -1,7 +1,27 @@
 /* Chat List Component - Telegram Desktop Style */
 
 .chat-list {
-    /* Layout handled by parent - this is just the scrollable content */
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+/* Scrollbar Styling (Telegram-like) */
+.chat-list::-webkit-scrollbar {
+    width: 6px;
+}
+
+.chat-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.chat-list::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 3px;
+}
+
+.chat-list::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.3);
 }
 
 .chat-list-item {


### PR DESCRIPTION
## Summary
- Fix chat sidebar not scrolling when many groups are present
- Move overflow-y: auto and scrollbar styling from Messages.razor.css to ChatList.razor.css
- Remove dead CSS code that was blocked by Blazor CSS isolation

## Root Cause
Blazor CSS isolation adds unique scope identifiers to selectors. The .chat-list element lives in ChatList.razor, so styles defined in Messages.razor.css could not apply to it. The empty .chat-list rule in ChatList.razor.css was claiming the scoped selector without applying the needed overflow styles.

## Test plan
- [x] Verified scrolling works with many groups in sidebar
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)