### PR TITLE
fix: Invite link caching and UI text corrections

### DIFF
--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/ChatManagementService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/ChatManagementService.cs
@@ -634,8 +634,8 @@ public class ChatManagementService(
             // Refresh admin cache in database (for permission checks in commands)
             await RefreshChatAdminsAsync(chatId, cancellationToken);
 
-            // Validate and refresh cached invite link (private groups only)
-            if (chat.Type == ChatType.Supergroup && string.IsNullOrEmpty(chat.Username))
+            // Validate and refresh cached invite link (all groups - public and private)
+            if (chat.Type is ChatType.Supergroup or ChatType.Group)
             {
                 await ValidateInviteLinkAsync(chatId, cancellationToken);
             }
@@ -861,9 +861,9 @@ public class ChatManagementService(
 
     /// <summary>
     /// Validate and update cached invite link from Telegram
-    /// Only applies to private supergroups (not public chats with usernames)
-    /// Fetches current primary link from Telegram and updates cache if changed
-    /// Detects when admin changes/revokes link and keeps cache in sync
+    /// Applies to all groups (public and private)
+    /// - Public groups: Caches https://t.me/{username} link
+    /// - Private groups: Fetches/caches primary invite link (only exports if not cached)
     /// </summary>
     private async Task ValidateInviteLinkAsync(long chatId, CancellationToken cancellationToken = default)
     {

--- a/TelegramGroupsAdmin.Telegram/Services/ChatInviteLinkService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ChatInviteLinkService.cs
@@ -105,6 +105,16 @@ public class ChatInviteLinkService : IChatInviteLinkService
         {
             currentLink = $"https://t.me/{chat.Username}";
             _logger.LogDebug("Got public invite link for chat {ChatId}: {Link}", chatId, currentLink);
+
+            // Cache public group link too (username could change)
+            var cachedConfig = await configRepo.GetByChatIdAsync(chatId, ct);
+            if (cachedConfig?.InviteLink != currentLink)
+            {
+                await configRepo.SaveInviteLinkAsync(chatId, currentLink, ct);
+                _logger.LogDebug("Cached public invite link for chat {ChatId}", chatId);
+            }
+
+            return currentLink;
         }
         else
         {
@@ -132,7 +142,5 @@ public class ChatInviteLinkService : IChatInviteLinkService
             await configRepo.SaveInviteLinkAsync(chatId, currentLink, ct);
             return currentLink;
         }
-
-        return currentLink;
     }
 }

--- a/TelegramGroupsAdmin/Components/Shared/ChatManagement/ChatConfigModal.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ChatManagement/ChatConfigModal.razor
@@ -111,21 +111,21 @@
                                         }
                                     </MudButton>
                                     <MudText Typo="Typo.caption" Class="mud-text-secondary">
-                                        Clear this if admins regenerated the invite link in Telegram. The next health check (within 1 minute) will fetch and cache the fresh link.
+                                        Clear this if admins regenerated the invite link in Telegram. The next health check will fetch and cache the fresh link.
                                     </MudText>
                                 </MudStack>
                             }
                             else
                             {
                                 <MudAlert Severity="Severity.Info">
-                                    No invite link cached yet. The health check will fetch and cache it within 1 minute.
+                                    No invite link cached yet. The next health check will fetch and cache it automatically.
                                 </MudAlert>
                             }
                         </MudPaper>
 
                         <!-- Info message about automatic updates -->
                         <MudAlert Severity="Severity.Info">
-                            Health status updates automatically every minute and when bot permissions change.
+                            Health status updates automatically on a schedule (configurable in Settings → Background Jobs) and when bot permissions change.
                         </MudAlert>
                     </MudStack>
                 }
@@ -455,7 +455,7 @@
             await ConfigRepository.ClearInviteLinkAsync(ChatInfo.Chat.ChatId);
             _cachedInviteLink = null;
             Snackbar.Add(
-                "Cleared cached invite link for this chat. The next health check (within 1 minute) will fetch a fresh link from Telegram.",
+                "Cleared cached invite link for this chat. The next health check will fetch a fresh link from Telegram.",
                 Severity.Success);
         }
         catch (Exception ex)

--- a/TelegramGroupsAdmin/Components/Shared/RestoreBackupModal.razor
+++ b/TelegramGroupsAdmin/Components/Shared/RestoreBackupModal.razor
@@ -1,8 +1,8 @@
 @using TelegramGroupsAdmin.BackgroundJobs.Services.Backup
 @inject IBackupService BackupService
 @inject ISnackbar Snackbar
-@inject NavigationManager Navigation
 @inject IDialogService DialogService
+@inject NavigationManager Navigation
 
 <MudDialog>
     <DialogContent>
@@ -11,7 +11,7 @@
         <MudAlert Severity="Severity.Warning" Class="mb-4">
             <MudText Typo="Typo.body2">
                 This will restore all users, settings, and data from a backup file.
-                After restore completes, log in with credentials from the backup.
+                If your account no longer exists after restore, you'll need to log in with credentials from the backup.
             </MudText>
         </MudAlert>
 
@@ -178,18 +178,10 @@
                 await BackupService.RestoreAsync(_backupBytes);
             }
 
-            Snackbar.Add("System restored successfully! The Telegram bot has been disabled to prevent dual instances. " +
-                        "You'll need to re-enable it if this is the only active instance. Redirecting to login...",
-                        Severity.Success,
-                        config =>
-                        {
-                            config.VisibleStateDuration = 5000; // Show for 5 seconds
-                        });
-
-            // Close dialog and redirect
+            // Close dialog and force page reload to re-evaluate auth state
+            // If user's account no longer exists, auth middleware will redirect to login
             MudDialog.Close(DialogResult.Ok(true));
-            await Task.Delay(5000); // Give user time to read the message (5 seconds)
-            Navigation.NavigateTo("/login", forceLoad: true);
+            Navigation.NavigateTo("/settings/backup", forceLoad: true);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Fix invite link caching for public groups (was not saving `https://t.me/{username}` to database)
- Fix health check skipping public groups for invite link validation
- Remove hardcoded "1 minute" time references (health check interval is configurable)
- Simplify restore backup flow: force reload to same page, auth middleware handles redirect if needed

## Changes

**ChatInviteLinkService.cs:**
- Public groups now cache their `https://t.me/{username}` links to database
- Removed unreachable dead code

**ChatManagementService.cs:**
- Health check now validates invite links for ALL groups (public and private)
- Updated documentation comments

**ChatConfigModal.razor:**
- Removed hardcoded "within 1 minute" references
- Added note that schedule is configurable in Settings → Background Jobs

**RestoreBackupModal.razor:**
- Force reload to /settings/backup after restore (re-evaluates auth state)
- Removed misleading snackbar message about redirect

## Test plan
- [x] Build passes
- [x] Verify public group invite links now appear in Chat Config modal
- [x] Verify restore stays on backup page (or redirects to login if account gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)