### PR TITLE
fix: Resolve TelegramConfigLoader DI and JobTriggerService key mismatch

### DIFF
--- a/TelegramGroupsAdmin.BackgroundJobs/Services/JobTriggerService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/JobTriggerService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Quartz;
 using System.Text.Json;
+using TelegramGroupsAdmin.Core.BackgroundJobs;
 using TelegramGroupsAdmin.Core.Services;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Services;
@@ -37,7 +38,7 @@ public class JobTriggerService(
         var payloadJson = JsonSerializer.Serialize(payload);
         var jobData = new JobDataMap
         {
-            { "payload", payloadJson }
+            { JobDataKeys.PayloadJson, payloadJson }
         };
 
         // Create trigger that fires immediately
@@ -89,7 +90,7 @@ public class JobTriggerService(
         var payloadJson = JsonSerializer.Serialize(payload);
         var jobData = new JobDataMap
         {
-            { "payload", payloadJson }
+            { JobDataKeys.PayloadJson, payloadJson }
         };
 
         // Create trigger that fires once at specified time

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs
@@ -85,7 +85,7 @@ public class DetectionActionService(
             var reportService = scope.ServiceProvider.GetRequiredService<IReportService>();
             var moderationActionService = scope.ServiceProvider.GetRequiredService<ModerationActionService>();
             var botFactory = scope.ServiceProvider.GetRequiredService<ITelegramBotClientFactory>();
-            var configLoader = scope.ServiceProvider.GetRequiredService<TelegramConfigLoader>();
+            var configLoader = scope.ServiceProvider.GetRequiredService<ITelegramConfigLoader>();
             var botToken = await configLoader.LoadConfigAsync();
             var userActionsRepo = scope.ServiceProvider.GetRequiredService<IUserActionsRepository>();
             var managedChatsRepo = scope.ServiceProvider.GetRequiredService<IManagedChatsRepository>();


### PR DESCRIPTION
## Summary

Fixes two critical production bugs discovered after PR #147 merge:

**Bug 1: TelegramConfigLoader DI Resolution Failure**
- `DetectionActionService.cs:88` was requesting the concrete type `TelegramConfigLoader` instead of the interface `ITelegramConfigLoader`
- The service is registered as the interface, causing `InvalidOperationException` during DI resolution
- **Impact:** Spam detection actions failed completely

**Bug 2: JobTriggerService Payload Key Mismatch**  
- `JobTriggerService` was storing payloads with literal key `"payload"`
- All jobs (including `SendChatNotificationJob`) expect `JobDataKeys.PayloadJson` ("PayloadJson")
- **Impact:** All notification jobs failed with "payload not found in job data" error

## Changes

- `DetectionActionService.cs`: Changed `GetRequiredService<TelegramConfigLoader>()` → `GetRequiredService<ITelegramConfigLoader>()`
- `JobTriggerService.cs`: Changed `{ "payload", payloadJson }` → `{ JobDataKeys.PayloadJson, payloadJson }` (both TriggerNowAsync and ScheduleOnceAsync)

## Test Plan

- [x] Build succeeds (0 errors, 0 warnings)
- [x] All 358 unit tests pass
- [x] Verified no other occurrences of concrete type usage
- [x] Manual verification in production environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)