### PR TITLE
refactor: Extract interfaces for concrete services

### DIFF
--- a/TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs
@@ -107,7 +107,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPassphraseManagementService, PassphraseManagementService>();
 
         // Internal handler services (required by BackupService)
-        services.AddScoped<BackupRetentionService>();
+        services.AddScoped<IBackupRetentionService, BackupRetentionService>();
         services.AddScoped<TableDiscoveryService>();
         services.AddScoped<TableExportService>();
         services.AddScoped<DependencyResolutionService>();

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupRetentionInfo.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupRetentionInfo.cs
@@ -1,0 +1,8 @@
+namespace TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
+
+/// <summary>
+/// Result of analyzing a backup's retention status.
+/// </summary>
+/// <param name="PrimaryTier">The highest retention tier this backup qualifies for.</param>
+/// <param name="WillBeKept">Whether this backup will be kept based on retention policy.</param>
+public record BackupRetentionInfo(BackupTier PrimaryTier, bool WillBeKept);

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupRetentionService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupRetentionService.cs
@@ -6,7 +6,7 @@ namespace TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
 /// <summary>
 /// Service for managing backup retention with grandfather-father-son strategy
 /// </summary>
-public class BackupRetentionService
+public class BackupRetentionService : IBackupRetentionService
 {
     private readonly ILogger<BackupRetentionService> _logger;
 
@@ -15,13 +15,7 @@ public class BackupRetentionService
         _logger = logger;
     }
 
-    /// <summary>
-    /// Determines which backup files should be deleted based on retention policy
-    /// Uses grandfather-father-son (5-tier) strategy
-    /// </summary>
-    /// <param name="backupFiles">All backup files with their metadata</param>
-    /// <param name="retentionConfig">Retention configuration</param>
-    /// <returns>List of backup files to delete</returns>
+    /// <inheritdoc/>
     public List<BackupFileInfo> GetBackupsToDelete(
         List<BackupFileInfo> backupFiles,
         RetentionConfig retentionConfig)
@@ -159,10 +153,8 @@ public class BackupRetentionService
         return classified;
     }
 
-    /// <summary>
-    /// Determines the primary (highest) tier for a backup and whether it will be kept
-    /// </summary>
-    public (BackupTier PrimaryTier, bool WillBeKept) GetBackupRetentionInfo(
+    /// <inheritdoc/>
+    public BackupRetentionInfo GetBackupRetentionInfo(
         BackupFileInfo backup,
         List<BackupFileInfo> allBackups,
         RetentionConfig retentionConfig)
@@ -185,7 +177,7 @@ public class BackupRetentionService
         var backupsToDelete = GetBackupsToDelete(allBackups, retentionConfig);
         var willBeKept = !backupsToDelete.Any(b => b.FilePath == backup.FilePath);
 
-        return (primaryTier, willBeKept);
+        return new BackupRetentionInfo(primaryTier, willBeKept);
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
@@ -29,7 +29,7 @@ public class BackupService : IBackupService
     private readonly IPassphraseManagementService _passphraseService;
     private readonly IBackupConfigurationService _configService;
     private readonly DependencyResolutionService _dependencyResolutionService;
-    private readonly BackupRetentionService _retentionService;
+    private readonly IBackupRetentionService _retentionService;
     private const string CurrentVersion = "2.1"; // SCHEMA-3: configs.chat_id NULL → 0 migration
 
     public BackupService(
@@ -45,7 +45,7 @@ public class BackupService : IBackupService
         IPassphraseManagementService passphraseService,
         IBackupConfigurationService configService,
         DependencyResolutionService dependencyResolutionService,
-        BackupRetentionService retentionService)
+        IBackupRetentionService retentionService)
     {
         _dataSource = dataSource;
         _logger = logger;

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/IBackupRetentionService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/IBackupRetentionService.cs
@@ -1,0 +1,26 @@
+namespace TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
+
+/// <summary>
+/// Service for managing backup retention with grandfather-father-son strategy.
+/// </summary>
+public interface IBackupRetentionService
+{
+    /// <summary>
+    /// Determines which backup files should be deleted based on retention policy.
+    /// Uses grandfather-father-son (5-tier) strategy.
+    /// </summary>
+    /// <param name="backupFiles">All backup files with their metadata.</param>
+    /// <param name="retentionConfig">Retention configuration.</param>
+    /// <returns>List of backup files to delete.</returns>
+    List<BackupFileInfo> GetBackupsToDelete(List<BackupFileInfo> backupFiles, RetentionConfig retentionConfig);
+
+    /// <summary>
+    /// Determines the primary (highest) tier for a backup and whether it will be kept.
+    /// </summary>
+    /// <param name="backup">The backup to analyze.</param>
+    /// <param name="allBackups">All backups for context.</param>
+    /// <param name="retentionConfig">Retention configuration.</param>
+    /// <returns>Retention info including tier and keep status.</returns>
+    BackupRetentionInfo GetBackupRetentionInfo(
+        BackupFileInfo backup, List<BackupFileInfo> allBackups, RetentionConfig retentionConfig);
+}

--- a/TelegramGroupsAdmin.ComponentTests/Components/NotificationBellTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/NotificationBellTests.cs
@@ -1,0 +1,121 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using NSubstitute;
+using TelegramGroupsAdmin.Components.Shared;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Services;
+
+namespace TelegramGroupsAdmin.ComponentTests.Components;
+
+/// <summary>
+/// Component tests for NotificationBell.razor
+/// Tests badge visibility, icon colors, and state handling.
+/// Uses INotificationStateService interface (enabled by Issue #127 interface extraction).
+/// </summary>
+/// <remarks>
+/// NotificationBell uses MudMenu which renders ChildContent in a popover.
+/// These tests focus on the activator content (badge, icon) which is testable via bUnit.
+/// The popover content (buttons, notifications list) requires more complex setup to test.
+/// </remarks>
+[TestFixture]
+public class NotificationBellTests : MudBlazorTestContext
+{
+    private readonly INotificationStateService _mockNotificationState;
+
+    public NotificationBellTests()
+    {
+        // Create and register mock in constructor (before base constructor locks service provider)
+        _mockNotificationState = Substitute.For<INotificationStateService>();
+
+        // Default setup: loaded with no notifications
+        _mockNotificationState.IsLoaded.Returns(true);
+        _mockNotificationState.UnreadCount.Returns(0);
+        _mockNotificationState.Notifications.Returns(Array.Empty<WebNotification>());
+
+        // Register mock service - must be in constructor for bUnit
+        Services.AddSingleton(_mockNotificationState);
+    }
+
+    #region Badge Visibility Tests
+
+    [Test]
+    public void ShowsBadge_WhenUnreadCountGreaterThanZero()
+    {
+        // Arrange
+        _mockNotificationState.UnreadCount.Returns(5);
+
+        // Act
+        var cut = Render<NotificationBell>();
+
+        // Assert - badge should be visible with unread count
+        Assert.That(cut.Markup, Does.Contain("5"));
+    }
+
+    [Test]
+    public void HidesBadge_WhenUnreadCountIsZero()
+    {
+        // Arrange
+        _mockNotificationState.UnreadCount.Returns(0);
+
+        // Act
+        var cut = Render<NotificationBell>();
+
+        // Assert - badge should not be visible when unread count is 0
+        // MudBadge with Visible="false" adds the "mud-badge-dot" class or hides the badge element
+        var visibleBadges = cut.FindAll(".mud-badge-visible");
+        Assert.That(visibleBadges.Count, Is.EqualTo(0), "Badge should not be visible when unread count is 0");
+    }
+
+    [Test]
+    public void AppliesWarningColor_WhenUnreadCountGreaterThanZero()
+    {
+        // Arrange
+        _mockNotificationState.UnreadCount.Returns(3);
+
+        // Act
+        var cut = Render<NotificationBell>();
+
+        // Assert - icon button should have warning color
+        // Using FindComponent instead of CSS classes for stability across MudBlazor versions
+        var iconButton = cut.FindComponent<MudIconButton>();
+        Assert.That(iconButton.Instance.Color, Is.EqualTo(Color.Warning));
+    }
+
+    [Test]
+    public void AppliesInheritColor_WhenUnreadCountIsZero()
+    {
+        // Arrange
+        _mockNotificationState.UnreadCount.Returns(0);
+
+        // Act
+        var cut = Render<NotificationBell>();
+
+        // Assert - icon button should have inherit color (default)
+        // Using FindComponent instead of CSS classes for stability across MudBlazor versions
+        var iconButton = cut.FindComponent<MudIconButton>();
+        Assert.That(iconButton.Instance.Color, Is.EqualTo(Color.Inherit));
+    }
+
+    #endregion
+
+    #region Badge Content Tests
+
+    [Test]
+    [TestCase(1)]
+    [TestCase(5)]
+    [TestCase(99)]
+    public void DisplaysCorrectUnreadCount(int unreadCount)
+    {
+        // Arrange
+        _mockNotificationState.UnreadCount.Returns(unreadCount);
+
+        // Act
+        var cut = Render<NotificationBell>();
+
+        // Assert - badge should display the unread count
+        Assert.That(cut.Markup, Does.Contain(unreadCount.ToString()));
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs
@@ -1,20 +1,417 @@
-// =============================================================================
-// BLOCKED: Interfaces required for component testing
-// =============================================================================
-// This component cannot be tested with bUnit until interfaces are extracted
-// for the following concrete services (NSubstitute cannot mock classes without
-// parameterless constructors):
-//
-//   - TelegramUserManagementService → ITelegramUserManagementService
-//   - ModerationActionService → IModerationActionService
-//   - BlazorAuthHelper → IBlazorAuthHelper
-//
-// See GitHub Issue #23: "REFACTOR-18: Extract Interfaces for Integration Testing"
-// https://github.com/musicislife08/TelegramGroupsAdmin/issues/23
-//
-// Workaround: Test via Playwright E2E tests instead.
-// =============================================================================
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using TelegramGroupsAdmin.Components.Shared;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Helpers;
+using TelegramGroupsAdmin.Services;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
+using TelegramGroupsAdmin.Telegram.Services.Moderation;
 
 namespace TelegramGroupsAdmin.ComponentTests.Components;
 
-// Component tests for UserDetailDialog.razor will be added after issue #23 is resolved.
+/// <summary>
+/// Component tests for UserDetailDialog.razor
+/// Tests loading states, user profile display, quick action buttons visibility.
+/// Uses ITelegramUserManagementService and IModerationOrchestrator interfaces
+/// (enabled by Issue #127 interface extraction).
+/// </summary>
+/// <remarks>
+/// MudDialog components require MudDialogProvider to render properly.
+/// Tests use the DialogService.ShowAsync pattern and check markup on the provider.
+/// </remarks>
+[TestFixture]
+public class UserDetailDialogTests : MudBlazorTestContext
+{
+    private ITelegramUserManagementService _mockUserService = null!;
+    private IModerationOrchestrator _mockModerationService = null!;
+    private IAdminNotesRepository _mockNotesRepo = null!;
+    private IUserTagsRepository _mockTagsRepo = null!;
+    private ITagDefinitionsRepository _mockTagDefinitionsRepo = null!;
+    private IUserActionsRepository _mockActionsRepo = null!;
+    private IBlazorAuthHelper _mockAuthHelper = null!;
+    private ISnackbar _mockSnackbar = null!;
+    private IDialogService _dialogService = null!;
+
+    private const long TestUserId = 123456789;
+
+    public UserDetailDialogTests()
+    {
+        // Additional JSInterop setup not in MudBlazorTestContext
+        // MudBlazor popover components require these handlers to return void results
+        JSInterop.SetupVoid("mudPopover.initialize", _ => true).SetVoidResult();
+        JSInterop.SetupVoid("mudPopover.connect", _ => true).SetVoidResult();
+        JSInterop.SetupVoid("mudPopover.disconnect", _ => true).SetVoidResult();
+
+        // Create mocks for services used by the dialog
+        _mockUserService = Substitute.For<ITelegramUserManagementService>();
+        _mockModerationService = Substitute.For<IModerationOrchestrator>();
+        _mockAuthHelper = Substitute.For<IBlazorAuthHelper>();
+        _mockSnackbar = Substitute.For<ISnackbar>();
+        _mockTagDefinitionsRepo = Substitute.For<ITagDefinitionsRepository>();
+
+        // These repositories are registered for DI but intentionally unconfigured.
+        // The dialog reads Notes/Tags/Actions from TelegramUserDetail (returned by user service),
+        // not directly from these repos. These mocks only exist to satisfy constructor injection.
+        _mockNotesRepo = Substitute.For<IAdminNotesRepository>();
+        _mockTagsRepo = Substitute.For<IUserTagsRepository>();
+        _mockActionsRepo = Substitute.For<IUserActionsRepository>();
+
+        // Register services
+        Services.AddSingleton(_mockUserService);
+        Services.AddSingleton(_mockModerationService);
+        Services.AddSingleton(_mockNotesRepo);
+        Services.AddSingleton(_mockTagsRepo);
+        Services.AddSingleton(_mockTagDefinitionsRepo);
+        Services.AddSingleton(_mockActionsRepo);
+        Services.AddSingleton(_mockAuthHelper);
+        Services.AddSingleton(_mockSnackbar);
+
+        // Default setup for tag definitions
+        _mockTagDefinitionsRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<TagDefinition>()));
+    }
+
+    private IRenderedComponent<MudDialogProvider> RenderDialogProvider()
+    {
+        var provider = Render<MudDialogProvider>();
+        _dialogService = Services.GetRequiredService<IDialogService>();
+        return provider;
+    }
+
+    private Task<IDialogReference> OpenDialogAsync(long userId)
+    {
+        var parameters = new DialogParameters<UserDetailDialog>
+        {
+            { x => x.UserId, userId }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Large,
+            FullWidth = true
+        };
+
+        return _dialogService.ShowAsync<UserDetailDialog>("User Details", parameters, options);
+    }
+
+    #region Loading State Tests
+
+    [Test]
+    public void ShowsLoadingIndicator_WhenInitializing()
+    {
+        // Arrange - delay user service response to keep loading state
+        var tcs = new TaskCompletionSource<TelegramUserDetail?>();
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(tcs.Task);
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert - should show progress indicator
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("mud-progress-circular"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void ShowsUserNotFound_WhenUserIsNull()
+    {
+        // Arrange
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(null));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("User not found"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    #endregion
+
+    #region User Profile Display Tests
+
+    [Test]
+    public void DisplaysUserProfile_WhenLoaded()
+    {
+        // Arrange
+        var userDetail = CreateUserDetail();
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain(userDetail.DisplayName));
+            Assert.That(provider.Markup, Does.Contain(TestUserId.ToString()));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void DisplaysUsername_WhenPresent()
+    {
+        // Arrange
+        var userDetail = CreateUserDetail(username: "testuser");
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("@testuser"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    #endregion
+
+    #region Quick Action Visibility Tests
+
+    [Test]
+    public void ShowsBanButtons_WhenUserNotBanned()
+    {
+        // Arrange
+        var userDetail = CreateUserDetail(isBanned: false);
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert - check for Quick Actions buttons (the specific button text rendering varies)
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("Quick Actions"));
+            Assert.That(provider.Markup, Does.Contain("Temp Ban"));
+            Assert.That(provider.Markup, Does.Contain("Warn"));
+            Assert.That(provider.Markup, Does.Not.Contain("Unban"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void ShowsUnbanButton_WhenUserIsBanned()
+    {
+        // Arrange
+        var userDetail = CreateUserDetail(isBanned: true);
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert - check Unban visible, Temp Ban/Warn not visible
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("Unban"));
+            Assert.That(provider.Markup, Does.Not.Contain("Temp Ban"));
+            Assert.That(provider.Markup, Does.Not.Contain("Warn</span>"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void ShowsTrustButton_WhenUserNotTrusted()
+    {
+        // Arrange
+        var userDetail = CreateUserDetail(isTrusted: false);
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("Trust User"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void ShowsRemoveTrustButton_WhenUserIsTrusted()
+    {
+        // Arrange
+        var userDetail = CreateUserDetail(isTrusted: true);
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("Remove Trust"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    #endregion
+
+    #region Admin Notes Display Tests
+
+    [Test]
+    public void ShowsNoNotesMessage_WhenEmpty()
+    {
+        // Arrange
+        var userDetail = CreateUserDetail();
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("No notes yet"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void DisplaysNotes_WhenPresent()
+    {
+        // Arrange
+        var userDetail = CreateUserDetail();
+        userDetail.Notes.Add(new AdminNote
+        {
+            Id = 1,
+            TelegramUserId = TestUserId,
+            NoteText = "Test note content",
+            CreatedBy = Actor.FromSystem("Admin"),
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("Test note content"));
+        });
+
+        // Verify no exception was thrown during dialog open
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    #endregion
+
+    #region Exception Handling Tests
+
+    [Test]
+    public void ShowsErrorSnackbar_WhenServiceThrowsException()
+    {
+        // Arrange
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Database connection failed"));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert - snackbar receives error message (may be called multiple times due to re-renders)
+        provider.WaitForAssertion(() =>
+        {
+            _mockSnackbar.Received().Add(
+                Arg.Is<string>(s => s.Contains("Error loading user detail")),
+                Severity.Error);
+        });
+
+        // Verify no exception was thrown during dialog open (exception is caught internally)
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static TelegramUserDetail CreateUserDetail(
+        string? username = null,
+        bool isTrusted = false,
+        bool isBanned = false)
+    {
+        return new TelegramUserDetail
+        {
+            TelegramUserId = TestUserId,
+            Username = username,
+            FirstName = "Test",
+            LastName = "User",
+            IsTrusted = isTrusted,
+            IsBanned = isBanned,
+            BotDmEnabled = false,
+            FirstSeenAt = DateTimeOffset.UtcNow.AddDays(-30),
+            LastSeenAt = DateTimeOffset.UtcNow.AddHours(-1),
+            ChatMemberships = [],
+            Actions = [],
+            DetectionHistory = [],
+            Notes = [],
+            Tags = [],
+            Warnings = []
+        };
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin.ContentDetection/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Extensions/ServiceCollectionExtensions.cs
@@ -75,7 +75,7 @@ public static class ServiceCollectionExtensions
 
             // Register file scanning services (Phase 4.17 - Tier 1: Local scanners)
             // Note: YARA was removed due to ARM compatibility issues - ClamAV provides superior coverage
-            services.AddScoped<ClamAVScannerService>();
+            services.AddScoped<IFileScannerService, ClamAVScannerService>();
             services.AddScoped<Tier1VotingCoordinator>();
 
             // Register file scanning services (Phase 4.17 - Phase 2: Tier 2 cloud scanners)

--- a/TelegramGroupsAdmin.ContentDetection/Services/ClamAVScannerService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/ClamAVScannerService.cs
@@ -302,7 +302,7 @@ public class ClamAVScannerService : IFileScannerService
     /// Check ClamAV daemon health and get version/signature info (Phase 4.22)
     /// </summary>
     /// <returns>Health check result with version and signature count</returns>
-    public async Task<ClamAVHealthResult> GetHealthAsync(CancellationToken cancellationToken = default)
+    public async Task<FileScannerHealthResult> GetHealthAsync(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -316,7 +316,7 @@ public class ClamAVScannerService : IFileScannerService
             var pingResult = await clamClient.PingAsync(cancellationToken);
             if (!pingResult)
             {
-                return new ClamAVHealthResult
+                return new FileScannerHealthResult
                 {
                     IsHealthy = false,
                     ErrorMessage = $"ClamAV daemon not responding at {config.Tier1.ClamAV.Host}:{config.Tier1.ClamAV.Port}"
@@ -329,7 +329,7 @@ public class ClamAVScannerService : IFileScannerService
             _logger.LogInformation("✅ ClamAV health check successful: {Version} at {Host}:{Port}",
                 versionResult, config.Tier1.ClamAV.Host, config.Tier1.ClamAV.Port);
 
-            return new ClamAVHealthResult
+            return new FileScannerHealthResult
             {
                 IsHealthy = true,
                 Version = versionResult ?? "Unknown",
@@ -340,7 +340,7 @@ public class ClamAVScannerService : IFileScannerService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error checking ClamAV health");
-            return new ClamAVHealthResult
+            return new FileScannerHealthResult
             {
                 IsHealthy = false,
                 ErrorMessage = ex.Message

--- a/TelegramGroupsAdmin.ContentDetection/Services/FileScannerHealthResult.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/FileScannerHealthResult.cs
@@ -1,9 +1,9 @@
 namespace TelegramGroupsAdmin.ContentDetection.Services;
 
 /// <summary>
-/// ClamAV health check result (Phase 4.22)
+/// Health check result for file scanner services.
 /// </summary>
-public class ClamAVHealthResult
+public class FileScannerHealthResult
 {
     public bool IsHealthy { get; set; }
     public string? Version { get; set; }

--- a/TelegramGroupsAdmin.ContentDetection/Services/IFileScannerService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/IFileScannerService.cs
@@ -21,4 +21,11 @@ public interface IFileScannerService
     /// <param name="cancellationToken">Cancellation token for timeout handling</param>
     /// <returns>Scan result with threat detection status</returns>
     Task<FileScanResult> ScanFileAsync(string filePath, string? fileName = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the health status of the file scanner service.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Health check result including connectivity and version info.</returns>
+    Task<FileScannerHealthResult> GetHealthAsync(CancellationToken cancellationToken = default);
 }

--- a/TelegramGroupsAdmin.ContentDetection/Services/Tier1VotingCoordinator.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/Tier1VotingCoordinator.cs
@@ -14,16 +14,16 @@ public class Tier1VotingCoordinator
 {
     private readonly ILogger<Tier1VotingCoordinator> _logger;
     private readonly FileScanningConfig _config;
-    private readonly ClamAVScannerService _clamAvScanner;
+    private readonly IFileScannerService _fileScannerService;
 
     public Tier1VotingCoordinator(
         ILogger<Tier1VotingCoordinator> logger,
         IOptions<FileScanningConfig> config,
-        ClamAVScannerService clamAvScanner)
+        IFileScannerService fileScannerService)
     {
         _logger = logger;
         _config = config.Value;
-        _clamAvScanner = clamAvScanner;
+        _fileScannerService = fileScannerService;
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ public class Tier1VotingCoordinator
         // Launch ClamAV scan
         if (_config.Tier1.ClamAV.Enabled)
         {
-            scanTasks.Add(_clamAvScanner.ScanFileAsync(filePath, fileName, cancellationToken));
+            scanTasks.Add(_fileScannerService.ScanFileAsync(filePath, fileName, cancellationToken));
         }
 
         if (!scanTasks.Any())

--- a/TelegramGroupsAdmin.E2ETests/Infrastructure/TestWebNotificationBuilder.cs
+++ b/TelegramGroupsAdmin.E2ETests/Infrastructure/TestWebNotificationBuilder.cs
@@ -1,0 +1,189 @@
+using Microsoft.Extensions.DependencyInjection;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Repositories;
+
+namespace TelegramGroupsAdmin.E2ETests.Infrastructure;
+
+/// <summary>
+/// Fluent builder for creating web notifications for E2E testing.
+/// Creates notifications directly via IWebNotificationRepository.
+/// </summary>
+/// <remarks>
+/// Example usage:
+/// <code>
+/// var notification = await new TestWebNotificationBuilder(Factory.Services)
+///     .ForUser(testUser.Id)
+///     .WithSubject("Spam Detected")
+///     .WithMessage("User xyz posted spam in Test Chat")
+///     .AsUnread()
+///     .BuildAsync();
+/// </code>
+/// </remarks>
+public class TestWebNotificationBuilder
+{
+    private readonly IServiceProvider _services;
+    private string _userId = string.Empty;
+    private string _subject = "Test Notification";
+    private string _message = "This is a test notification message";
+    private NotificationEventType _eventType = NotificationEventType.SpamDetected;
+    private bool _isRead;
+    private DateTimeOffset _createdAt = DateTimeOffset.UtcNow;
+
+    public TestWebNotificationBuilder(IServiceProvider services)
+    {
+        _services = services;
+    }
+
+    /// <summary>
+    /// Sets the user ID this notification belongs to.
+    /// </summary>
+    public TestWebNotificationBuilder ForUser(string userId)
+    {
+        _userId = userId;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the notification subject/title.
+    /// </summary>
+    public TestWebNotificationBuilder WithSubject(string subject)
+    {
+        _subject = subject;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the notification message body.
+    /// </summary>
+    public TestWebNotificationBuilder WithMessage(string message)
+    {
+        _message = message;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the notification event type.
+    /// </summary>
+    public TestWebNotificationBuilder WithEventType(NotificationEventType eventType)
+    {
+        _eventType = eventType;
+        return this;
+    }
+
+    /// <summary>
+    /// Marks the notification as unread (default).
+    /// </summary>
+    public TestWebNotificationBuilder AsUnread()
+    {
+        _isRead = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Marks the notification as already read.
+    /// </summary>
+    public TestWebNotificationBuilder AsRead()
+    {
+        _isRead = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the creation timestamp.
+    /// </summary>
+    public TestWebNotificationBuilder CreatedAt(DateTimeOffset createdAt)
+    {
+        _createdAt = createdAt;
+        return this;
+    }
+
+    /// <summary>
+    /// Creates the notification with a relative age.
+    /// </summary>
+    public TestWebNotificationBuilder CreatedAgo(TimeSpan age)
+    {
+        _createdAt = DateTimeOffset.UtcNow - age;
+        return this;
+    }
+
+    /// <summary>
+    /// Builds and persists the notification.
+    /// </summary>
+    public async Task<WebNotification> BuildAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(_userId))
+        {
+            throw new InvalidOperationException("User ID must be set via ForUser()");
+        }
+
+        using var scope = _services.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IWebNotificationRepository>();
+
+        var notification = new WebNotification
+        {
+            UserId = _userId,
+            Subject = _subject,
+            Message = _message,
+            EventType = _eventType,
+            IsRead = _isRead,
+            CreatedAt = _createdAt,
+            ReadAt = _isRead ? DateTimeOffset.UtcNow : null
+        };
+
+        return await repository.CreateAsync(notification, cancellationToken);
+    }
+
+    #region Common Notification Shortcuts
+
+    /// <summary>
+    /// Creates a spam detected notification.
+    /// </summary>
+    public TestWebNotificationBuilder AsSpamDetected(string chatName = "Test Chat", string userName = "spammer")
+    {
+        return WithEventType(NotificationEventType.SpamDetected)
+            .WithSubject("Spam Detected")
+            .WithMessage($"Spam message from {userName} in {chatName}");
+    }
+
+    /// <summary>
+    /// Creates a message reported notification.
+    /// </summary>
+    public TestWebNotificationBuilder AsMessageReported(string chatName = "Test Chat", string reporterName = "reporter")
+    {
+        return WithEventType(NotificationEventType.MessageReported)
+            .WithSubject("Message Reported")
+            .WithMessage($"{reporterName} reported a message in {chatName}");
+    }
+
+    /// <summary>
+    /// Creates a user banned notification.
+    /// </summary>
+    public TestWebNotificationBuilder AsUserBanned(string userName = "banned_user", int chatsAffected = 1)
+    {
+        return WithEventType(NotificationEventType.UserBanned)
+            .WithSubject("User Banned")
+            .WithMessage($"{userName} was banned from {chatsAffected} chat(s)");
+    }
+
+    /// <summary>
+    /// Creates a malware detected notification.
+    /// </summary>
+    public TestWebNotificationBuilder AsMalwareDetected(string fileName = "malware.exe")
+    {
+        return WithEventType(NotificationEventType.MalwareDetected)
+            .WithSubject("Malware Detected")
+            .WithMessage($"Malicious file detected: {fileName}");
+    }
+
+    /// <summary>
+    /// Creates a backup failed notification.
+    /// </summary>
+    public TestWebNotificationBuilder AsBackupFailed(string reason = "Disk full")
+    {
+        return WithEventType(NotificationEventType.BackupFailed)
+            .WithSubject("Backup Failed")
+            .WithMessage($"Database backup failed: {reason}");
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin.E2ETests/Tests/Components/NotificationBellTests.cs
+++ b/TelegramGroupsAdmin.E2ETests/Tests/Components/NotificationBellTests.cs
@@ -1,0 +1,307 @@
+using Microsoft.Playwright;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.E2ETests.Infrastructure;
+using static Microsoft.Playwright.Assertions;
+
+namespace TelegramGroupsAdmin.E2ETests.Tests.Components;
+
+/// <summary>
+/// E2E tests for the NotificationBell component.
+/// Tests dropdown interactions that can't be tested via bUnit due to MudMenu popover limitations.
+/// </summary>
+/// <remarks>
+/// The NotificationBell uses MudMenu which renders its ChildContent in a popover.
+/// bUnit can only test the activator content (badge, icon). These E2E tests cover
+/// the full dropdown interaction experience.
+/// </remarks>
+[TestFixture]
+public class NotificationBellTests : SharedAuthenticatedTestBase
+{
+    /// <summary>
+    /// Locator for the notification bell button in the app bar.
+    /// </summary>
+    private ILocator NotificationBellButton => Page.Locator(".notification-bell button");
+
+    /// <summary>
+    /// Locator for the notification badge showing unread count.
+    /// MudBlazor renders the badge content in a span with class "mud-badge" (not "mud-badge-content").
+    /// </summary>
+    private ILocator NotificationBadge => Page.Locator(".notification-bell .mud-badge");
+
+    /// <summary>
+    /// Locator for the dropdown menu content (visible after clicking bell).
+    /// </summary>
+    private ILocator DropdownMenu => Page.Locator(".mud-popover-open");
+
+    /// <summary>
+    /// Locator for the "Mark all read" button in the dropdown.
+    /// </summary>
+    private ILocator MarkAllReadButton => DropdownMenu.GetByRole(AriaRole.Button, new() { Name = "Mark all read" });
+
+    /// <summary>
+    /// Locator for the "Clear all" button in the dropdown.
+    /// </summary>
+    private ILocator ClearAllButton => DropdownMenu.GetByRole(AriaRole.Button, new() { Name = "Clear all" });
+
+    /// <summary>
+    /// Locator for the empty state message.
+    /// </summary>
+    private ILocator EmptyStateMessage => DropdownMenu.GetByText("No notifications yet");
+
+    [Test]
+    public async Task NotificationBell_WithNoNotifications_ShowsEmptyState()
+    {
+        // Arrange
+        await LoginAsOwnerAsync();
+        await NavigateToAsync("/");
+
+        // Act - click the notification bell
+        await NotificationBellButton.ClickAsync();
+
+        // Assert - dropdown shows empty state
+        await Expect(DropdownMenu).ToBeVisibleAsync();
+        await Expect(EmptyStateMessage).ToBeVisibleAsync();
+        await Expect(MarkAllReadButton).Not.ToBeVisibleAsync();
+        await Expect(ClearAllButton).Not.ToBeVisibleAsync();
+    }
+
+    [Test]
+    public async Task NotificationBell_WithUnreadNotifications_ShowsBadgeCount()
+    {
+        // Arrange - create user and notifications BEFORE login
+        // This ensures notifications exist when NotificationStateService initializes
+        var user = await CreateUserAsync(PermissionLevel.Owner);
+
+        // Create 3 unread notifications before the first navigation
+        for (var i = 1; i <= 3; i++)
+        {
+            await new TestWebNotificationBuilder(SharedFactory.Services)
+                .ForUser(user.Id)
+                .WithSubject($"Test Notification {i}")
+                .WithMessage($"This is test notification {i}")
+                .AsUnread()
+                .BuildAsync();
+        }
+
+        // Now log in (injects cookie) and navigate
+        await LoginAsAsync(user);
+        await NavigateToAsync("/");
+
+        // Wait for Blazor Server's async initialization to complete
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Assert - badge shows count of 3
+        await Expect(NotificationBadge).ToBeVisibleAsync();
+        await Expect(NotificationBadge).ToHaveTextAsync("3");
+    }
+
+    [Test]
+    public async Task NotificationBell_ClickingBell_OpensDropdownWithNotifications()
+    {
+        // Arrange - create user and notifications BEFORE login
+        var user = await CreateUserAsync(PermissionLevel.Owner);
+
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .AsSpamDetected("Test Chat", "spammer123")
+            .AsUnread()
+            .BuildAsync();
+
+        // Now log in and navigate
+        await LoginAsAsync(user);
+        await NavigateToAsync("/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Act - click the notification bell
+        await NotificationBellButton.ClickAsync();
+
+        // Assert - dropdown shows notification content
+        await Expect(DropdownMenu).ToBeVisibleAsync();
+        await Expect(DropdownMenu.GetByText("Spam Detected")).ToBeVisibleAsync();
+        await Expect(DropdownMenu.GetByText("spammer123")).ToBeVisibleAsync();
+    }
+
+    [Test]
+    public async Task NotificationBell_MarkAllRead_ClearsBadgeAndHidesButton()
+    {
+        // Arrange - create user and notifications BEFORE login
+        var user = await CreateUserAsync(PermissionLevel.Owner);
+
+        // Create 2 unread notifications before the first navigation
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .AsSpamDetected()
+            .AsUnread()
+            .BuildAsync();
+
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .AsMessageReported()
+            .AsUnread()
+            .BuildAsync();
+
+        // Now log in and navigate
+        await LoginAsAsync(user);
+        await NavigateToAsync("/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Verify badge shows 2 unread
+        await Expect(NotificationBadge).ToBeVisibleAsync();
+        await Expect(NotificationBadge).ToHaveTextAsync("2");
+
+        // Act - open dropdown and click "Mark all read"
+        await NotificationBellButton.ClickAsync();
+        await Expect(MarkAllReadButton).ToBeVisibleAsync();
+        await MarkAllReadButton.ClickAsync();
+
+        // Assert - badge disappears, "Mark all read" button hidden
+        await Expect(NotificationBadge).Not.ToBeVisibleAsync();
+
+        // Re-open dropdown to verify button is hidden
+        await NotificationBellButton.ClickAsync();
+        await Expect(MarkAllReadButton).Not.ToBeVisibleAsync();
+        // But "Clear all" should still be visible (notifications exist, just read)
+        await Expect(ClearAllButton).ToBeVisibleAsync();
+    }
+
+    [Test]
+    public async Task NotificationBell_ClearAll_RemovesAllNotifications()
+    {
+        // Arrange - create user and notifications BEFORE login
+        var user = await CreateUserAsync(PermissionLevel.Owner);
+
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .AsSpamDetected()
+            .AsUnread()
+            .BuildAsync();
+
+        // Now log in and navigate
+        await LoginAsAsync(user);
+        await NavigateToAsync("/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Open dropdown
+        await NotificationBellButton.ClickAsync();
+        await Expect(DropdownMenu.GetByText("Spam Detected")).ToBeVisibleAsync();
+
+        // Act - click "Clear all"
+        await ClearAllButton.ClickAsync();
+
+        // Assert - dropdown now shows empty state
+        // Need to re-open the dropdown as it may close after action
+        await NotificationBellButton.ClickAsync();
+        await Expect(EmptyStateMessage).ToBeVisibleAsync();
+        await Expect(NotificationBadge).Not.ToBeVisibleAsync();
+    }
+
+    [Test]
+    public async Task NotificationBell_MultipleEventTypes_DisplayCorrectly()
+    {
+        // Arrange - create user and notifications BEFORE login
+        var user = await CreateUserAsync(PermissionLevel.Owner);
+
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .AsSpamDetected("Chat A", "user1")
+            .AsUnread()
+            .BuildAsync();
+
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .AsUserBanned("banned_guy", 5)
+            .AsUnread()
+            .BuildAsync();
+
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .AsMalwareDetected("virus.exe")
+            .AsUnread()
+            .BuildAsync();
+
+        // Now log in and navigate
+        await LoginAsAsync(user);
+        await NavigateToAsync("/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Act - open dropdown
+        await NotificationBellButton.ClickAsync();
+
+        // Assert - all notification types display
+        await Expect(DropdownMenu.GetByText("Spam Detected")).ToBeVisibleAsync();
+        await Expect(DropdownMenu.GetByText("User Banned")).ToBeVisibleAsync();
+        await Expect(DropdownMenu.GetByText("Malware Detected")).ToBeVisibleAsync();
+
+        // Badge shows total count
+        await Expect(NotificationBadge).ToBeVisibleAsync();
+        await Expect(NotificationBadge).ToHaveTextAsync("3");
+    }
+
+    [Test]
+    public async Task NotificationBell_ReadNotifications_NotCountedInBadge()
+    {
+        // Arrange - create user and notifications BEFORE login
+        var user = await CreateUserAsync(PermissionLevel.Owner);
+
+        // Create 2 unread and 1 read notification before the first navigation
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .WithSubject("Unread 1")
+            .AsUnread()
+            .BuildAsync();
+
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .WithSubject("Unread 2")
+            .AsUnread()
+            .BuildAsync();
+
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .WithSubject("Already Read")
+            .AsRead()
+            .BuildAsync();
+
+        // Now log in and navigate
+        await LoginAsAsync(user);
+        await NavigateToAsync("/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Assert - badge only shows unread count (2, not 3)
+        await Expect(NotificationBadge).ToBeVisibleAsync();
+        await Expect(NotificationBadge).ToHaveTextAsync("2");
+
+        // Open dropdown - all 3 notifications should be visible
+        await NotificationBellButton.ClickAsync();
+        await Expect(DropdownMenu.GetByText("Unread 1")).ToBeVisibleAsync();
+        await Expect(DropdownMenu.GetByText("Unread 2")).ToBeVisibleAsync();
+        await Expect(DropdownMenu.GetByText("Already Read")).ToBeVisibleAsync();
+    }
+
+    [Test]
+    public async Task NotificationBell_NoBadge_WhenAllNotificationsRead()
+    {
+        // Arrange - create user and notifications BEFORE login
+        var user = await CreateUserAsync(PermissionLevel.Owner);
+
+        // Create only read notifications before the first navigation
+        await new TestWebNotificationBuilder(SharedFactory.Services)
+            .ForUser(user.Id)
+            .WithSubject("Read Notification")
+            .AsRead()
+            .BuildAsync();
+
+        // Now log in and navigate
+        await LoginAsAsync(user);
+        await NavigateToAsync("/");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Assert - no badge visible (all read)
+        await Expect(NotificationBadge).Not.ToBeVisibleAsync();
+
+        // But dropdown should still show the notification
+        await NotificationBellButton.ClickAsync();
+        await Expect(DropdownMenu.GetByText("Read Notification")).ToBeVisibleAsync();
+        await Expect(EmptyStateMessage).Not.ToBeVisibleAsync();
+    }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
@@ -98,7 +98,7 @@ public class BackupServiceTests
         services.AddScoped<IBackupEncryptionService, BackupEncryptionService>();
         services.AddScoped<IBackupConfigurationService, BackupConfigurationService>();
         services.AddScoped<IPassphraseManagementService, PassphraseManagementService>();
-        services.AddScoped<BackupRetentionService>();
+        services.AddScoped<IBackupRetentionService, BackupRetentionService>();
 
         // Add internal handler services (required by BackupService)
         services.AddScoped<TelegramGroupsAdmin.BackgroundJobs.Services.Backup.Handlers.TableDiscoveryService>();

--- a/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
@@ -98,13 +98,13 @@ public static class ServiceCollectionExtensions
             services.AddScoped<ITrainingHandler, TrainingHandler>();
 
             // Orchestrator (routes to handlers and owns business rules)
-            services.AddScoped<ModerationOrchestrator>();
+            services.AddScoped<IModerationOrchestrator, ModerationOrchestrator>();
 
             // Report service
             services.AddScoped<IReportService, ReportService>();
             services.AddScoped<UserAutoTrustService>();
             services.AddScoped<AdminMentionHandler>();
-            services.AddScoped<TelegramUserManagementService>(); // Orchestrates Telegram user operations
+            services.AddScoped<ITelegramUserManagementService, TelegramUserManagementService>(); // Orchestrates Telegram user operations
             services.AddScoped<IUserMessagingService, UserMessagingService>(); // DM with fallback to chat mentions
             services.AddSingleton<IChatInviteLinkService, ChatInviteLinkService>(); // Phase 4.6: Invite link retrieval
             services.AddSingleton<IWelcomeService, WelcomeService>();

--- a/TelegramGroupsAdmin.Telegram/Handlers/LanguageWarningHandler.cs
+++ b/TelegramGroupsAdmin.Telegram/Handlers/LanguageWarningHandler.cs
@@ -90,7 +90,7 @@ public class LanguageWarningHandler
                 .Replace("{warnings_remaining}", warningsRemaining.ToString());
 
             // Issue warning using moderation system
-            var moderationService = scope.ServiceProvider.GetRequiredService<Services.Moderation.ModerationOrchestrator>();
+            var moderationService = scope.ServiceProvider.GetRequiredService<Services.Moderation.IModerationOrchestrator>();
             await moderationService.WarnUserAsync(
                 userId: message.From.Id,
                 messageId: message.MessageId,

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs
@@ -108,7 +108,7 @@ public class DetectionActionService(
 
             using var scope = serviceProvider.CreateScope();
             var reportService = scope.ServiceProvider.GetRequiredService<IReportService>();
-            var moderationActionService = scope.ServiceProvider.GetRequiredService<Moderation.ModerationOrchestrator>();
+            var moderationActionService = scope.ServiceProvider.GetRequiredService<Moderation.IModerationOrchestrator>();
             var botFactory = scope.ServiceProvider.GetRequiredService<ITelegramBotClientFactory>();
             var configLoader = scope.ServiceProvider.GetRequiredService<ITelegramConfigLoader>();
             var botToken = await configLoader.LoadConfigAsync();

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
@@ -186,7 +186,7 @@ public partial class MessageProcessingService(
             if (message.NewChatMembers != null)
             {
                 var userRepo = messageScope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
-                var moderationService = messageScope.ServiceProvider.GetRequiredService<Moderation.ModerationOrchestrator>();
+                var moderationService = messageScope.ServiceProvider.GetRequiredService<Moderation.IModerationOrchestrator>();
 
                 foreach (var joiningUser in message.NewChatMembers)
                 {
@@ -560,7 +560,7 @@ public partial class MessageProcessingService(
                     LogDisplayName.ChatDebug(message.Chat.Title, message.Chat.Id),
                     message.MessageId);
 
-                var moderationService = messageScope.ServiceProvider.GetRequiredService<Moderation.ModerationOrchestrator>();
+                var moderationService = messageScope.ServiceProvider.GetRequiredService<Moderation.IModerationOrchestrator>();
                 await moderationService.DeleteMessageAsync(
                     messageId: message.MessageId,
                     chatId: message.Chat.Id,

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/BanCallbackHandler.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/BanCallbackHandler.cs
@@ -122,7 +122,7 @@ public class BanCallbackHandler : IBanCallbackHandler
                 executorUser.LastName);
 
             // Execute ban (resolve from scope since ModerationOrchestrator is Scoped)
-            var moderationService = scope.ServiceProvider.GetRequiredService<ModerationOrchestrator>();
+            var moderationService = scope.ServiceProvider.GetRequiredService<IModerationOrchestrator>();
             var result = await moderationService.BanUserAsync(
                 userId: targetUserId,
                 messageId: null, // No trigger message for fuzzy search bans

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/BanCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/BanCommand.cs
@@ -18,7 +18,7 @@ public class BanCommand : IBotCommand
 {
     private readonly ILogger<BanCommand> _logger;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ModerationOrchestrator _moderationService;
+    private readonly IModerationOrchestrator _moderationService;
     private readonly IUserMessagingService _messagingService;
     private readonly ITelegramBotClientFactory _botClientFactory;
 
@@ -33,7 +33,7 @@ public class BanCommand : IBotCommand
     public BanCommand(
         ILogger<BanCommand> logger,
         IServiceProvider serviceProvider,
-        ModerationOrchestrator moderationService,
+        IModerationOrchestrator moderationService,
         IUserMessagingService messagingService,
         ITelegramBotClientFactory botClientFactory)
     {

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/MuteCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/MuteCommand.cs
@@ -15,7 +15,7 @@ public class MuteCommand : IBotCommand
 {
     private readonly ILogger<MuteCommand> _logger;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ModerationOrchestrator _moderationService;
+    private readonly IModerationOrchestrator _moderationService;
 
     public string Name => "mute";
     public string Description => "Temporarily mute user with auto-unmute";
@@ -28,7 +28,7 @@ public class MuteCommand : IBotCommand
     public MuteCommand(
         ILogger<MuteCommand> logger,
         IServiceProvider serviceProvider,
-        ModerationOrchestrator moderationService)
+        IModerationOrchestrator moderationService)
     {
         _logger = logger;
         _serviceProvider = serviceProvider;

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/SpamCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/SpamCommand.cs
@@ -14,7 +14,7 @@ public class SpamCommand : IBotCommand
 {
     private readonly ILogger<SpamCommand> _logger;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ModerationOrchestrator _moderationService;
+    private readonly IModerationOrchestrator _moderationService;
 
     public string Name => "spam";
     public string Description => "Mark message as spam and delete it";
@@ -27,7 +27,7 @@ public class SpamCommand : IBotCommand
     public SpamCommand(
         ILogger<SpamCommand> logger,
         IServiceProvider serviceProvider,
-        ModerationOrchestrator moderationService)
+        IModerationOrchestrator moderationService)
     {
         _logger = logger;
         _serviceProvider = serviceProvider;

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/TempBanCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/TempBanCommand.cs
@@ -16,7 +16,7 @@ public class TempBanCommand : IBotCommand
 {
     private readonly ILogger<TempBanCommand> _logger;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ModerationOrchestrator _moderationService;
+    private readonly IModerationOrchestrator _moderationService;
 
     public string Name => "tempban";
     public string Description => "Temporarily ban user with auto-unrestriction";
@@ -29,7 +29,7 @@ public class TempBanCommand : IBotCommand
     public TempBanCommand(
         ILogger<TempBanCommand> logger,
         IServiceProvider serviceProvider,
-        ModerationOrchestrator moderationService)
+        IModerationOrchestrator moderationService)
     {
         _logger = logger;
         _serviceProvider = serviceProvider;

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/TrustCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/TrustCommand.cs
@@ -15,7 +15,7 @@ public class TrustCommand : IBotCommand
 {
     private readonly ILogger<TrustCommand> _logger;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ModerationOrchestrator _moderationService;
+    private readonly IModerationOrchestrator _moderationService;
 
     public string Name => "trust";
     public string Description => "Toggle trust status (bypass spam detection)";
@@ -28,7 +28,7 @@ public class TrustCommand : IBotCommand
     public TrustCommand(
         ILogger<TrustCommand> logger,
         IServiceProvider serviceProvider,
-        ModerationOrchestrator moderationService)
+        IModerationOrchestrator moderationService)
     {
         _logger = logger;
         _serviceProvider = serviceProvider;

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/UnbanCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/UnbanCommand.cs
@@ -12,7 +12,7 @@ public class UnbanCommand : IBotCommand
 {
     private readonly ILogger<UnbanCommand> _logger;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ModerationOrchestrator _moderationService;
+    private readonly IModerationOrchestrator _moderationService;
 
     public string Name => "unban";
     public string Description => "Remove ban from user";
@@ -25,7 +25,7 @@ public class UnbanCommand : IBotCommand
     public UnbanCommand(
         ILogger<UnbanCommand> logger,
         IServiceProvider serviceProvider,
-        ModerationOrchestrator moderationService)
+        IModerationOrchestrator moderationService)
     {
         _logger = logger;
         _serviceProvider = serviceProvider;

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/WarnCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/WarnCommand.cs
@@ -15,7 +15,7 @@ public class WarnCommand : IBotCommand
 {
     private readonly ILogger<WarnCommand> _logger;
     private readonly IServiceProvider _serviceProvider;
-    private readonly ModerationOrchestrator _moderationService;
+    private readonly IModerationOrchestrator _moderationService;
     private readonly IUserMessagingService _messagingService;
 
     public string Name => "warn";
@@ -29,7 +29,7 @@ public class WarnCommand : IBotCommand
     public WarnCommand(
         ILogger<WarnCommand> logger,
         IServiceProvider serviceProvider,
-        ModerationOrchestrator moderationService,
+        IModerationOrchestrator moderationService,
         IUserMessagingService messagingService)
     {
         _logger = logger;

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/ReportCallbackHandler.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/ReportCallbackHandler.cs
@@ -74,7 +74,7 @@ public class ReportCallbackHandler : IReportCallbackHandler
         var callbackContextRepo = scope.ServiceProvider.GetRequiredService<IReportCallbackContextRepository>();
         var reportsRepo = scope.ServiceProvider.GetRequiredService<IReportsRepository>();
         var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
-        var moderationService = scope.ServiceProvider.GetRequiredService<ModerationOrchestrator>();
+        var moderationService = scope.ServiceProvider.GetRequiredService<IModerationOrchestrator>();
 
         // Look up callback context from database
         var context = await callbackContextRepo.GetByIdAsync(contextId, cancellationToken);
@@ -242,7 +242,7 @@ public class ReportCallbackHandler : IReportCallbackHandler
     }
 
     private async Task<ReportActionResult> HandleSpamActionAsync(
-        ModerationOrchestrator moderationService,
+        IModerationOrchestrator moderationService,
         long reportId,
         long userId,
         int messageId,
@@ -272,7 +272,7 @@ public class ReportCallbackHandler : IReportCallbackHandler
     }
 
     private async Task<ReportActionResult> HandleWarnActionAsync(
-        ModerationOrchestrator moderationService,
+        IModerationOrchestrator moderationService,
         long reportId,
         long chatId,
         long userId,
@@ -303,7 +303,7 @@ public class ReportCallbackHandler : IReportCallbackHandler
     }
 
     private async Task<ReportActionResult> HandleTempBanActionAsync(
-        ModerationOrchestrator moderationService,
+        IModerationOrchestrator moderationService,
         long reportId,
         long userId,
         int messageId,

--- a/TelegramGroupsAdmin.Telegram/Services/ITelegramUserManagementService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ITelegramUserManagementService.cs
@@ -1,0 +1,55 @@
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Services;
+
+/// <summary>
+/// Service for managing Telegram users - queries, trust status, bans, and user details.
+/// </summary>
+public interface ITelegramUserManagementService
+{
+    /// <summary>Gets all Telegram users.</summary>
+    Task<List<TelegramUserListItem>> GetAllUsersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets users filtered by specific chat IDs.</summary>
+    Task<List<TelegramUserListItem>> GetAllUsersAsync(List<long> chatIds, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets users with any tags applied.</summary>
+    Task<List<TelegramUserListItem>> GetTaggedUsersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets all banned users.</summary>
+    Task<List<TelegramUserListItem>> GetBannedUsersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets banned users with detailed ban information.</summary>
+    Task<List<BannedUserListItem>> GetBannedUsersWithDetailsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets all trusted users.</summary>
+    Task<List<TelegramUserListItem>> GetTrustedUsersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets inactive users based on activity threshold.</summary>
+    Task<List<TelegramUserListItem>> GetInactiveUsersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets top active users by message count.</summary>
+    Task<List<TopActiveUser>> GetTopActiveUsersAsync(int limit = 3, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets moderation queue statistics (pending reports, reviews).</summary>
+    Task<ModerationQueueStats> GetModerationQueueStatsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Gets detailed information for a specific user.</summary>
+    Task<TelegramUserDetail?> GetUserDetailAsync(long telegramUserId, CancellationToken cancellationToken = default);
+
+    /// <summary>Toggles the trust status of a user.</summary>
+    Task<bool> ToggleTrustAsync(long telegramUserId, Actor modifiedBy, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets the action history for a user (bans, warnings, etc.).</summary>
+    Task<List<UserActionRecord>> GetUserActionsAsync(long telegramUserId, CancellationToken cancellationToken = default);
+
+    /// <summary>Checks if a user is currently banned.</summary>
+    Task<bool> IsBannedAsync(long telegramUserId, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets the count of active (non-expired) warnings for a user.</summary>
+    Task<int> GetActiveWarningCountAsync(long telegramUserId, CancellationToken cancellationToken = default);
+
+    /// <summary>Unbans a user from all chats.</summary>
+    Task<bool> UnbanAsync(long telegramUserId, Actor unbannedBy, string? reason = null, CancellationToken cancellationToken = default);
+}

--- a/TelegramGroupsAdmin.Telegram/Services/ImpersonationDetectionService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ImpersonationDetectionService.cs
@@ -33,7 +33,7 @@ public class ImpersonationDetectionService : IImpersonationDetectionService
     private readonly IMessageHistoryRepository _messageHistoryRepository;
     private readonly IPhotoHashService _photoHashService;
     private readonly IImpersonationAlertsRepository _impersonationAlertsRepository;
-    private readonly ModerationOrchestrator _moderationActionService;
+    private readonly IModerationOrchestrator _moderationActionService;
     private readonly ITelegramBotClientFactory _botClientFactory;
     private readonly IConfigService _configService;
     private readonly ILogger<ImpersonationDetectionService> _logger;
@@ -52,7 +52,7 @@ public class ImpersonationDetectionService : IImpersonationDetectionService
         IMessageHistoryRepository messageHistoryRepository,
         IPhotoHashService photoHashService,
         IImpersonationAlertsRepository impersonationAlertsRepository,
-        ModerationOrchestrator moderationActionService,
+        IModerationOrchestrator moderationActionService,
         ITelegramBotClientFactory botClientFactory,
         IConfigService configService,
         ILogger<ImpersonationDetectionService> logger)

--- a/TelegramGroupsAdmin.Telegram/Services/Moderation/IModerationOrchestrator.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Moderation/IModerationOrchestrator.cs
@@ -1,0 +1,186 @@
+using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Services.Moderation;
+
+/// <summary>
+/// Orchestrates moderation actions across Telegram and database.
+/// Handles bans, warnings, trust status, and message deletion with audit logging.
+/// The "boss" that knows all workers, decides who to call, and owns business rules.
+/// </summary>
+public interface IModerationOrchestrator
+{
+    /// <summary>
+    /// Mark message as spam, delete it, ban user globally, and revoke trust.
+    /// Composes: EnsureExists → Delete → Ban → Training Data
+    /// </summary>
+    /// <param name="messageId">The message ID to mark as spam.</param>
+    /// <param name="userId">The Telegram user ID of the message author.</param>
+    /// <param name="chatId">The chat ID where the message was posted.</param>
+    /// <param name="executor">The actor performing this action.</param>
+    /// <param name="reason">Reason for marking as spam.</param>
+    /// <param name="telegramMessage">Optional Telegram message object for backfill.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success and affected chats/actions.</returns>
+    Task<ModerationResult> MarkAsSpamAndBanAsync(
+        long messageId,
+        long userId,
+        long chatId,
+        Actor executor,
+        string reason,
+        Message? telegramMessage = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Ban user globally across all managed chats.
+    /// Business rule: Bans always revoke trust.
+    /// </summary>
+    /// <param name="userId">The Telegram user ID to ban.</param>
+    /// <param name="messageId">Optional message ID that triggered the ban.</param>
+    /// <param name="executor">The actor performing this action.</param>
+    /// <param name="reason">Reason for the ban.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success and affected chats.</returns>
+    Task<ModerationResult> BanUserAsync(
+        long userId,
+        long? messageId,
+        Actor executor,
+        string reason,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Warn user globally with automatic ban after threshold.
+    /// Business rule: N warnings = auto-ban (configurable per chat).
+    /// </summary>
+    /// <param name="userId">The Telegram user ID to warn.</param>
+    /// <param name="messageId">Optional message ID that triggered the warning.</param>
+    /// <param name="executor">The actor performing this action.</param>
+    /// <param name="reason">Reason for the warning.</param>
+    /// <param name="chatId">The chat ID for chat-specific warning threshold configuration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success, warning count, and whether auto-ban was triggered.</returns>
+    Task<ModerationResult> WarnUserAsync(
+        long userId,
+        long? messageId,
+        Actor executor,
+        string reason,
+        long chatId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Trust user globally (bypass spam detection).
+    /// </summary>
+    /// <param name="userId">The Telegram user ID to trust.</param>
+    /// <param name="executor">The actor performing this action.</param>
+    /// <param name="reason">Reason for trusting the user.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success.</returns>
+    Task<ModerationResult> TrustUserAsync(
+        long userId,
+        Actor executor,
+        string reason,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Remove trust from user globally.
+    /// </summary>
+    /// <param name="userId">The Telegram user ID to untrust.</param>
+    /// <param name="executor">The actor performing this action.</param>
+    /// <param name="reason">Reason for removing trust.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success.</returns>
+    Task<ModerationResult> UntrustUserAsync(
+        long userId,
+        Actor executor,
+        string reason,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Unban user globally and optionally restore trust.
+    /// </summary>
+    /// <param name="userId">The Telegram user ID to unban.</param>
+    /// <param name="executor">The actor performing this action.</param>
+    /// <param name="reason">Reason for the unban.</param>
+    /// <param name="restoreTrust">Whether to restore trust after unbanning (for false positive corrections).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success and affected chats.</returns>
+    Task<ModerationResult> UnbanUserAsync(
+        long userId,
+        Actor executor,
+        string reason,
+        bool restoreTrust = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete a message from Telegram and mark as deleted in database.
+    /// </summary>
+    /// <param name="messageId">The message ID to delete.</param>
+    /// <param name="chatId">The chat ID containing the message.</param>
+    /// <param name="userId">The Telegram user ID of the message author.</param>
+    /// <param name="deletedBy">The actor performing the deletion.</param>
+    /// <param name="reason">Optional reason for deletion.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating whether the message was deleted.</returns>
+    Task<ModerationResult> DeleteMessageAsync(
+        long messageId,
+        long chatId,
+        long userId,
+        Actor deletedBy,
+        string? reason = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Temporarily ban user globally with automatic unrestriction.
+    /// </summary>
+    /// <param name="userId">The Telegram user ID to temp ban.</param>
+    /// <param name="messageId">Optional message ID that triggered the temp ban.</param>
+    /// <param name="executor">The actor performing this action.</param>
+    /// <param name="reason">Reason for the temp ban.</param>
+    /// <param name="duration">Duration of the temporary ban.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success and affected chats.</returns>
+    Task<ModerationResult> TempBanUserAsync(
+        long userId,
+        long? messageId,
+        Actor executor,
+        string reason,
+        TimeSpan duration,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Restrict user (mute) globally or in a specific chat with automatic unrestriction.
+    /// </summary>
+    /// <param name="userId">The Telegram user ID to restrict.</param>
+    /// <param name="messageId">Optional message ID that triggered the restriction.</param>
+    /// <param name="executor">The actor performing this action.</param>
+    /// <param name="reason">Reason for the restriction.</param>
+    /// <param name="duration">Duration of the restriction.</param>
+    /// <param name="chatId">Optional chat ID for chat-specific restriction; null for global.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success and affected chats.</returns>
+    Task<ModerationResult> RestrictUserAsync(
+        long userId,
+        long? messageId,
+        Actor executor,
+        string reason,
+        TimeSpan duration,
+        long? chatId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sync an existing global ban to a specific chat (lazy sync for chats added after ban).
+    /// Use when a globally banned user joins or posts in a chat that was added after their ban.
+    /// </summary>
+    /// <param name="user">The Telegram User object to ban.</param>
+    /// <param name="chat">The Telegram Chat to sync the ban to.</param>
+    /// <param name="reason">Reason for the ban sync.</param>
+    /// <param name="triggeredByMessageId">Optional message ID that triggered the sync.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success and affected chats.</returns>
+    Task<ModerationResult> SyncBanToChatAsync(
+        User user,
+        Chat chat,
+        string reason,
+        long? triggeredByMessageId = null,
+        CancellationToken cancellationToken = default);
+}

--- a/TelegramGroupsAdmin.Telegram/Services/Moderation/ModerationOrchestrator.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Moderation/ModerationOrchestrator.cs
@@ -25,7 +25,7 @@ namespace TelegramGroupsAdmin.Telegram.Services.Moderation;
 /// Workers are domain experts that don't know about each other.
 /// Only the orchestrator composes workflows across workers.
 /// </summary>
-public class ModerationOrchestrator
+public class ModerationOrchestrator : IModerationOrchestrator
 {
     // Domain handlers (workers)
     private readonly IBanHandler _banHandler;
@@ -72,10 +72,7 @@ public class ModerationOrchestrator
         _logger = logger;
     }
 
-    /// <summary>
-    /// Mark message as spam, delete it, ban user globally, and revoke trust.
-    /// Composes: EnsureExists → Delete → Ban → Training Data
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> MarkAsSpamAndBanAsync(
         long messageId,
         long userId,
@@ -132,10 +129,7 @@ public class ModerationOrchestrator
         };
     }
 
-    /// <summary>
-    /// Ban user globally across all managed chats.
-    /// Business rule: Bans always revoke trust.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> BanUserAsync(
         long userId,
         long? messageId,
@@ -178,10 +172,7 @@ public class ModerationOrchestrator
         };
     }
 
-    /// <summary>
-    /// Warn user globally with automatic ban after threshold.
-    /// Business rule: N warnings = auto-ban (configurable per chat).
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> WarnUserAsync(
         long userId,
         long? messageId,
@@ -249,9 +240,7 @@ public class ModerationOrchestrator
         return result;
     }
 
-    /// <summary>
-    /// Trust user globally (bypass spam detection).
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> TrustUserAsync(
         long userId,
         Actor executor,
@@ -269,9 +258,7 @@ public class ModerationOrchestrator
         return new ModerationResult { Success = true };
     }
 
-    /// <summary>
-    /// Remove trust from user globally.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> UntrustUserAsync(
         long userId,
         Actor executor,
@@ -289,9 +276,7 @@ public class ModerationOrchestrator
         return new ModerationResult { Success = true };
     }
 
-    /// <summary>
-    /// Unban user globally and optionally restore trust.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> UnbanUserAsync(
         long userId,
         Actor executor,
@@ -325,9 +310,7 @@ public class ModerationOrchestrator
         return result;
     }
 
-    /// <summary>
-    /// Delete a message from Telegram and mark as deleted in database.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> DeleteMessageAsync(
         long messageId,
         long chatId,
@@ -348,9 +331,7 @@ public class ModerationOrchestrator
         };
     }
 
-    /// <summary>
-    /// Temporarily ban user globally with automatic unrestriction.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> TempBanUserAsync(
         long userId,
         long? messageId,
@@ -380,9 +361,7 @@ public class ModerationOrchestrator
         };
     }
 
-    /// <summary>
-    /// Restrict user (mute) globally with automatic unrestriction.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> RestrictUserAsync(
         long userId,
         long? messageId,
@@ -411,10 +390,7 @@ public class ModerationOrchestrator
         };
     }
 
-    /// <summary>
-    /// Sync an existing global ban to a specific chat (lazy sync for chats added after ban).
-    /// Use when a globally banned user joins or posts in a chat that was added after their ban.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<ModerationResult> SyncBanToChatAsync(
         User user,
         Chat chat,

--- a/TelegramGroupsAdmin.Telegram/Services/TelegramUserManagementService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/TelegramUserManagementService.cs
@@ -11,7 +11,7 @@ namespace TelegramGroupsAdmin.Telegram.Services;
 /// Orchestration service for Telegram user management operations.
 /// Coordinates between TelegramUserRepository, UserActionRepository, and DetectionResultRepository.
 /// </summary>
-public class TelegramUserManagementService
+public class TelegramUserManagementService : ITelegramUserManagementService
 {
     private readonly ITelegramUserRepository _userRepository;
     private readonly IUserActionsRepository _userActionsRepository;
@@ -27,19 +27,13 @@ public class TelegramUserManagementService
         _logger = logger;
     }
 
-    /// <summary>
-    /// Get all Telegram users with computed stats for list view
-    /// </summary>
+    /// <inheritdoc/>
     public Task<List<TelegramUserListItem>> GetAllUsersAsync(CancellationToken cancellationToken = default)
     {
         return _userRepository.GetAllWithStatsAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Get Telegram users filtered by accessible chats
-    /// </summary>
-    /// <param name="chatIds">List of accessible chat IDs (empty = all users for GlobalAdmin/Owner)</param>
-    /// <param name="cancellationToken">Cancellation token</param>
+    /// <inheritdoc/>
     public Task<List<TelegramUserListItem>> GetAllUsersAsync(List<long> chatIds, CancellationToken cancellationToken = default)
     {
         // Empty list means all chats (GlobalAdmin/Owner)
@@ -51,75 +45,55 @@ public class TelegramUserManagementService
         return _userRepository.GetAllWithStatsAsync(chatIds, cancellationToken);
     }
 
-    /// <summary>
-    /// Get users with tags or notes for tracking (includes warned users)
-    /// </summary>
+    /// <inheritdoc/>
     public Task<List<TelegramUserListItem>> GetTaggedUsersAsync(CancellationToken cancellationToken = default)
     {
         return _userRepository.GetTaggedUsersAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Get banned users
-    /// </summary>
+    /// <inheritdoc/>
     public Task<List<TelegramUserListItem>> GetBannedUsersAsync(CancellationToken cancellationToken = default)
     {
         return _userRepository.GetBannedUsersAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Get banned users with detailed ban information
-    /// Includes ban date, banned by, reason, expiry, and trigger message
-    /// </summary>
+    /// <inheritdoc/>
     public Task<List<BannedUserListItem>> GetBannedUsersWithDetailsAsync(CancellationToken cancellationToken = default)
     {
         return _userRepository.GetBannedUsersWithDetailsAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Get trusted (whitelisted) users
-    /// </summary>
+    /// <inheritdoc/>
     public Task<List<TelegramUserListItem>> GetTrustedUsersAsync(CancellationToken cancellationToken = default)
     {
         return _userRepository.GetTrustedUsersAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Get inactive users (joined but never engaged - no welcome accept or message)
-    /// </summary>
+    /// <inheritdoc/>
     public Task<List<TelegramUserListItem>> GetInactiveUsersAsync(CancellationToken cancellationToken = default)
     {
         return _userRepository.GetInactiveUsersAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Get top active users by 30-day message count
-    /// </summary>
+    /// <inheritdoc/>
     public Task<List<TopActiveUser>> GetTopActiveUsersAsync(int limit = 3, CancellationToken cancellationToken = default)
     {
         return _userRepository.GetTopActiveUsersAsync(limit: limit, cancellationToken: cancellationToken);
     }
 
-    /// <summary>
-    /// Get moderation queue statistics (banned, warned, flagged counts)
-    /// </summary>
+    /// <inheritdoc/>
     public Task<ModerationQueueStats> GetModerationQueueStatsAsync(CancellationToken cancellationToken = default)
     {
         return _userRepository.GetModerationQueueStatsAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Get detailed user info with all related data (chat memberships, actions, detection history)
-    /// </summary>
+    /// <inheritdoc/>
     public Task<TelegramUserDetail?> GetUserDetailAsync(long telegramUserId, CancellationToken cancellationToken = default)
     {
         return _userRepository.GetUserDetailAsync(telegramUserId, cancellationToken);
     }
 
-    /// <summary>
-    /// Toggle user trust status (whitelist on/off)
-    /// Creates audit trail via user_actions table.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<bool> ToggleTrustAsync(long telegramUserId, Actor modifiedBy, CancellationToken cancellationToken = default)
     {
         // Get current user
@@ -189,36 +163,25 @@ public class TelegramUserManagementService
         return true;
     }
 
-    /// <summary>
-    /// Get all user actions (warnings, bans, trusts) for a specific user
-    /// </summary>
+    /// <inheritdoc/>
     public Task<List<UserActionRecord>> GetUserActionsAsync(long telegramUserId, CancellationToken cancellationToken = default)
     {
         return _userActionsRepository.GetByUserIdAsync(telegramUserId);
     }
 
-    /// <summary>
-    /// Check if user is currently banned.
-    /// REFACTOR-5: Uses is_banned column as source of truth (not user_actions audit log).
-    /// </summary>
+    /// <inheritdoc/>
     public Task<bool> IsBannedAsync(long telegramUserId, CancellationToken cancellationToken = default)
     {
         return _userRepository.IsBannedAsync(telegramUserId, cancellationToken);
     }
 
-    /// <summary>
-    /// Get active warning count for user.
-    /// REFACTOR-5: Uses warnings JSONB column as source of truth (not user_actions audit log).
-    /// </summary>
+    /// <inheritdoc/>
     public Task<int> GetActiveWarningCountAsync(long telegramUserId, CancellationToken cancellationToken = default)
     {
         return _userRepository.GetActiveWarningCountAsync(telegramUserId, cancellationToken);
     }
 
-    /// <summary>
-    /// Unban a user (expire all active bans and create unban action record)
-    /// Phase 5: Banned users tab enhancements
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<bool> UnbanAsync(long telegramUserId, Actor unbannedBy, string? reason = null, CancellationToken cancellationToken = default)
     {
         // Verify user exists

--- a/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
@@ -238,7 +238,7 @@ public class WelcomeService : IWelcomeService
                     casResult.Reason ?? "No reason provided");
 
                 // Ban user using ModerationOrchestrator
-                var moderationOrchestrator = impersonationScope.ServiceProvider.GetRequiredService<ModerationOrchestrator>();
+                var moderationOrchestrator = impersonationScope.ServiceProvider.GetRequiredService<IModerationOrchestrator>();
                 var reason = $"CAS banned: {casResult.Reason ?? "Listed in CAS database"}";
                 await moderationOrchestrator.BanUserAsync(
                     userId: user.Id,

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Services/Backup/BackupRetentionServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Services/Backup/BackupRetentionServiceTests.cs
@@ -1,0 +1,345 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
+
+namespace TelegramGroupsAdmin.UnitTests.BackgroundJobs.Services.Backup;
+
+/// <summary>
+/// Unit tests for BackupRetentionService.
+/// Tests grandfather-father-son retention strategy for backup management.
+/// Pure logic tests - no external dependencies required.
+/// </summary>
+[TestFixture]
+public class BackupRetentionServiceTests
+{
+    private ILogger<BackupRetentionService> _mockLogger = null!;
+    private BackupRetentionService _service = null!;
+    private RetentionConfig _defaultConfig = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockLogger = Substitute.For<ILogger<BackupRetentionService>>();
+        _service = new BackupRetentionService(_mockLogger);
+
+        // Default config: 24 hourly, 7 daily, 4 weekly, 12 monthly, 3 yearly
+        _defaultConfig = new RetentionConfig
+        {
+            RetainHourlyBackups = 24,
+            RetainDailyBackups = 7,
+            RetainWeeklyBackups = 4,
+            RetainMonthlyBackups = 12,
+            RetainYearlyBackups = 3
+        };
+    }
+
+    #region Edge Case Tests
+
+    [Test]
+    public void GetBackupsToDelete_ReturnsEmpty_WhenInputIsNull()
+    {
+        // Act
+        var result = _service.GetBackupsToDelete(null!, _defaultConfig);
+
+        // Assert
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void GetBackupsToDelete_ReturnsEmpty_WhenInputIsEmpty()
+    {
+        // Arrange
+        var backups = new List<BackupFileInfo>();
+
+        // Act
+        var result = _service.GetBackupsToDelete(backups, _defaultConfig);
+
+        // Assert
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void GetBackupsToDelete_KeepsSingleBackup()
+    {
+        // Arrange
+        var backups = new List<BackupFileInfo>
+        {
+            CreateBackup("backup1.db", DateTimeOffset.UtcNow)
+        };
+
+        // Act
+        var result = _service.GetBackupsToDelete(backups, _defaultConfig);
+
+        // Assert - single backup should be kept
+        Assert.That(result, Is.Empty);
+    }
+
+    #endregion
+
+    #region Hourly Retention Tests
+
+    [Test]
+    public void GetBackupsToDelete_KeepsLast24HourlyBackups()
+    {
+        // Arrange - 30 backups, one per hour
+        var now = DateTimeOffset.UtcNow;
+        var backups = Enumerable.Range(0, 30)
+            .Select(i => CreateBackup($"backup{i}.db", now.AddHours(-i)))
+            .ToList();
+
+        var config = new RetentionConfig
+        {
+            RetainHourlyBackups = 24,
+            RetainDailyBackups = 0, // Disable other tiers
+            RetainWeeklyBackups = 0,
+            RetainMonthlyBackups = 0,
+            RetainYearlyBackups = 0
+        };
+
+        // Act
+        var toDelete = _service.GetBackupsToDelete(backups, config);
+
+        // Assert - should delete oldest 6 backups (30 - 24 = 6)
+        Assert.That(toDelete.Count, Is.EqualTo(6));
+        Assert.That(toDelete.All(b => b.FileName.StartsWith("backup2")), Is.True); // backups 24-29
+    }
+
+    #endregion
+
+    #region Daily Retention Tests
+
+    [Test]
+    public void GetBackupsToDelete_KeepsFirstBackupOfEachDay()
+    {
+        // Arrange - 10 backups across 5 days (2 per day)
+        var now = new DateTimeOffset(2026, 1, 10, 12, 0, 0, TimeSpan.Zero);
+        var backups = new List<BackupFileInfo>
+        {
+            CreateBackup("day1_am.db", now.AddDays(-4).AddHours(-6)), // Day 1 first
+            CreateBackup("day1_pm.db", now.AddDays(-4).AddHours(6)),  // Day 1 second
+            CreateBackup("day2_am.db", now.AddDays(-3).AddHours(-6)), // Day 2 first
+            CreateBackup("day2_pm.db", now.AddDays(-3).AddHours(6)),  // Day 2 second
+            CreateBackup("day3_am.db", now.AddDays(-2).AddHours(-6)), // Day 3 first
+            CreateBackup("day3_pm.db", now.AddDays(-2).AddHours(6)),  // Day 3 second
+            CreateBackup("day4_am.db", now.AddDays(-1).AddHours(-6)), // Day 4 first
+            CreateBackup("day4_pm.db", now.AddDays(-1).AddHours(6)),  // Day 4 second
+            CreateBackup("day5_am.db", now.AddHours(-6)),             // Day 5 first
+            CreateBackup("day5_pm.db", now),                          // Day 5 second
+        };
+
+        var config = new RetentionConfig
+        {
+            RetainHourlyBackups = 0, // Disable hourly
+            RetainDailyBackups = 5,  // Keep 5 daily backups
+            RetainWeeklyBackups = 0,
+            RetainMonthlyBackups = 0,
+            RetainYearlyBackups = 0
+        };
+
+        // Act
+        var toDelete = _service.GetBackupsToDelete(backups, config);
+
+        // Assert - should delete the "pm" backups (not first of day)
+        Assert.That(toDelete.Count, Is.EqualTo(5));
+        Assert.That(toDelete.All(b => b.FileName.Contains("_pm")), Is.True);
+    }
+
+    #endregion
+
+    #region Weekly Retention Tests
+
+    [Test]
+    public void GetBackupsToDelete_KeepsFirstBackupOfEachWeek()
+    {
+        // Arrange - 6 backups across 6 weeks
+        var monday = new DateTimeOffset(2026, 1, 6, 12, 0, 0, TimeSpan.Zero); // A Monday
+        var backups = Enumerable.Range(0, 6)
+            .Select(i => CreateBackup($"week{i}.db", monday.AddDays(-i * 7)))
+            .ToList();
+
+        var config = new RetentionConfig
+        {
+            RetainHourlyBackups = 0,
+            RetainDailyBackups = 0,
+            RetainWeeklyBackups = 4, // Keep 4 weeks
+            RetainMonthlyBackups = 0,
+            RetainYearlyBackups = 0
+        };
+
+        // Act
+        var toDelete = _service.GetBackupsToDelete(backups, config);
+
+        // Assert - should delete oldest 2 weekly backups
+        Assert.That(toDelete.Count, Is.EqualTo(2));
+        Assert.That(toDelete.Any(b => b.FileName == "week4.db"), Is.True);
+        Assert.That(toDelete.Any(b => b.FileName == "week5.db"), Is.True);
+    }
+
+    #endregion
+
+    #region Monthly Retention Tests
+
+    [Test]
+    public void GetBackupsToDelete_KeepsFirstBackupOfEachMonth()
+    {
+        // Arrange - 15 backups across 15 months
+        var startDate = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var backups = Enumerable.Range(0, 15)
+            .Select(i => CreateBackup($"month{i}.db", startDate.AddMonths(-i)))
+            .ToList();
+
+        var config = new RetentionConfig
+        {
+            RetainHourlyBackups = 0,
+            RetainDailyBackups = 0,
+            RetainWeeklyBackups = 0,
+            RetainMonthlyBackups = 12, // Keep 12 months
+            RetainYearlyBackups = 0
+        };
+
+        // Act
+        var toDelete = _service.GetBackupsToDelete(backups, config);
+
+        // Assert - should delete oldest 3 monthly backups
+        Assert.That(toDelete.Count, Is.EqualTo(3));
+    }
+
+    #endregion
+
+    #region Yearly Retention Tests
+
+    [Test]
+    public void GetBackupsToDelete_KeepsFirstBackupOfEachYear()
+    {
+        // Arrange - 5 backups across 5 years
+        var startDate = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var backups = Enumerable.Range(0, 5)
+            .Select(i => CreateBackup($"year{i}.db", startDate.AddYears(-i)))
+            .ToList();
+
+        var config = new RetentionConfig
+        {
+            RetainHourlyBackups = 0,
+            RetainDailyBackups = 0,
+            RetainWeeklyBackups = 0,
+            RetainMonthlyBackups = 0,
+            RetainYearlyBackups = 3 // Keep 3 years
+        };
+
+        // Act
+        var toDelete = _service.GetBackupsToDelete(backups, config);
+
+        // Assert - should delete oldest 2 yearly backups
+        Assert.That(toDelete.Count, Is.EqualTo(2));
+        Assert.That(toDelete.Any(b => b.FileName == "year3.db"), Is.True);
+        Assert.That(toDelete.Any(b => b.FileName == "year4.db"), Is.True);
+    }
+
+    #endregion
+
+    #region Tier Hierarchy Tests
+
+    [Test]
+    public void GetBackupsToDelete_HigherTierPreventsDeletion()
+    {
+        // Arrange - backup qualifies for both hourly and yearly
+        var firstOfYear = new DateTimeOffset(2026, 1, 1, 1, 0, 0, TimeSpan.Zero);
+        var backups = new List<BackupFileInfo>
+        {
+            CreateBackup("first_of_year.db", firstOfYear)
+        };
+
+        var config = new RetentionConfig
+        {
+            RetainHourlyBackups = 0, // Don't keep as hourly
+            RetainDailyBackups = 0,
+            RetainWeeklyBackups = 0,
+            RetainMonthlyBackups = 0,
+            RetainYearlyBackups = 1  // But keep as yearly
+        };
+
+        // Act
+        var toDelete = _service.GetBackupsToDelete(backups, config);
+
+        // Assert - backup should be kept (yearly tier)
+        Assert.That(toDelete, Is.Empty);
+    }
+
+    #endregion
+
+    #region GetBackupRetentionInfo Tests
+
+    [Test]
+    public void GetBackupRetentionInfo_ReturnsYearlyTier_ForFirstOfYear()
+    {
+        // Arrange
+        var firstOfYear = new DateTimeOffset(2026, 1, 1, 1, 0, 0, TimeSpan.Zero);
+        var backup = CreateBackup("first_of_year.db", firstOfYear);
+        var allBackups = new List<BackupFileInfo> { backup };
+
+        // Act
+        var info = _service.GetBackupRetentionInfo(backup, allBackups, _defaultConfig);
+
+        // Assert
+        Assert.That(info.PrimaryTier, Is.EqualTo(BackupTier.Yearly));
+        Assert.That(info.WillBeKept, Is.True);
+    }
+
+    [Test]
+    public void GetBackupRetentionInfo_ReturnsDailyTier_ForFirstOfDay()
+    {
+        // Arrange - first backup of a day that's not first of week/month/year
+        var midMonthDay = new DateTimeOffset(2026, 1, 15, 1, 0, 0, TimeSpan.Zero);
+        var backup = CreateBackup("mid_month.db", midMonthDay);
+        var allBackups = new List<BackupFileInfo> { backup };
+
+        // Act
+        var info = _service.GetBackupRetentionInfo(backup, allBackups, _defaultConfig);
+
+        // Assert - will be highest tier it qualifies for
+        Assert.That(info.WillBeKept, Is.True);
+    }
+
+    [Test]
+    public void GetBackupRetentionInfo_ReturnsWillBeKeptFalse_WhenExceedsRetention()
+    {
+        // Arrange - backup beyond retention
+        var now = DateTimeOffset.UtcNow;
+        var backups = Enumerable.Range(0, 30)
+            .Select(i => CreateBackup($"backup{i}.db", now.AddHours(-i)))
+            .ToList();
+
+        var config = new RetentionConfig
+        {
+            RetainHourlyBackups = 5, // Only keep 5 most recent
+            RetainDailyBackups = 0,
+            RetainWeeklyBackups = 0,
+            RetainMonthlyBackups = 0,
+            RetainYearlyBackups = 0
+        };
+
+        var oldBackup = backups[25]; // backup25.db - old backup
+
+        // Act
+        var info = _service.GetBackupRetentionInfo(oldBackup, backups, config);
+
+        // Assert
+        Assert.That(info.WillBeKept, Is.False);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static BackupFileInfo CreateBackup(string fileName, DateTimeOffset createdAt)
+    {
+        return new BackupFileInfo
+        {
+            FilePath = $"/backups/{fileName}",
+            CreatedAt = createdAt,
+            FileSizeBytes = 1024 * 1024 // 1MB
+        };
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin.UnitTests/Services/ReportActionsServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/ReportActionsServiceTests.cs
@@ -1,0 +1,592 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using TelegramGroupsAdmin.ContentDetection.Repositories;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Services;
+using TelegramGroupsAdmin.Services;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
+using TelegramGroupsAdmin.Telegram.Services.Moderation;
+using Report = TelegramGroupsAdmin.ContentDetection.Models.Report;
+using ModerationResult = TelegramGroupsAdmin.Telegram.Services.Moderation.ModerationResult;
+using DataModels = TelegramGroupsAdmin.Data.Models;
+
+namespace TelegramGroupsAdmin.UnitTests.Services;
+
+/// <summary>
+/// Unit tests for ReportActionsService.
+/// Tests the web UI report actions (spam, ban, warn, dismiss).
+/// Uses IModerationOrchestrator interface (enabled by Issue #127 interface extraction).
+/// </summary>
+[TestFixture]
+public class ReportActionsServiceTests
+{
+    private const long TestReportId = 123L;
+    private const long TestMessageId = 456L;
+    private const long TestChatId = -100123456789L;
+    private const long TestUserId = 789L;
+    private const string TestReviewerId = "reviewer-user-id";
+
+    private IReportsRepository _mockReportsRepo = null!;
+    private IMessageHistoryRepository _mockMessageRepo = null!;
+    private IModerationOrchestrator _mockModerationService = null!;
+    private IAuditService _mockAuditService = null!;
+    private IBotMessageService _mockBotMessageService = null!;
+    private IReportCallbackContextRepository _mockCallbackContextRepo = null!;
+    private ILogger<ReportActionsService> _mockLogger = null!;
+
+    private ReportActionsService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockReportsRepo = Substitute.For<IReportsRepository>();
+        _mockMessageRepo = Substitute.For<IMessageHistoryRepository>();
+        _mockModerationService = Substitute.For<IModerationOrchestrator>();
+        _mockAuditService = Substitute.For<IAuditService>();
+        _mockBotMessageService = Substitute.For<IBotMessageService>();
+        _mockCallbackContextRepo = Substitute.For<IReportCallbackContextRepository>();
+        _mockLogger = Substitute.For<ILogger<ReportActionsService>>();
+
+        _service = new ReportActionsService(
+            _mockReportsRepo,
+            _mockMessageRepo,
+            _mockModerationService,
+            _mockAuditService,
+            _mockBotMessageService,
+            _mockCallbackContextRepo,
+            _mockLogger);
+    }
+
+    #region HandleSpamActionAsync Tests
+
+    [Test]
+    public async Task HandleSpamActionAsync_Success_ExecutesModerationAndUpdatesReport()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.MarkAsSpamAndBanAsync(
+                TestMessageId,
+                TestUserId,
+                TestChatId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<Message?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, ChatsAffected = 5 });
+
+        // Act
+        await _service.HandleSpamActionAsync(TestReportId, TestReviewerId);
+
+        // Assert
+        await _mockModerationService.Received(1).MarkAsSpamAndBanAsync(
+            TestMessageId,
+            TestUserId,
+            TestChatId,
+            Arg.Any<Actor>(),
+            Arg.Is<string>(s => s.Contains($"Report #{TestReportId}")),
+            Arg.Any<Message?>(),
+            Arg.Any<CancellationToken>());
+
+        await _mockReportsRepo.Received(1).UpdateReportStatusAsync(
+            TestReportId,
+            DataModels.ReportStatus.Reviewed,
+            TestReviewerId,
+            "spam",
+            Arg.Is<string>(s => s.Contains("5 chats")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleSpamActionAsync_ReportNotFound_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns((Report?)null);
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _service.HandleSpamActionAsync(TestReportId, TestReviewerId));
+        Assert.That(ex!.Message, Does.Contain($"Report {TestReportId} not found"));
+    }
+
+    [Test]
+    public async Task HandleSpamActionAsync_MessageNotFound_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+        _mockMessageRepo.GetMessageAsync(TestMessageId, Arg.Any<CancellationToken>())
+            .Returns((MessageRecord?)null);
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _service.HandleSpamActionAsync(TestReportId, TestReviewerId));
+        Assert.That(ex!.Message, Does.Contain($"Message {TestMessageId} not found"));
+    }
+
+    [Test]
+    public async Task HandleSpamActionAsync_ModerationFails_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.MarkAsSpamAndBanAsync(
+                TestMessageId,
+                TestUserId,
+                TestChatId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<Message?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ModerationResult.Failed("User is admin"));
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _service.HandleSpamActionAsync(TestReportId, TestReviewerId));
+        Assert.That(ex!.Message, Does.Contain("User is admin"));
+    }
+
+    [Test]
+    public async Task HandleSpamActionAsync_Success_CreatesAuditLog()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+        SetupSuccessfulModeration();
+
+        // Act
+        await _service.HandleSpamActionAsync(TestReportId, TestReviewerId);
+
+        // Assert - human-readable format: "Marked as spam (report #123, affected 5 chats)"
+        await _mockAuditService.Received(1).LogEventAsync(
+            AuditEventType.ReportReviewed,
+            Arg.Is<Actor>(a => a.WebUserId == TestReviewerId),
+            Arg.Is<Actor>(a => a.TelegramUserId == TestUserId),
+            Arg.Is<string>(s => s.Contains("Marked as spam") && s.Contains($"report #{TestReportId}")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleSpamActionAsync_Success_CleansUpCallbackContext()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+        SetupSuccessfulModeration();
+
+        // Act
+        await _service.HandleSpamActionAsync(TestReportId, TestReviewerId);
+
+        // Assert
+        await _mockCallbackContextRepo.Received(1)
+            .DeleteByReportIdAsync(TestReportId, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region HandleBanActionAsync Tests
+
+    [Test]
+    public async Task HandleBanActionAsync_Success_BansUserAndDeletesMessage()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.BanUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, ChatsAffected = 3 });
+
+        // Act
+        await _service.HandleBanActionAsync(TestReportId, TestReviewerId);
+
+        // Assert
+        await _mockModerationService.Received(1).BanUserAsync(
+            TestUserId,
+            TestMessageId,
+            Arg.Any<Actor>(),
+            Arg.Is<string>(s => s.Contains($"Report #{TestReportId}")),
+            Arg.Any<CancellationToken>());
+
+        await _mockBotMessageService.Received(1).DeleteAndMarkMessageAsync(
+            TestChatId,
+            Arg.Is<int>(i => i == (int)TestMessageId),
+            deletionSource: "ban_action",
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleBanActionAsync_ModerationFails_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.BanUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ModerationResult.Failed("Rate limited"));
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _service.HandleBanActionAsync(TestReportId, TestReviewerId));
+        Assert.That(ex!.Message, Does.Contain("Rate limited"));
+    }
+
+    [Test]
+    public async Task HandleBanActionAsync_DeleteMessageFails_ContinuesExecution()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.BanUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, ChatsAffected = 3 });
+
+        _mockBotMessageService.DeleteAndMarkMessageAsync(
+                TestChatId,
+                Arg.Any<int>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Message already deleted"));
+
+        // Act - should not throw
+        await _service.HandleBanActionAsync(TestReportId, TestReviewerId);
+
+        // Assert - report status still updated
+        await _mockReportsRepo.Received(1).UpdateReportStatusAsync(
+            TestReportId,
+            DataModels.ReportStatus.Reviewed,
+            TestReviewerId,
+            "ban",
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region HandleWarnActionAsync Tests
+
+    [Test]
+    public async Task HandleWarnActionAsync_Success_WarnsUserAndUpdatesReport()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.WarnUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                TestChatId,
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, WarningCount = 2 });
+
+        // Act
+        await _service.HandleWarnActionAsync(TestReportId, TestReviewerId);
+
+        // Assert
+        await _mockModerationService.Received(1).WarnUserAsync(
+            TestUserId,
+            TestMessageId,
+            Arg.Any<Actor>(),
+            Arg.Is<string>(s => s.Contains($"Report #{TestReportId}")),
+            TestChatId,
+            Arg.Any<CancellationToken>());
+
+        await _mockReportsRepo.Received(1).UpdateReportStatusAsync(
+            TestReportId,
+            DataModels.ReportStatus.Reviewed,
+            TestReviewerId,
+            "warn",
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleWarnActionAsync_ModerationFails_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.WarnUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                TestChatId,
+                Arg.Any<CancellationToken>())
+            .Returns(ModerationResult.Failed("User not found"));
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _service.HandleWarnActionAsync(TestReportId, TestReviewerId));
+        Assert.That(ex!.Message, Does.Contain("User not found"));
+    }
+
+    [Test]
+    public async Task HandleWarnActionAsync_Success_IncludesWarningCountInAuditLog()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.WarnUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                TestChatId,
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, WarningCount = 3 });
+
+        // Act
+        await _service.HandleWarnActionAsync(TestReportId, TestReviewerId);
+
+        // Assert - human-readable format: "Warned user (report #123, 3 warnings total)"
+        await _mockAuditService.Received(1).LogEventAsync(
+            AuditEventType.ReportReviewed,
+            Arg.Any<Actor>(),
+            Arg.Any<Actor>(),
+            Arg.Is<string>(s => s.Contains("Warned user") && s.Contains("3 warnings total")),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region HandleDismissActionAsync Tests
+
+    [Test]
+    public async Task HandleDismissActionAsync_Success_DismissesReportWithoutModeration()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        // Act
+        await _service.HandleDismissActionAsync(TestReportId, TestReviewerId, "Not spam");
+
+        // Assert - no moderation action
+        await _mockModerationService.DidNotReceive()
+            .BanUserAsync(Arg.Any<long>(), Arg.Any<long?>(), Arg.Any<Actor>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _mockModerationService.DidNotReceive()
+            .WarnUserAsync(Arg.Any<long>(), Arg.Any<long?>(), Arg.Any<Actor>(),
+                Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+
+        // Report updated to dismissed
+        await _mockReportsRepo.Received(1).UpdateReportStatusAsync(
+            TestReportId,
+            DataModels.ReportStatus.Dismissed,
+            TestReviewerId,
+            "dismiss",
+            "Not spam",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleDismissActionAsync_NullReason_UsesDefaultReason()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        // Act
+        await _service.HandleDismissActionAsync(TestReportId, TestReviewerId, null);
+
+        // Assert
+        await _mockReportsRepo.Received(1).UpdateReportStatusAsync(
+            TestReportId,
+            DataModels.ReportStatus.Dismissed,
+            TestReviewerId,
+            "dismiss",
+            "No action needed",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleDismissActionAsync_Success_SendsReplyToReportedMessage()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        // Act
+        await _service.HandleDismissActionAsync(TestReportId, TestReviewerId);
+
+        // Assert - reply sent to reported message (not command message)
+        await _mockBotMessageService.Received(1).SendAndSaveMessageAsync(
+            TestChatId,
+            Arg.Is<string>(s => s.Contains("reviewed") && s.Contains("no action")),
+            parseMode: ParseMode.Markdown,
+            replyParameters: Arg.Is<ReplyParameters>(r => r.MessageId == (int)TestMessageId),
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleDismissActionAsync_Success_DeletesReportCommandMessage()
+    {
+        // Arrange
+        var reportCommandMessageId = 999;
+        var report = CreateTestReport(reportCommandMessageId: reportCommandMessageId);
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        // Act
+        await _service.HandleDismissActionAsync(TestReportId, TestReviewerId);
+
+        // Assert - /report command deleted
+        await _mockBotMessageService.Received(1).DeleteAndMarkMessageAsync(
+            TestChatId,
+            reportCommandMessageId,
+            deletionSource: "report_reviewed",
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleDismissActionAsync_ReplyFails_ContinuesExecution()
+    {
+        // Arrange
+        var report = CreateTestReport();
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        _mockBotMessageService.SendAndSaveMessageAsync(
+                TestChatId,
+                Arg.Any<string>(),
+                Arg.Any<ParseMode?>(),
+                Arg.Any<ReplyParameters>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Message deleted"));
+
+        // Act - should not throw
+        await _service.HandleDismissActionAsync(TestReportId, TestReviewerId);
+
+        // Assert - report status still updated
+        await _mockReportsRepo.Received(1).UpdateReportStatusAsync(
+            TestReportId,
+            DataModels.ReportStatus.Dismissed,
+            TestReviewerId,
+            "dismiss",
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static Report CreateTestReport(int? reportCommandMessageId = null)
+    {
+        return new Report(
+            Id: TestReportId,
+            MessageId: (int)TestMessageId,
+            ChatId: TestChatId,
+            ReportCommandMessageId: reportCommandMessageId,
+            ReportedByUserId: 11111L,
+            ReportedByUserName: "reporter",
+            ReportedAt: DateTimeOffset.UtcNow.AddMinutes(-10),
+            Status: DataModels.ReportStatus.Pending,
+            ReviewedBy: null,
+            ReviewedAt: null,
+            ActionTaken: null,
+            AdminNotes: null);
+    }
+
+    private static MessageRecord CreateTestMessage()
+    {
+        return new MessageRecord(
+            MessageId: TestMessageId,
+            UserId: TestUserId,
+            UserName: "testuser",
+            FirstName: "Test",
+            LastName: "User",
+            ChatId: TestChatId,
+            Timestamp: DateTimeOffset.UtcNow.AddMinutes(-15),
+            MessageText: "Spam message content",
+            PhotoFileId: null,
+            PhotoFileSize: null,
+            Urls: null,
+            EditDate: null,
+            ContentHash: null,
+            ChatName: "Test Chat",
+            PhotoLocalPath: null,
+            PhotoThumbnailPath: null,
+            ChatIconPath: null,
+            UserPhotoPath: null,
+            DeletedAt: null,
+            DeletionSource: null,
+            ReplyToMessageId: null,
+            ReplyToUser: null,
+            ReplyToText: null,
+            MediaType: null,
+            MediaFileId: null,
+            MediaFileSize: null,
+            MediaFileName: null,
+            MediaMimeType: null,
+            MediaLocalPath: null,
+            MediaDuration: null,
+            Translation: null,
+            ContentCheckSkipReason: ContentCheckSkipReason.NotSkipped);
+    }
+
+    private void SetupReportAndMessage(Report report, MessageRecord message)
+    {
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+        _mockMessageRepo.GetMessageAsync(TestMessageId, Arg.Any<CancellationToken>())
+            .Returns(message);
+    }
+
+    private void SetupSuccessfulModeration()
+    {
+        _mockModerationService.MarkAsSpamAndBanAsync(
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<Message?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, ChatsAffected = 5 });
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/ReportCallbackHandlerTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/ReportCallbackHandlerTests.cs
@@ -1,0 +1,1090 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+using TelegramGroupsAdmin.ContentDetection.Repositories;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Data.Models;
+using TelegramGroupsAdmin.Telegram.Constants;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
+using TelegramGroupsAdmin.Telegram.Services.BotCommands;
+using TelegramGroupsAdmin.Telegram.Services.Moderation;
+using Report = TelegramGroupsAdmin.ContentDetection.Models.Report;
+using TelegramUser = TelegramGroupsAdmin.Telegram.Models.TelegramUser;
+using ReportCallbackContext = TelegramGroupsAdmin.Telegram.Models.ReportCallbackContext;
+// Fully qualify ModerationResult to avoid ambiguity with Models.ModerationResult
+using ModerationResult = TelegramGroupsAdmin.Telegram.Services.Moderation.ModerationResult;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services.BotCommands;
+
+/// <summary>
+/// Unit tests for ReportCallbackHandler.
+/// Tests callback parsing, context lookup, action execution, and cleanup.
+/// Uses IModerationOrchestrator interface (enabled by Issue #127 interface extraction).
+/// </summary>
+[TestFixture]
+public class ReportCallbackHandlerTests
+{
+    private const long TestContextId = 12345L;
+    private const long TestReportId = 99L;
+    private const long TestChatId = -100123456789L;
+    private const long TestUserId = 54321L;
+    private const int TestMessageId = 42;
+
+    private ILogger<ReportCallbackHandler> _mockLogger = null!;
+    private IServiceScopeFactory _mockScopeFactory = null!;
+    private IServiceScope _mockScope = null!;
+    private IServiceProvider _mockServiceProvider = null!;
+    private ITelegramBotClientFactory _mockBotClientFactory = null!;
+    private ITelegramOperations _mockOperations = null!;
+
+    // Scoped services resolved from the mock scope
+    private IReportCallbackContextRepository _mockCallbackContextRepo = null!;
+    private IReportsRepository _mockReportsRepo = null!;
+    private ITelegramUserRepository _mockUserRepo = null!;
+    private IModerationOrchestrator _mockModerationService = null!;
+
+    private ReportCallbackHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockLogger = Substitute.For<ILogger<ReportCallbackHandler>>();
+        _mockScopeFactory = Substitute.For<IServiceScopeFactory>();
+        _mockScope = Substitute.For<IServiceScope>();
+        _mockServiceProvider = Substitute.For<IServiceProvider>();
+        _mockBotClientFactory = Substitute.For<ITelegramBotClientFactory>();
+        _mockOperations = Substitute.For<ITelegramOperations>();
+
+        // Scoped services
+        _mockCallbackContextRepo = Substitute.For<IReportCallbackContextRepository>();
+        _mockReportsRepo = Substitute.For<IReportsRepository>();
+        _mockUserRepo = Substitute.For<ITelegramUserRepository>();
+        _mockModerationService = Substitute.For<IModerationOrchestrator>();
+
+        // Wire up scope factory → scope → service provider
+        _mockScopeFactory.CreateScope().Returns(_mockScope);
+        _mockScope.ServiceProvider.Returns(_mockServiceProvider);
+
+        // Wire up service resolution
+        _mockServiceProvider.GetService(typeof(IReportCallbackContextRepository))
+            .Returns(_mockCallbackContextRepo);
+        _mockServiceProvider.GetService(typeof(IReportsRepository))
+            .Returns(_mockReportsRepo);
+        _mockServiceProvider.GetService(typeof(ITelegramUserRepository))
+            .Returns(_mockUserRepo);
+        _mockServiceProvider.GetService(typeof(IModerationOrchestrator))
+            .Returns(_mockModerationService);
+
+        // Bot client factory returns operations
+        _mockBotClientFactory.GetOperationsAsync().Returns(_mockOperations);
+
+        _handler = new ReportCallbackHandler(
+            _mockLogger,
+            _mockScopeFactory,
+            _mockBotClientFactory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _mockScope?.Dispose();
+        _mockBotClientFactory?.Dispose();
+    }
+
+    #region CanHandle Tests
+
+    [Test]
+    public void CanHandle_ReportActionPrefix_ReturnsTrue()
+    {
+        // Arrange - callback data with report action prefix
+        var callbackData = "rpt:123:0";
+
+        // Act
+        var result = _handler.CanHandle(callbackData);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    [TestCase("ban_select:123:456")]
+    [TestCase("ban_cancel:456")]
+    [TestCase("welcome:123")]
+    [TestCase("other:data")]
+    [TestCase("")]
+    public void CanHandle_NonReportPrefix_ReturnsFalse(string callbackData)
+    {
+        // Act
+        var result = _handler.CanHandle(callbackData);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    #endregion
+
+    #region Callback Data Parsing Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_NullData_ReturnsEarly()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: null);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - no scope created since we return early
+        _mockScopeFactory.DidNotReceive().CreateScope();
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_EmptyData_ReturnsEarly()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: "");
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert
+        _mockScopeFactory.DidNotReceive().CreateScope();
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_InvalidFormat_OnePart_ReturnsEarly()
+    {
+        // Arrange - only 1 part after prefix (need 2: contextId:action)
+        var callbackQuery = CreateCallbackQuery(data: "rpt:123");
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - scope created but no context lookup attempted
+        await _mockCallbackContextRepo.DidNotReceive()
+            .GetByIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_InvalidContextId_ReturnsEarly()
+    {
+        // Arrange - non-numeric context ID
+        var callbackQuery = CreateCallbackQuery(data: "rpt:abc:0");
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert
+        await _mockCallbackContextRepo.DidNotReceive()
+            .GetByIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_InvalidActionId_ReturnsEarly()
+    {
+        // Arrange - non-numeric action
+        var callbackQuery = CreateCallbackQuery(data: "rpt:123:xyz");
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert
+        await _mockCallbackContextRepo.DidNotReceive()
+            .GetByIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    [TestCase(-1, Description = "Negative action value")]
+    [TestCase(4, Description = "Action value exceeds Dismiss (3)")]
+    [TestCase(99, Description = "Way out of range")]
+    public async Task HandleCallbackAsync_ActionOutOfRange_ReturnsEarly(int invalidAction)
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:{invalidAction}");
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - should not attempt context lookup for invalid action
+        await _mockCallbackContextRepo.DidNotReceive()
+            .GetByIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Context Lookup Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_ContextNotFound_UpdatesMessageWithExpiredNotice()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:0");
+        _mockCallbackContextRepo.GetByIdAsync(TestContextId, Arg.Any<CancellationToken>())
+            .Returns((ReportCallbackContext?)null);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - message updated to show expired
+        await _mockOperations.Received(1).EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Is<string>(s => s.Contains("expired")),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        // No report lookup should happen
+        await _mockReportsRepo.DidNotReceive()
+            .GetByIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_ValidContext_ProceedsWithReportLookup()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:0");
+        var context = CreateTestContext();
+        _mockCallbackContextRepo.GetByIdAsync(TestContextId, Arg.Any<CancellationToken>())
+            .Returns(context);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - should look up the report
+        await _mockReportsRepo.Received(1)
+            .GetByIdAsync(TestReportId, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Report Validation Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_ReportNotFound_UpdatesMessageAndCleansUp()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:0");
+        SetupValidContext();
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns((Report?)null);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - message updated
+        await _mockOperations.Received(1).EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Is<string>(s => s.Contains("not found")),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        // Context deleted for cleanup
+        await _mockCallbackContextRepo.Received(1)
+            .DeleteAsync(TestContextId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_ReportAlreadyReviewed_UpdatesMessageAndCleansUp()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:0");
+        SetupValidContext();
+        var report = CreateTestReport(status: ReportStatus.Reviewed);
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert
+        await _mockOperations.Received(1).EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Is<string>(s => s.Contains("already") && s.Contains("reviewed")),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        await _mockCallbackContextRepo.Received(1)
+            .DeleteAsync(TestContextId, Arg.Any<CancellationToken>());
+
+        // Moderation should NOT be called
+        await _mockModerationService.DidNotReceive()
+            .BanUserAsync(Arg.Any<long>(), Arg.Any<long?>(), Arg.Any<Actor>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_RaceCondition_ShowsAlreadyHandledMessage()
+    {
+        // Arrange - report is pending, action succeeds, but status update fails (race condition)
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3"); // Dismiss
+        SetupValidContext();
+        var pendingReport = CreateTestReport(status: ReportStatus.Pending);
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(pendingReport);
+
+        // First call returns the pending report, but TryUpdate fails
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                TestReportId,
+                ReportStatus.Reviewed,
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(false); // Race condition - another admin handled it
+
+        // Second GetByIdAsync returns the already-reviewed report
+        var reviewedReport = CreateTestReport(
+            status: ReportStatus.Reviewed,
+            reviewedBy: "OtherAdmin",
+            actionTaken: "Spam",
+            reviewedAt: DateTimeOffset.UtcNow);
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(pendingReport, reviewedReport);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - message shows already handled by other admin
+        await _mockOperations.Received().EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Is<string>(s => s.Contains("OtherAdmin") && s.Contains("Spam")),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Spam Action Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_SpamAction_BansUserAndUpdatesReport()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:0"); // Spam = 0
+        SetupValidContext();
+        SetupPendingReport();
+        SetupTargetUser();
+
+        _mockModerationService.BanUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, ChatsAffected = 5 });
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - ban was called
+        await _mockModerationService.Received(1).BanUserAsync(
+            TestUserId,
+            TestMessageId,
+            Arg.Any<Actor>(),
+            Arg.Is<string>(s => s.Contains("spam")),
+            Arg.Any<CancellationToken>());
+
+        // Report status updated
+        await _mockReportsRepo.Received(1).TryUpdateReportStatusAsync(
+            TestReportId,
+            ReportStatus.Reviewed,
+            Arg.Any<string>(),
+            "Spam",
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_SpamAction_BanFails_ReportsFailure()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:0");
+        SetupValidContext();
+        SetupPendingReport();
+        SetupTargetUser();
+
+        _mockModerationService.BanUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ModerationResult.Failed("User is admin"));
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - message updated with failure
+        await _mockOperations.Received().EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Is<string>(s => s.Contains("failed") || s.Contains("User is admin")),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        // Report status NOT updated on failure
+        await _mockReportsRepo.DidNotReceive().TryUpdateReportStatusAsync(
+            Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Warn Action Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_WarnAction_WarnsUserAndUpdatesReport()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:1"); // Warn = 1
+        SetupValidContext();
+        SetupPendingReport();
+        SetupTargetUser();
+
+        _mockModerationService.WarnUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                TestChatId,
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, WarningCount = 2 });
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert
+        await _mockModerationService.Received(1).WarnUserAsync(
+            TestUserId,
+            TestMessageId,
+            Arg.Any<Actor>(),
+            Arg.Is<string>(s => s.Contains("report")),
+            TestChatId,
+            Arg.Any<CancellationToken>());
+
+        await _mockReportsRepo.Received(1).TryUpdateReportStatusAsync(
+            TestReportId,
+            ReportStatus.Reviewed,
+            Arg.Any<string>(),
+            "Warn",
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_WarnAction_WarnFails_ReportsFailure()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:1");
+        SetupValidContext();
+        SetupPendingReport();
+        SetupTargetUser();
+
+        _mockModerationService.WarnUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                TestChatId,
+                Arg.Any<CancellationToken>())
+            .Returns(ModerationResult.Failed("Database error"));
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert
+        await _mockOperations.Received().EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Is<string>(s => s.Contains("failed") || s.Contains("Database error")),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region TempBan Action Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_TempBanAction_TempBansUserAndUpdatesReport()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:2"); // TempBan = 2
+        SetupValidContext();
+        SetupPendingReport();
+        SetupTargetUser();
+
+        _mockModerationService.TempBanUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, ChatsAffected = 3 });
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert
+        await _mockModerationService.Received(1).TempBanUserAsync(
+            TestUserId,
+            TestMessageId,
+            Arg.Any<Actor>(),
+            Arg.Is<string>(s => s.Contains("report")),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+
+        await _mockReportsRepo.Received(1).TryUpdateReportStatusAsync(
+            TestReportId,
+            ReportStatus.Reviewed,
+            Arg.Any<string>(),
+            "TempBan",
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_TempBanAction_TempBanFails_ReportsFailure()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:2");
+        SetupValidContext();
+        SetupPendingReport();
+        SetupTargetUser();
+
+        _mockModerationService.TempBanUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ModerationResult.Failed("Rate limited"));
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert
+        await _mockOperations.Received().EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Is<string>(s => s.Contains("failed") || s.Contains("Rate limited")),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Dismiss Action Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_DismissAction_DismissesReportWithoutModerationAction()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3"); // Dismiss = 3
+        SetupValidContext();
+        SetupPendingReport();
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - no moderation action called
+        await _mockModerationService.DidNotReceive()
+            .BanUserAsync(Arg.Any<long>(), Arg.Any<long?>(), Arg.Any<Actor>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _mockModerationService.DidNotReceive()
+            .WarnUserAsync(Arg.Any<long>(), Arg.Any<long?>(), Arg.Any<Actor>(),
+                Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+        await _mockModerationService.DidNotReceive()
+            .TempBanUserAsync(Arg.Any<long>(), Arg.Any<long?>(), Arg.Any<Actor>(),
+                Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+
+        // Report status still updated
+        await _mockReportsRepo.Received(1).TryUpdateReportStatusAsync(
+            TestReportId,
+            ReportStatus.Reviewed,
+            Arg.Any<string>(),
+            "Dismiss",
+            Arg.Is<string>(s => s.Contains("dismissed")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_DismissAction_SendsReplyToOriginalMessage()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3");
+        SetupValidContext();
+        SetupPendingReport();
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - sends reply to original message in chat
+        await _mockOperations.Received().SendMessageAsync(
+            chatId: TestChatId,
+            text: Arg.Is<string>(s => s.Contains("reviewed") && s.Contains("no action")),
+            replyParameters: Arg.Is<ReplyParameters>(r => r.MessageId == TestMessageId),
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Cleanup Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_Success_DeletesCallbackContext()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3");
+        SetupValidContext();
+        SetupPendingReport();
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - callback context deleted
+        await _mockCallbackContextRepo.Received(1)
+            .DeleteAsync(TestContextId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_Success_DeletesReportCommandMessage()
+    {
+        // Arrange
+        var reportCommandMessageId = 999;
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3");
+        SetupValidContext();
+        var report = CreateTestReport(
+            status: ReportStatus.Pending,
+            reportCommandMessageId: reportCommandMessageId);
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - /report command message deleted
+        await _mockOperations.Received().DeleteMessageAsync(
+            TestChatId,
+            reportCommandMessageId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_DeleteMessageFails_DoesNotThrow()
+    {
+        // Arrange - command message already deleted (should handle gracefully)
+        var reportCommandMessageId = 999;
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3");
+        SetupValidContext();
+        var report = CreateTestReport(
+            status: ReportStatus.Pending,
+            reportCommandMessageId: reportCommandMessageId);
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        _mockOperations.DeleteMessageAsync(TestChatId, reportCommandMessageId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Message not found"));
+
+        // Act - should not throw
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - test passes if no exception thrown
+    }
+
+    #endregion
+
+    #region Message Update Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_TextMessage_UpdatesText()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3", isPhotoMessage: false);
+        SetupValidContext();
+        SetupPendingReport();
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - EditMessageTextAsync called (not EditMessageCaptionAsync)
+        await _mockOperations.Received().EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        await _mockOperations.DidNotReceive().EditMessageCaptionAsync(
+            Arg.Any<long>(), Arg.Any<int>(), Arg.Any<string>(),
+            replyMarkup: Arg.Any<InlineKeyboardMarkup?>(),
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_PhotoMessage_UpdatesCaption()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3", isPhotoMessage: true);
+        SetupValidContext();
+        SetupPendingReport();
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - EditMessageCaptionAsync called (not EditMessageTextAsync)
+        await _mockOperations.Received().EditMessageCaptionAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_VideoMessage_UpdatesCaption()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3", isVideoMessage: true);
+        SetupValidContext();
+        SetupPendingReport();
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - EditMessageCaptionAsync called for videos (like photos)
+        await _mockOperations.Received().EditMessageCaptionAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Any<string>(),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        // Verify text update was NOT called
+        await _mockOperations.DidNotReceive().EditMessageTextAsync(
+            Arg.Any<long>(), Arg.Any<int>(), Arg.Any<string>(),
+            replyMarkup: Arg.Any<InlineKeyboardMarkup?>(),
+            cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task HandleCallbackAsync_NullMessage_ReturnsEarlyWithoutUpdating()
+    {
+        // Arrange - message is null (can happen if message was deleted before callback)
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:3", includeMessage: false);
+        SetupValidContext();
+        SetupPendingReport();
+
+        _mockReportsRepo.TryUpdateReportStatusAsync(
+                Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - no message edit attempted since message is null
+        await _mockOperations.DidNotReceive().EditMessageTextAsync(
+            Arg.Any<long>(), Arg.Any<int>(), Arg.Any<string>(),
+            replyMarkup: Arg.Any<InlineKeyboardMarkup?>(),
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        await _mockOperations.DidNotReceive().EditMessageCaptionAsync(
+            Arg.Any<long>(), Arg.Any<int>(), Arg.Any<string>(),
+            replyMarkup: Arg.Any<InlineKeyboardMarkup?>(),
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        // The action should still complete (context deleted, report status updated)
+        await _mockCallbackContextRepo.Received(1)
+            .DeleteAsync(TestContextId, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Exception Handling Tests
+
+    [Test]
+    public async Task HandleCallbackAsync_ActionThrows_ReturnsFailureResult()
+    {
+        // Arrange
+        var callbackQuery = CreateCallbackQuery(data: $"rpt:{TestContextId}:0");
+        SetupValidContext();
+        SetupPendingReport();
+        SetupTargetUser();
+
+        _mockModerationService.BanUserAsync(
+                TestUserId,
+                TestMessageId,
+                Arg.Any<Actor>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act
+        await _handler.HandleCallbackAsync(callbackQuery);
+
+        // Assert - message updated with failure
+        await _mockOperations.Received().EditMessageTextAsync(
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Is<string>(s => s.Contains("failed") || s.Contains("Unexpected error")),
+            replyMarkup: null,
+            cancellationToken: Arg.Any<CancellationToken>());
+
+        // Context still cleaned up
+        await _mockCallbackContextRepo.Received(1)
+            .DeleteAsync(TestContextId, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private enum TestMessageType { Text, Photo, Video }
+
+    private static CallbackQuery CreateCallbackQuery(
+        string? data,
+        bool isPhotoMessage = false,
+        bool isVideoMessage = false,
+        bool includeMessage = true,
+        long chatId = -1001234567890,
+        int messageId = 100)
+    {
+        Message? message = null;
+
+        if (data != null && includeMessage)
+        {
+            var messageType = isVideoMessage ? TestMessageType.Video
+                            : isPhotoMessage ? TestMessageType.Photo
+                            : TestMessageType.Text;
+            message = CreateMessage(messageId, chatId, messageType);
+        }
+
+        return new CallbackQuery
+        {
+            Id = "callback123",
+            Data = data,
+            Message = message,
+            From = new User { Id = 999, FirstName = "Admin", Username = "admin" }
+        };
+    }
+
+    /// <summary>
+    /// Create a Message using JSON deserialization since Telegram.Bot.Types.Message has read-only properties.
+    /// This is the same pattern used by Telegram.Bot internally.
+    /// </summary>
+    private static Message CreateMessage(int messageId, long chatId, TestMessageType messageType)
+    {
+        var json = messageType switch
+        {
+            TestMessageType.Photo => $$"""
+            {
+                "message_id": {{messageId}},
+                "date": {{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}},
+                "chat": {
+                    "id": {{chatId}},
+                    "type": "private"
+                },
+                "from": {
+                    "id": 999,
+                    "is_bot": false,
+                    "first_name": "Admin"
+                },
+                "photo": [
+                    {
+                        "file_id": "photo123",
+                        "file_unique_id": "unique123",
+                        "width": 100,
+                        "height": 100
+                    }
+                ],
+                "caption": "Original caption"
+            }
+            """,
+            TestMessageType.Video => $$"""
+            {
+                "message_id": {{messageId}},
+                "date": {{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}},
+                "chat": {
+                    "id": {{chatId}},
+                    "type": "private"
+                },
+                "from": {
+                    "id": 999,
+                    "is_bot": false,
+                    "first_name": "Admin"
+                },
+                "video": {
+                    "file_id": "video123",
+                    "file_unique_id": "uniquevideo123",
+                    "width": 1920,
+                    "height": 1080,
+                    "duration": 30
+                },
+                "caption": "Original video caption"
+            }
+            """,
+            _ => $$"""
+            {
+                "message_id": {{messageId}},
+                "date": {{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}},
+                "chat": {
+                    "id": {{chatId}},
+                    "type": "private"
+                },
+                "from": {
+                    "id": 999,
+                    "is_bot": false,
+                    "first_name": "Admin"
+                },
+                "text": "Original text"
+            }
+            """
+        };
+
+        return JsonSerializer.Deserialize<Message>(json, JsonSerializerOptions.Web)!;
+    }
+
+    private static ReportCallbackContext CreateTestContext()
+    {
+        return new ReportCallbackContext(
+            Id: TestContextId,
+            ReportId: TestReportId,
+            ChatId: TestChatId,
+            UserId: TestUserId,
+            CreatedAt: DateTimeOffset.UtcNow.AddMinutes(-5));
+    }
+
+    private static Report CreateTestReport(
+        ReportStatus status = ReportStatus.Pending,
+        string? reviewedBy = null,
+        string? actionTaken = null,
+        DateTimeOffset? reviewedAt = null,
+        int? reportCommandMessageId = null)
+    {
+        return new Report(
+            Id: TestReportId,
+            MessageId: TestMessageId,
+            ChatId: TestChatId,
+            ReportCommandMessageId: reportCommandMessageId,
+            ReportedByUserId: 11111L,
+            ReportedByUserName: "reporter",
+            ReportedAt: DateTimeOffset.UtcNow.AddMinutes(-10),
+            Status: status,
+            ReviewedBy: reviewedBy,
+            ReviewedAt: reviewedAt,
+            ActionTaken: actionTaken,
+            AdminNotes: null);
+    }
+
+    private static TelegramUser CreateTestUser()
+    {
+        return new TelegramUser(
+            TelegramUserId: TestUserId,
+            Username: "testuser",
+            FirstName: "Test",
+            LastName: "User",
+            UserPhotoPath: null,
+            PhotoHash: null,
+            PhotoFileUniqueId: null,
+            IsBot: false,
+            IsTrusted: false,
+            IsBanned: false,
+            BotDmEnabled: false,
+            FirstSeenAt: DateTimeOffset.UtcNow.AddDays(-30),
+            LastSeenAt: DateTimeOffset.UtcNow.AddMinutes(-5),
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-30),
+            UpdatedAt: DateTimeOffset.UtcNow.AddMinutes(-5),
+            IsActive: true);
+    }
+
+    private void SetupValidContext()
+    {
+        var context = CreateTestContext();
+        _mockCallbackContextRepo.GetByIdAsync(TestContextId, Arg.Any<CancellationToken>())
+            .Returns(context);
+    }
+
+    private void SetupPendingReport()
+    {
+        var report = CreateTestReport(status: ReportStatus.Pending);
+        _mockReportsRepo.GetByIdAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+    }
+
+    private void SetupTargetUser()
+    {
+        var user = CreateTestUser();
+        _mockUserRepo.GetByTelegramIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/TelegramUserManagementServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/TelegramUserManagementServiceTests.cs
@@ -1,0 +1,321 @@
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using TelegramGroupsAdmin.Core;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services;
+
+/// <summary>
+/// Unit tests for TelegramUserManagementService.
+/// Tests business logic for ToggleTrustAsync and UnbanAsync,
+/// and verifies delegation to repositories for query methods.
+/// Uses ITelegramUserRepository and IUserActionsRepository interfaces
+/// (enabled by Issue #127 interface extraction).
+/// </summary>
+[TestFixture]
+public class TelegramUserManagementServiceTests
+{
+    private ITelegramUserRepository _mockUserRepo = null!;
+    private IUserActionsRepository _mockActionsRepo = null!;
+    private ILogger<TelegramUserManagementService> _mockLogger = null!;
+    private TelegramUserManagementService _service = null!;
+
+    private const long TestUserId = 123456789;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockUserRepo = Substitute.For<ITelegramUserRepository>();
+        _mockActionsRepo = Substitute.For<IUserActionsRepository>();
+
+        // Logger is required by constructor but intentionally not verified.
+        // Logging is an implementation detail - tests focus on business logic outcomes.
+        _mockLogger = Substitute.For<ILogger<TelegramUserManagementService>>();
+
+        _service = new TelegramUserManagementService(
+            _mockUserRepo,
+            _mockActionsRepo,
+            _mockLogger);
+    }
+
+    #region ToggleTrustAsync Tests
+
+    [Test]
+    public async Task ToggleTrustAsync_ReturnsFalse_WhenUserNotFound()
+    {
+        // Arrange
+        _mockUserRepo.GetByTelegramIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .ReturnsNull();
+
+        var executor = Actor.FromSystem("Test");
+
+        // Act
+        var result = await _service.ToggleTrustAsync(TestUserId, executor);
+
+        // Assert
+        Assert.That(result, Is.False);
+        await _mockUserRepo.DidNotReceive().UpdateTrustStatusAsync(
+            Arg.Any<long>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ToggleTrustAsync_TrustsUser_WhenNotCurrentlyTrusted()
+    {
+        // Arrange
+        var user = CreateTelegramUser(isTrusted: false);
+        _mockUserRepo.GetByTelegramIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        var executor = Actor.FromSystem("Test");
+
+        // Act
+        var result = await _service.ToggleTrustAsync(TestUserId, executor);
+
+        // Assert
+        Assert.That(result, Is.True);
+        await _mockUserRepo.Received(1).UpdateTrustStatusAsync(
+            TestUserId, true, Arg.Any<CancellationToken>());
+        await _mockActionsRepo.Received(1).InsertAsync(
+            Arg.Is<UserActionRecord>(a => a.ActionType == UserActionType.Trust && a.UserId == TestUserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ToggleTrustAsync_UntrustsUser_WhenCurrentlyTrusted()
+    {
+        // Arrange
+        var user = CreateTelegramUser(isTrusted: true);
+        _mockUserRepo.GetByTelegramIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        var executor = Actor.FromSystem("Test");
+
+        // Act
+        var result = await _service.ToggleTrustAsync(TestUserId, executor);
+
+        // Assert
+        Assert.That(result, Is.True);
+        await _mockUserRepo.Received(1).UpdateTrustStatusAsync(
+            TestUserId, false, Arg.Any<CancellationToken>());
+        await _mockActionsRepo.Received(1).ExpireTrustsForUserAsync(TestUserId, Arg.Any<long?>(), Arg.Any<CancellationToken>());
+        await _mockActionsRepo.Received(1).InsertAsync(
+            Arg.Is<UserActionRecord>(a => a.ActionType == UserActionType.Untrust && a.UserId == TestUserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ToggleTrustAsync_BlocksUntrustingSystemAccount()
+    {
+        // Arrange - Use Telegram system account ID (777000 = Telegram notifications)
+        const long systemUserId = 777000;
+        var systemUser = CreateTelegramUser(telegramUserId: systemUserId, isTrusted: true);
+        _mockUserRepo.GetByTelegramIdAsync(systemUserId, Arg.Any<CancellationToken>())
+            .Returns(systemUser);
+
+        var executor = Actor.FromSystem("Test");
+
+        // Act
+        var result = await _service.ToggleTrustAsync(systemUserId, executor);
+
+        // Assert - Should fail to untrust system account
+        Assert.That(result, Is.False);
+        await _mockUserRepo.DidNotReceive().UpdateTrustStatusAsync(
+            Arg.Any<long>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ToggleTrustAsync_AllowsTrustingSystemAccount()
+    {
+        // Arrange - System account not yet trusted (edge case)
+        const long systemUserId = 777000;
+        var systemUser = CreateTelegramUser(telegramUserId: systemUserId, isTrusted: false);
+        _mockUserRepo.GetByTelegramIdAsync(systemUserId, Arg.Any<CancellationToken>())
+            .Returns(systemUser);
+
+        var executor = Actor.FromSystem("Test");
+
+        // Act
+        var result = await _service.ToggleTrustAsync(systemUserId, executor);
+
+        // Assert - Should succeed (trusting system accounts is allowed)
+        Assert.That(result, Is.True);
+        await _mockUserRepo.Received(1).UpdateTrustStatusAsync(
+            systemUserId, true, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region UnbanAsync Tests
+
+    [Test]
+    public async Task UnbanAsync_ReturnsFalse_WhenUserNotFound()
+    {
+        // Arrange
+        _mockUserRepo.GetByTelegramIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .ReturnsNull();
+
+        var executor = Actor.FromSystem("Test");
+
+        // Act
+        var result = await _service.UnbanAsync(TestUserId, executor);
+
+        // Assert
+        Assert.That(result, Is.False);
+        await _mockActionsRepo.DidNotReceive().ExpireBansForUserAsync(
+            Arg.Any<long>(), Arg.Any<long?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task UnbanAsync_ReturnsFalse_WhenUserNotBanned()
+    {
+        // Arrange
+        var user = CreateTelegramUser();
+        _mockUserRepo.GetByTelegramIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+        _mockUserRepo.IsBannedAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var executor = Actor.FromSystem("Test");
+
+        // Act
+        var result = await _service.UnbanAsync(TestUserId, executor);
+
+        // Assert
+        Assert.That(result, Is.False);
+        await _mockActionsRepo.DidNotReceive().ExpireBansForUserAsync(
+            Arg.Any<long>(), Arg.Any<long?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task UnbanAsync_Succeeds_WhenUserIsBanned()
+    {
+        // Arrange
+        var user = CreateTelegramUser();
+        _mockUserRepo.GetByTelegramIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+        _mockUserRepo.IsBannedAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var executor = Actor.FromSystem("Test");
+
+        // Act
+        var result = await _service.UnbanAsync(TestUserId, executor);
+
+        // Assert
+        Assert.That(result, Is.True);
+        await _mockActionsRepo.Received(1).ExpireBansForUserAsync(
+            TestUserId, null, Arg.Any<CancellationToken>());
+        await _mockActionsRepo.Received(1).InsertAsync(
+            Arg.Is<UserActionRecord>(a => a.ActionType == UserActionType.Unban && a.UserId == TestUserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task UnbanAsync_UsesProvidedReason()
+    {
+        // Arrange
+        var user = CreateTelegramUser();
+        _mockUserRepo.GetByTelegramIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+        _mockUserRepo.IsBannedAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var executor = Actor.FromSystem("Test");
+        const string customReason = "Ban reversed after review";
+
+        // Act
+        var result = await _service.UnbanAsync(TestUserId, executor, customReason);
+
+        // Assert
+        Assert.That(result, Is.True);
+        await _mockActionsRepo.Received(1).InsertAsync(
+            Arg.Is<UserActionRecord>(a =>
+                a.ActionType == UserActionType.Unban &&
+                a.Reason == customReason),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Query Delegation Tests
+
+    [Test]
+    public async Task GetUserDetailAsync_DelegatesToRepository()
+    {
+        // Arrange
+        var expectedDetail = new TelegramUserDetail { TelegramUserId = TestUserId };
+        _mockUserRepo.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(expectedDetail);
+
+        // Act
+        var result = await _service.GetUserDetailAsync(TestUserId);
+
+        // Assert
+        Assert.That(result, Is.SameAs(expectedDetail));
+        await _mockUserRepo.Received(1).GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task IsBannedAsync_DelegatesToRepository()
+    {
+        // Arrange
+        _mockUserRepo.IsBannedAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var result = await _service.IsBannedAsync(TestUserId);
+
+        // Assert
+        Assert.That(result, Is.True);
+        await _mockUserRepo.Received(1).IsBannedAsync(TestUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task GetActiveWarningCountAsync_DelegatesToRepository()
+    {
+        // Arrange
+        _mockUserRepo.GetActiveWarningCountAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(3);
+
+        // Act
+        var result = await _service.GetActiveWarningCountAsync(TestUserId);
+
+        // Assert
+        Assert.That(result, Is.EqualTo(3));
+        await _mockUserRepo.Received(1).GetActiveWarningCountAsync(TestUserId, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static TelegramUser CreateTelegramUser(
+        long telegramUserId = TestUserId,
+        bool isTrusted = false)
+    {
+        return new TelegramUser(
+            TelegramUserId: telegramUserId,
+            Username: "testuser",
+            FirstName: "Test",
+            LastName: "User",
+            UserPhotoPath: null,
+            PhotoHash: null,
+            PhotoFileUniqueId: null,
+            IsBot: false,
+            IsTrusted: isTrusted,
+            IsBanned: false,
+            BotDmEnabled: false,
+            FirstSeenAt: DateTimeOffset.UtcNow.AddDays(-30),
+            LastSeenAt: DateTimeOffset.UtcNow.AddHours(-1),
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-30),
+            UpdatedAt: DateTimeOffset.UtcNow.AddHours(-1),
+            IsActive: true
+        );
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin/Components/Layout/MainLayout.razor
+++ b/TelegramGroupsAdmin/Components/Layout/MainLayout.razor
@@ -3,7 +3,7 @@
 @using TelegramGroupsAdmin.Services
 @using TelegramGroupsAdmin.Components.Shared
 @inject AuthenticationStateProvider AuthStateProvider
-@inject NotificationStateService NotificationState
+@inject INotificationStateService NotificationState
 @inject IHostEnvironment HostEnvironment
 
 <MudThemeProvider Theme="@_currentTheme" IsDarkMode="true" />

--- a/TelegramGroupsAdmin/Components/Pages/Chats.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Chats.razor
@@ -8,7 +8,7 @@
 @inject IManagedChatsRepository ManagedChatsRepository
 @inject IContentDetectionConfigRepository SpamConfigRepository
 @inject TelegramGroupsAdmin.Configuration.Repositories.IConfigRepository ConfigRepository
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 @attribute [Authorize]
 @implements IDisposable

--- a/TelegramGroupsAdmin/Components/Pages/Messages.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Messages.razor
@@ -17,11 +17,11 @@
 @inject IJSRuntime Js
 @inject IDialogService DialogService
 @inject ITelegramBotService BotService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject IDetectionResultsRepository DetectionResultsRepository
 @inject ITrainingLabelsRepository TrainingLabelsRepository
 @inject IJobTriggerService JobTriggerService
-@inject ModerationOrchestrator ModerationService
+@inject IModerationOrchestrator ModerationService
 @inject ITelegramUserMappingRepository TelegramMappingRepository
 @inject ITelegramUserRepository TelegramUserRepository
 @inject NavigationManager NavigationManager

--- a/TelegramGroupsAdmin/Components/Pages/NotificationDebug.razor
+++ b/TelegramGroupsAdmin/Components/Pages/NotificationDebug.razor
@@ -8,8 +8,8 @@
 
 @inject INotificationService NotificationService
 @inject IWebPushNotificationService WebPushService
-@inject NotificationStateService NotificationState
-@inject BlazorAuthHelper AuthHelper
+@inject INotificationStateService NotificationState
+@inject IBlazorAuthHelper AuthHelper
 @inject IUserRepository UserRepository
 
 <PageTitle>Notification Debug</PageTitle>

--- a/TelegramGroupsAdmin/Components/Pages/Reports.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Reports.razor
@@ -10,7 +10,7 @@
 @inject IImpersonationAlertsRepository ImpersonationAlertsRepository
 @inject IReportActionsService ReportActionsService
 @inject IManagedChatsRepository ManagedChatsRepository
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 @inject AuthenticationStateProvider AuthStateProvider
 @inject ILogger<Reports> Logger

--- a/TelegramGroupsAdmin/Components/Pages/Settings.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Settings.razor
@@ -6,7 +6,7 @@
 @using TelegramGroupsAdmin.Constants
 @using TelegramGroupsAdmin.Services
 @inject NavigationManager Navigation
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @implements IDisposable
 
 <PageTitle>Settings</PageTitle>

--- a/TelegramGroupsAdmin/Components/Pages/Users.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Users.razor
@@ -2,8 +2,8 @@
 @attribute [Authorize]
 @using Microsoft.AspNetCore.Components.Authorization
 @using TelegramGroupsAdmin.Components.Shared.Settings
-@inject TelegramUserManagementService UserManagementService
-@inject BlazorAuthHelper AuthHelper
+@inject ITelegramUserManagementService UserManagementService
+@inject IBlazorAuthHelper AuthHelper
 @inject IManagedChatsRepository ManagedChatsRepository
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService

--- a/TelegramGroupsAdmin/Components/Shared/Analytics/MessageTrends.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Analytics/MessageTrends.razor
@@ -3,7 +3,7 @@
 @using ApexCharts
 @inject IMessageStatsService MessageStatsService
 @inject IManagedChatsRepository ChatsRepository
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 @inject IJSRuntime JsRuntime
 

--- a/TelegramGroupsAdmin/Components/Shared/BackupBrowser.razor
+++ b/TelegramGroupsAdmin/Components/Shared/BackupBrowser.razor
@@ -4,7 +4,7 @@
 @using TelegramGroupsAdmin.Core.Models
 @using TelegramGroupsAdmin.Core.Services
 @inject IBackupService BackupService
-@inject BackupRetentionService RetentionService
+@inject IBackupRetentionService RetentionService
 @inject ISnackbar Snackbar
 @inject IJSRuntime Js
 @inject IAuditService AuditService
@@ -304,7 +304,7 @@
 
     private List<BackupFileInfo> _backups = [];
     private List<TierGroup> _tierGroups = [];
-    private readonly Dictionary<string, (BackupTier PrimaryTier, bool WillBeKept)> _backupRetentionInfo = new();
+    private readonly Dictionary<string, BackupRetentionInfo> _backupRetentionInfo = new();
     private bool _isLoading;
     private readonly RetentionConfig _retentionConfig = new(); // Default retention policy
 

--- a/TelegramGroupsAdmin/Components/Shared/ContentDetection/AIIntegrationSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ContentDetection/AIIntegrationSettings.razor
@@ -6,7 +6,7 @@
 @inject IAIServiceFactory AIServiceFactory
 @inject IFeatureTestService FeatureTestService
 @inject IAuditService AuditService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation
 

--- a/TelegramGroupsAdmin/Components/Shared/ContentDetection/ContentDetectionOpenAI.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ContentDetection/ContentDetectionOpenAI.razor
@@ -4,7 +4,7 @@
 @inject IPromptVersionRepository PromptVersionRepository
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 
 <MudPaper Class="pa-4" Elevation="1">
     <MudStack Spacing="3">

--- a/TelegramGroupsAdmin/Components/Shared/NotificationBell.razor
+++ b/TelegramGroupsAdmin/Components/Shared/NotificationBell.razor
@@ -1,6 +1,6 @@
 @using TelegramGroupsAdmin.Services
 @using TelegramGroupsAdmin.Core.Models
-@inject NotificationStateService NotificationState
+@inject INotificationStateService NotificationState
 @implements IDisposable
 
 <MudMenu Icon="@Icons.Material.Filled.Notifications"

--- a/TelegramGroupsAdmin/Components/Shared/Settings/AIProviderSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/AIProviderSettings.razor
@@ -6,7 +6,7 @@
 @inject IAIServiceFactory AIServiceFactory
 @inject IChatService ChatService
 @inject IAuditService AuditService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 

--- a/TelegramGroupsAdmin/Components/Shared/Settings/AlgorithmTuning.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/AlgorithmTuning.razor
@@ -5,7 +5,7 @@
 @inject IThresholdRecommendationsRepository RecommendationsRepository
 @inject IThresholdRecommendationService RecommendationService
 @inject IAuditService AuditService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation
 @inject IJSRuntime JsRuntime

--- a/TelegramGroupsAdmin/Components/Shared/Settings/ClamAVInfrastructureSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/ClamAVInfrastructureSettings.razor
@@ -3,9 +3,9 @@
 @using TelegramGroupsAdmin.ContentDetection.Services
 @using TelegramGroupsAdmin.Services
 @inject ISystemConfigRepository ConfigRepository
-@inject ClamAVScannerService ClamAvService
+@inject IFileScannerService FileScannerService
 @inject IAuditService AuditService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 
 <MudGrid>
@@ -170,7 +170,7 @@
         try
         {
             // Use the ClamAV service to test the connection with current settings
-            var healthResult = await ClamAvService.GetHealthAsync();
+            var healthResult = await FileScannerService.GetHealthAsync();
 
             if (healthResult.IsHealthy)
             {

--- a/TelegramGroupsAdmin/Components/Shared/Settings/EmailInfrastructureSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/EmailInfrastructureSettings.razor
@@ -5,7 +5,7 @@
 @inject ISystemConfigRepository ConfigRepository
 @inject IAuditService AuditService
 @inject IEmailService EmailService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 
 <MudGrid>

--- a/TelegramGroupsAdmin/Components/Shared/Settings/FileScanningSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/FileScanningSettings.razor
@@ -8,9 +8,9 @@
 @inject IFileScanQuotaRepository QuotaRepository
 @inject IDetectionResultsRepository DetectionResultsRepository
 @inject IFileScanResultRepository FileScanResultRepository
-@inject ClamAVScannerService ClamAvService
+@inject IFileScannerService FileScannerService
 @inject IAuditService AuditService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 @inject IConfiguration Configuration
 
@@ -476,7 +476,7 @@
     private FileScanningConfig _config = new();
     private ApiKeysConfig _apiKeys = new();
     private List<FileScanQuotaModel> _quotas = [];
-    private ClamAVHealthResult? _clamAvHealth;
+    private FileScannerHealthResult? _clamAvHealth;
     private Dictionary<string, int> _scanStats = new();
     private List<DetectionResultRecord> _scanResults = [];
     private bool _isSaving;
@@ -621,7 +621,7 @@
         try
         {
             // Load ClamAV health check
-            _clamAvHealth = await ClamAvService.GetHealthAsync();
+            _clamAvHealth = await FileScannerService.GetHealthAsync();
 
             // Load scan statistics (7-day window, infected files only)
             _scanStats = await DetectionResultsRepository.GetFileScanStatsAsync();

--- a/TelegramGroupsAdmin/Components/Shared/Settings/LoggingSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/LoggingSettings.razor
@@ -3,7 +3,7 @@
 @using Microsoft.Extensions.Logging
 @inject IRuntimeLoggingService RuntimeLoggingService
 @inject IAuditService AuditService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 
 <MudStack Spacing="4">

--- a/TelegramGroupsAdmin/Components/Shared/Settings/VirusTotalInfrastructureSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/VirusTotalInfrastructureSettings.razor
@@ -3,7 +3,7 @@
 @using TelegramGroupsAdmin.Services
 @inject ISystemConfigRepository ConfigRepository
 @inject IAuditService AuditService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 
 <MudGrid>

--- a/TelegramGroupsAdmin/Components/Shared/Settings/WebAdminAccounts.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/WebAdminAccounts.razor
@@ -4,7 +4,7 @@
 @inject IInviteService InviteService
 @inject IAuthService AuthService
 @inject IAccountLockoutService AccountLockoutService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation

--- a/TelegramGroupsAdmin/Components/Shared/Settings/WebPushSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/WebPushSettings.razor
@@ -4,7 +4,7 @@
 @using TelegramGroupsAdmin.Services
 @inject ISystemConfigRepository ConfigRepository
 @inject IAuditService AuditService
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 
 <MudGrid>

--- a/TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
@@ -1,13 +1,13 @@
 @using TelegramGroupsAdmin.Services
 @using TelegramGroupsAdmin.Helpers
 @using TelegramGroupsAdmin.Telegram.Services.Moderation
-@inject TelegramUserManagementService UserManagementService
-@inject ModerationOrchestrator ModerationService
+@inject ITelegramUserManagementService UserManagementService
+@inject IModerationOrchestrator ModerationService
 @inject IAdminNotesRepository AdminNotesRepository
 @inject IUserTagsRepository UserTagsRepository
 @inject ITagDefinitionsRepository TagDefinitionsRepository
 @inject IUserActionsRepository UserActionsRepository
-@inject BlazorAuthHelper AuthHelper
+@inject IBlazorAuthHelper AuthHelper
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject NavigationManager Navigation

--- a/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
@@ -137,7 +137,7 @@ public static class ServiceCollectionExtensions
             services.AddScoped<IUserManagementService, UserManagementService>();
             services.AddScoped<IAuditService, AuditService>();
             services.AddScoped<IFeatureAvailabilityService, FeatureAvailabilityService>(); // FEATURE-5.3: Check external service configuration status
-            services.AddScoped<BlazorAuthHelper>(); // Authentication context extraction helper for UI components
+            services.AddScoped<IBlazorAuthHelper, BlazorAuthHelper>(); // Authentication context extraction helper for UI components
 
             // Prompt builder service (Phase 4.X: AI-powered prompt generation)
             services.AddScoped<Services.PromptBuilder.IPromptBuilderService, Services.PromptBuilder.PromptBuilderService>();
@@ -151,7 +151,7 @@ public static class ServiceCollectionExtensions
             // Notification services (User notification preferences with Telegram DM, Email, and Web Push channels)
             services.AddScoped<INotificationService, NotificationService>();
             services.AddScoped<IWebPushNotificationService, WebPushNotificationService>();
-            services.AddScoped<NotificationStateService>(); // Blazor state for notification bell
+            services.AddScoped<INotificationStateService, NotificationStateService>(); // Blazor state for notification bell
 
             // Web Push browser notifications (PushServiceClient + VAPID auto-generation)
             services.AddHttpClient<Lib.Net.Http.WebPush.PushServiceClient>();

--- a/TelegramGroupsAdmin/Services/BlazorAuthHelper.cs
+++ b/TelegramGroupsAdmin/Services/BlazorAuthHelper.cs
@@ -9,7 +9,7 @@ namespace TelegramGroupsAdmin.Services;
 /// Helper service for extracting authenticated user information in Blazor components.
 /// Provides consistent authentication context extraction across UI layer.
 /// </summary>
-public class BlazorAuthHelper
+public class BlazorAuthHelper : IBlazorAuthHelper
 {
     private readonly AuthenticationStateProvider _authStateProvider;
 
@@ -18,31 +18,21 @@ public class BlazorAuthHelper
         _authStateProvider = authStateProvider;
     }
 
-    /// <summary>
-    /// Get the current authenticated user's ID (GUID string).
-    /// Returns null if user is not authenticated or NameIdentifier claim is missing.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<string?> GetCurrentUserIdAsync()
     {
         var authState = await _authStateProvider.GetAuthenticationStateAsync();
         return authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
     }
 
-    /// <summary>
-    /// Get the current authenticated user's email.
-    /// Returns null if user is not authenticated or Email claim is missing.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<string?> GetCurrentUserEmailAsync()
     {
         var authState = await _authStateProvider.GetAuthenticationStateAsync();
         return authState.User.FindFirst(ClaimTypes.Email)?.Value;
     }
 
-    /// <summary>
-    /// Get an Actor representing the current authenticated web user.
-    /// Throws InvalidOperationException if user is not authenticated.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when user is not authenticated or NameIdentifier claim is missing</exception>
+    /// <inheritdoc/>
     public async Task<Actor> GetCurrentActorAsync()
     {
         var userId = await GetCurrentUserIdAsync();
@@ -55,10 +45,7 @@ public class BlazorAuthHelper
         return Actor.FromWebUser(userId, email);
     }
 
-    /// <summary>
-    /// Try to get an Actor representing the current authenticated web user.
-    /// Returns null if user is not authenticated instead of throwing.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<Actor?> TryGetCurrentActorAsync()
     {
         var userId = await GetCurrentUserIdAsync();
@@ -71,10 +58,7 @@ public class BlazorAuthHelper
         return Actor.FromWebUser(userId, email);
     }
 
-    /// <summary>
-    /// Get the current authenticated user's permission level from claims.
-    /// Returns PermissionLevel.Admin (0) if not authenticated or PermissionLevel claim is missing/invalid.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<PermissionLevel> GetCurrentPermissionLevelAsync()
     {
         var authState = await _authStateProvider.GetAuthenticationStateAsync();
@@ -88,49 +72,35 @@ public class BlazorAuthHelper
         return PermissionLevel.Admin; // Default to lowest permission level
     }
 
-    /// <summary>
-    /// Check if current user can edit infrastructure settings (backups, API keys, logging, bot config).
-    /// Only Owner can edit infrastructure.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<bool> CanEditInfrastructureAsync()
     {
         var permissionLevel = await GetCurrentPermissionLevelAsync();
         return permissionLevel >= PermissionLevel.Owner;
     }
 
-    /// <summary>
-    /// Check if current user can edit content settings (spam detection, URL filters, training data).
-    /// GlobalAdmin and Owner can edit content.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<bool> CanEditContentSettingsAsync()
     {
         var permissionLevel = await GetCurrentPermissionLevelAsync();
         return permissionLevel >= PermissionLevel.GlobalAdmin;
     }
 
-    /// <summary>
-    /// Check if current user can manage admin accounts.
-    /// GlobalAdmin and Owner can manage admin accounts.
-    /// GlobalAdmin can only create Admin/GlobalAdmin users (escalation prevention enforced at API level).
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<bool> CanManageAdminAccountsAsync()
     {
         var permissionLevel = await GetCurrentPermissionLevelAsync();
         return permissionLevel >= PermissionLevel.GlobalAdmin;
     }
 
-    /// <summary>
-    /// Check if current user is Owner.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<bool> IsOwnerAsync()
     {
         var permissionLevel = await GetCurrentPermissionLevelAsync();
         return permissionLevel >= PermissionLevel.Owner;
     }
 
-    /// <summary>
-    /// Check if current user is GlobalAdmin or higher.
-    /// </summary>
+    /// <inheritdoc/>
     public async Task<bool> IsGlobalAdminOrHigherAsync()
     {
         var permissionLevel = await GetCurrentPermissionLevelAsync();

--- a/TelegramGroupsAdmin/Services/IBlazorAuthHelper.cs
+++ b/TelegramGroupsAdmin/Services/IBlazorAuthHelper.cs
@@ -1,0 +1,39 @@
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.Services;
+
+/// <summary>
+/// Helper service for accessing current user authentication state in Blazor components.
+/// </summary>
+public interface IBlazorAuthHelper
+{
+    /// <summary>Gets the current authenticated user's ID.</summary>
+    Task<string?> GetCurrentUserIdAsync();
+
+    /// <summary>Gets the current authenticated user's email address.</summary>
+    Task<string?> GetCurrentUserEmailAsync();
+
+    /// <summary>Gets the current user as an Actor for audit logging. Throws if not authenticated.</summary>
+    Task<Actor> GetCurrentActorAsync();
+
+    /// <summary>Attempts to get the current user as an Actor, returning null if not authenticated.</summary>
+    Task<Actor?> TryGetCurrentActorAsync();
+
+    /// <summary>Gets the current user's permission level.</summary>
+    Task<PermissionLevel> GetCurrentPermissionLevelAsync();
+
+    /// <summary>Checks if current user can edit infrastructure settings (Owner only).</summary>
+    Task<bool> CanEditInfrastructureAsync();
+
+    /// <summary>Checks if current user can edit content detection settings (GlobalAdmin or higher).</summary>
+    Task<bool> CanEditContentSettingsAsync();
+
+    /// <summary>Checks if current user can manage admin accounts (GlobalAdmin or higher).</summary>
+    Task<bool> CanManageAdminAccountsAsync();
+
+    /// <summary>Checks if current user is an Owner.</summary>
+    Task<bool> IsOwnerAsync();
+
+    /// <summary>Checks if current user is GlobalAdmin or higher.</summary>
+    Task<bool> IsGlobalAdminOrHigherAsync();
+}

--- a/TelegramGroupsAdmin/Services/INotificationStateService.cs
+++ b/TelegramGroupsAdmin/Services/INotificationStateService.cs
@@ -1,0 +1,43 @@
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.Services;
+
+/// <summary>
+/// Manages notification state for the current user's session.
+/// Scoped service that maintains in-memory notification cache.
+/// </summary>
+public interface INotificationStateService : IDisposable
+{
+    /// <summary>Raised when notification state changes (new notification, read, deleted).</summary>
+    event Func<Task>? OnChange;
+
+    /// <summary>Gets the count of unread notifications.</summary>
+    int UnreadCount { get; }
+
+    /// <summary>Gets the cached list of notifications.</summary>
+    IReadOnlyList<WebNotification> Notifications { get; }
+
+    /// <summary>Indicates whether notifications have been loaded from database.</summary>
+    bool IsLoaded { get; }
+
+    /// <summary>Initializes the notification state for a user, loading from database.</summary>
+    Task InitializeAsync(string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>Refreshes notifications from the database.</summary>
+    Task RefreshAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Marks a specific notification as read.</summary>
+    Task MarkAsReadAsync(long notificationId, CancellationToken cancellationToken = default);
+
+    /// <summary>Marks all notifications as read.</summary>
+    Task MarkAllAsReadAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Adds a notification to the in-memory cache (for real-time updates).</summary>
+    Task AddNotificationAsync(WebNotification notification);
+
+    /// <summary>Deletes a specific notification.</summary>
+    Task DeleteAsync(long notificationId, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes all notifications for the current user.</summary>
+    Task DeleteAllAsync(CancellationToken cancellationToken = default);
+}

--- a/TelegramGroupsAdmin/Services/NotificationStateService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationStateService.cs
@@ -7,7 +7,7 @@ namespace TelegramGroupsAdmin.Services;
 /// Blazor state service for managing in-app notification UI state
 /// Scoped per circuit - tracks unread count and recent notifications
 /// </summary>
-public class NotificationStateService : IDisposable
+public class NotificationStateService : INotificationStateService
 {
 
     private readonly IWebPushNotificationService _notificationService;
@@ -31,9 +31,7 @@ public class NotificationStateService : IDisposable
         _logger = logger;
     }
 
-    /// <summary>
-    /// Initialize state for a user (call from layout OnInitializedAsync)
-    /// </summary>
+    /// <inheritdoc/>
     public async Task InitializeAsync(string userId, CancellationToken cancellationToken = default)
     {
         if (_userId == userId && _isLoaded)
@@ -43,9 +41,7 @@ public class NotificationStateService : IDisposable
         await RefreshAsync(cancellationToken);
     }
 
-    /// <summary>
-    /// Refresh notifications from database
-    /// </summary>
+    /// <inheritdoc/>
     public async Task RefreshAsync(CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(_userId))
@@ -65,9 +61,7 @@ public class NotificationStateService : IDisposable
         }
     }
 
-    /// <summary>
-    /// Mark a single notification as read
-    /// </summary>
+    /// <inheritdoc/>
     public async Task MarkAsReadAsync(long notificationId, CancellationToken cancellationToken = default)
     {
         await _notificationService.MarkAsReadAsync(notificationId, cancellationToken);
@@ -83,9 +77,7 @@ public class NotificationStateService : IDisposable
         }
     }
 
-    /// <summary>
-    /// Mark all notifications as read
-    /// </summary>
+    /// <inheritdoc/>
     public async Task MarkAllAsReadAsync(CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(_userId))
@@ -104,9 +96,7 @@ public class NotificationStateService : IDisposable
         await NotifyStateChangedAsync();
     }
 
-    /// <summary>
-    /// Add a new notification (called when receiving real-time updates)
-    /// </summary>
+    /// <inheritdoc/>
     public async Task AddNotificationAsync(WebNotification notification)
     {
         _notifications.Insert(0, notification);
@@ -124,9 +114,7 @@ public class NotificationStateService : IDisposable
         await NotifyStateChangedAsync();
     }
 
-    /// <summary>
-    /// Delete a single notification
-    /// </summary>
+    /// <inheritdoc/>
     public async Task DeleteAsync(long notificationId, CancellationToken cancellationToken = default)
     {
         await _notificationService.DeleteAsync(notificationId, cancellationToken);
@@ -144,9 +132,7 @@ public class NotificationStateService : IDisposable
         }
     }
 
-    /// <summary>
-    /// Delete all notifications for current user
-    /// </summary>
+    /// <inheritdoc/>
     public async Task DeleteAllAsync(CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(_userId))

--- a/TelegramGroupsAdmin/Services/ReportActionsService.cs
+++ b/TelegramGroupsAdmin/Services/ReportActionsService.cs
@@ -17,7 +17,7 @@ public class ReportActionsService : IReportActionsService
 {
     private readonly IReportsRepository _reportsRepository;
     private readonly IMessageHistoryRepository _messageRepository;
-    private readonly ModerationOrchestrator _moderationService;
+    private readonly IModerationOrchestrator _moderationService;
     private readonly IAuditService _auditService;
     private readonly IBotMessageService _botMessageService;
     private readonly IReportCallbackContextRepository _callbackContextRepo;
@@ -26,7 +26,7 @@ public class ReportActionsService : IReportActionsService
     public ReportActionsService(
         IReportsRepository reportsRepository,
         IMessageHistoryRepository messageRepository,
-        ModerationOrchestrator moderationService,
+        IModerationOrchestrator moderationService,
         IAuditService auditService,
         IBotMessageService botMessageService,
         IReportCallbackContextRepository callbackContextRepo,
@@ -87,7 +87,7 @@ public class ReportActionsService : IReportActionsService
             AuditEventType.ReportReviewed,
             Actor.FromWebUser(reviewerId),
             Actor.FromTelegramUser(message.UserId),
-            $"spam:report#{reportId}:chats{result.ChatsAffected}",
+            $"Marked as spam (report #{reportId}, affected {result.ChatsAffected} chats)",
             cancellationToken);
 
         // Delete the /report command message (cleanup - no reply needed, action is visible)
@@ -158,7 +158,7 @@ public class ReportActionsService : IReportActionsService
             AuditEventType.ReportReviewed,
             Actor.FromWebUser(reviewerId),
             Actor.FromTelegramUser(message.UserId),
-            $"ban:report#{reportId}:chats{result.ChatsAffected}",
+            $"Banned user (report #{reportId}, affected {result.ChatsAffected} chats)",
             cancellationToken);
 
         // Delete the /report command message (cleanup - no reply needed, action is visible)
@@ -214,7 +214,7 @@ public class ReportActionsService : IReportActionsService
             AuditEventType.ReportReviewed,
             Actor.FromWebUser(reviewerId),
             Actor.FromTelegramUser(message.UserId),
-            $"warn:report#{reportId}:warnings{result.WarningCount}",
+            $"Warned user (report #{reportId}, {result.WarningCount} warnings total)",
             cancellationToken);
 
         // Delete the /report command message (cleanup - no reply needed, action is visible)
@@ -246,7 +246,7 @@ public class ReportActionsService : IReportActionsService
             AuditEventType.ReportReviewed,
             Actor.FromWebUser(reviewerId),
             null,
-            $"dismiss:report#{reportId}:{reason ?? "no_action"}",
+            $"Dismissed report #{reportId} ({reason ?? "no action taken"})",
             cancellationToken);
 
         // Reply to original REPORTED message (not /report command) - for dismiss only


### PR DESCRIPTION
Closes #127

## Summary

- Extract interfaces from 5 concrete service implementations to improve testability
- Rename `ClamAVHealthResult` to `FileScannerHealthResult` for generic naming
- Add comprehensive unit, component, and E2E tests for the refactored services

## New Interfaces

| Interface | Extracted From |
|-----------|----------------|
| `IBackupRetentionService` | `BackupRetentionService` |
| `ITelegramUserManagementService` | `TelegramUserManagementService` |
| `IModerationOrchestrator` | `ModerationOrchestrator` |
| `IBlazorAuthHelper` | `BlazorAuthHelper` |
| `INotificationStateService` | `NotificationStateService` |

## New Tests

- **Unit Tests**: `BackupRetentionServiceTests`, `ReportActionsServiceTests`, `TelegramUserManagementServiceTests`, `ReportCallbackHandlerTests`
- **Component Tests**: `NotificationBellTests` (bUnit)
- **E2E Tests**: `NotificationBellTests` (Playwright - dropdown interactions)
- **Infrastructure**: `TestWebNotificationBuilder` for E2E test setup

## Test plan

- [x] All existing tests pass
- [x] New unit tests pass
- [x] New component tests pass
- [x] New E2E tests pass
- [x] Build and Test CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)