### PR TITLE
fix: FirstOrDefault without OrderBy warning and message delete exception handling

### DIFF
--- a/TelegramGroupsAdmin.Telegram/Services/BotMessageService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotMessageService.cs
@@ -251,6 +251,10 @@ public class BotMessageService : IBotMessageService
                     "Failed to mark message {MessageId} as deleted in database",
                     messageId);
             }
+
+            // Re-throw so callers know the Telegram delete failed
+            // (DB cleanup is done, but caller should log appropriately)
+            throw;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed EF Core warning about FirstOrDefault without OrderBy in MLTrainingDataRepository
- Fixed exception swallowing in BotMessageService that caused misleading success logs

## Technical Details

### Issue 1: Non-deterministic query results
```
[WRN] The query uses the 'First'/'FirstOrDefault' operator without 'OrderBy' and filter operators. This may lead to unpredictable results.
```

The GroupJoin queries in MLTrainingDataRepository used `mts.FirstOrDefault()` without ordering. When multiple translations exist for a message, which one gets returned was non-deterministic.

**Fix:** Added `OrderByDescending(t => t.TranslatedAt)` to consistently return the most recent translation.

### Issue 2: Swallowed exceptions hiding failures
BotMessageService.DeleteAndMarkMessageAsync caught exceptions, logged a warning, marked the message as deleted in DB, but did NOT re-throw. This meant callers (like MessageHandler) thought the delete succeeded and logged misleading success messages.

**Fix:** After DB cleanup, re-throw the exception so callers can log appropriately.

## Test plan
- [x] Build passes
- [ ] No more FirstOrDefault warning in spam detection logs
- [ ] Failed message deletes now show failure instead of success in logs

---
Generated with [Claude Code](https://claude.com/code)