### PR TITLE
refactor: downgrade routine logging from Info to Debug

### DIFF
--- a/TelegramGroupsAdmin.ContentDetection/Services/ContentDetectionEngineV2.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/ContentDetectionEngineV2.cs
@@ -151,7 +151,7 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
                 var activePrompt = await _promptVersionRepo.GetActiveVersionAsync(request.ChatId, cancellationToken);
                 var systemPrompt = activePrompt?.PromptText;
 
-                _logger.LogInformation("Running AI veto check for {User} (custom prompt: {HasCustom})",
+                _logger.LogDebug("Running AI veto check for {User} (custom prompt: {HasCustom})",
                     request.UserName ?? $"User {request.UserId}", systemPrompt != null);
 
                 var vetoRequest = request with { HasSpamFlags = true };
@@ -194,7 +194,7 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
                 }
 
                 // AI confirmed spam - add score to total
-                _logger.LogInformation("AI confirmed spam for {User} with score {Score}",
+                _logger.LogDebug("AI confirmed spam for {User} with score {Score}",
                     request.UserName ?? $"User {request.UserId}", vetoResultV2.Score);
 
                 var newTotalScore = (pipelineResult.NetConfidence / 20.0) + vetoResultV2.Score;
@@ -290,7 +290,7 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
             VisionAnalysisText = visionAnalysisText
         };
 
-        _logger.LogInformation("V2 spam check complete: Score={TotalScore:F1}, IsSpam={IsSpam}, Action={Action}",
+        _logger.LogDebug("V2 spam check complete: Score={TotalScore:F1}, IsSpam={IsSpam}, Action={Action}",
             totalScore, result.IsSpam, result.RecommendedAction);
 
         return result;

--- a/TelegramGroupsAdmin.Telegram/Handlers/ContentDetectionOrchestrator.cs
+++ b/TelegramGroupsAdmin.Telegram/Handlers/ContentDetectionOrchestrator.cs
@@ -51,7 +51,7 @@ public class ContentDetectionOrchestrator
     {
         try
         {
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Starting content detection for message {MessageId} from user {UserId} (@{Username}) in chat {ChatId} (hasText: {HasText}, hasPhoto: {HasPhoto}, edit: {EditVersion})",
                 message.MessageId,
                 message.From?.Id,

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
@@ -186,11 +186,11 @@ public partial class MessageProcessingService(
 
         if (ServiceMessageHelper.IsServiceMessage(message, deletionConfig, out var shouldDelete))
         {
-            logger.LogInformation(
+            logger.LogDebug(
                 "Detected service message: Type={Type}, MessageId={MessageId}, Chat={Chat}",
                 message.Type,
                 message.MessageId,
-                message.Chat.ToLogInfo());
+                message.Chat.ToLogDebug());
 
             // Store service message for UI consistency with Telegram Desktop
             var serviceMessageText = ServiceMessageHelper.GetServiceMessageText(message);

--- a/TelegramGroupsAdmin.Telegram/Services/ContentCheckCoordinator.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ContentCheckCoordinator.cs
@@ -40,7 +40,7 @@ public class ContentCheckCoordinator : IContentCheckCoordinator
         // on first message before user record is created
         if (TelegramConstants.IsSystemUser(request.UserId))
         {
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Skipping all content detection for Telegram system account ({User}) in {Chat}",
                 request.UserName,
                 request.ChatName);
@@ -73,7 +73,7 @@ public class ContentCheckCoordinator : IContentCheckCoordinator
         // Check if user is a chat admin
         isUserAdmin = await chatAdminsRepository.IsAdminAsync(request.ChatId, request.UserId, cancellationToken);
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "{User} status in {Chat}: Trusted={Trusted}, Admin={Admin}",
             request.UserName,
             request.ChatName,
@@ -84,7 +84,7 @@ public class ContentCheckCoordinator : IContentCheckCoordinator
         // Phase 1: Get list of critical checks (always_run=true) using optimized JSONB query
         var criticalCheckNames = await configService.GetCriticalCheckNamesAsync(request.ChatId, cancellationToken);
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "{Chat} has {Count} critical (always_run) checks configured: {Checks}",
             request.ChatName,
             criticalCheckNames.Count,
@@ -99,7 +99,7 @@ public class ContentCheckCoordinator : IContentCheckCoordinator
                 ? "User is trusted and no critical checks configured"
                 : "User is admin and no critical checks configured";
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Skipping all spam detection for {User} in {Chat}: {Reason}",
                 request.UserName,
                 request.ChatName,
@@ -123,7 +123,7 @@ public class ContentCheckCoordinator : IContentCheckCoordinator
                 ? "untrusted/non-admin user"
                 : "standard user";
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Running full spam detection pipeline for {User} in {Chat}: {Reason}",
             request.UserName,
             request.ChatName,
@@ -171,7 +171,7 @@ public class ContentCheckCoordinator : IContentCheckCoordinator
                 ? "User is trusted - regular spam detection bypassed (critical checks passed)"
                 : "User is a chat admin - regular spam detection bypassed (critical checks passed)";
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "✓ Critical checks passed, skipping regular spam detection for {User} in {Chat}: {Reason}",
                 request.UserName,
                 request.ChatName,

--- a/TelegramGroupsAdmin.Telegram/Services/TelegramPhotoService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/TelegramPhotoService.cs
@@ -68,8 +68,8 @@ public class TelegramPhotoService
 
             if (chat.Photo == null)
             {
-                _logger.LogInformation("Chat {Chat} has no profile photo - skipping icon cache",
-                    LogDisplayName.ChatInfo(chatName, chatId));
+                _logger.LogDebug("Chat {Chat} has no profile photo - skipping icon cache",
+                    LogDisplayName.ChatDebug(chatName, chatId));
                 return null;
             }
 
@@ -94,8 +94,8 @@ public class TelegramPhotoService
                 // Resize to 64x64 icon
                 await ResizeImageAsync(tempPath, localPath, 64, cancellationToken);
 
-                _logger.LogInformation("Cached chat icon for {Chat}",
-                    LogDisplayName.ChatInfo(chatName, chatId));
+                _logger.LogDebug("Cached chat icon for {Chat}",
+                    LogDisplayName.ChatDebug(chatName, chatId));
                 return relativePath;
             }
             finally
@@ -210,7 +210,7 @@ public class TelegramPhotoService
                 // Resize to 64x64 icon
                 await ResizeImageAsync(tempPath, localPath, 64, cancellationToken);
 
-                _logger.LogInformation("Cached user photo for {User}: {Path}", user.ToLogInfo(userId), relativePath);
+                _logger.LogDebug("Cached user photo for {User}: {Path}", user.ToLogDebug(userId), relativePath);
                 return new UserPhotoResult(relativePath, currentPhotoId);
             }
             finally

--- a/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
@@ -184,9 +184,9 @@ public class WelcomeService : IWelcomeService
                 );
                 await telegramUserRepo.UpsertAsync(newUser, cancellationToken);
 
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "Created inactive user record for {User} on join",
-                    user.ToLogInfo());
+                    user.ToLogDebug());
             }
 
             // Step 2: Check for impersonation (name + photo similarity vs admins)
@@ -311,10 +311,10 @@ public class WelcomeService : IWelcomeService
             // Store the job ID in the welcome response record
             await WithRepositoryAsync((repo, cancellationToken) => repo.SetTimeoutJobIdAsync(responseId, jobId, cancellationToken), cancellationToken);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Successfully scheduled welcome timeout for {User} in {Chat} (mode: {Mode}, timeout: {Timeout}s, JobId: {JobId})",
-                user.ToLogInfo(),
-                chatMemberUpdate.Chat.ToLogInfo(),
+                user.ToLogDebug(),
+                chatMemberUpdate.Chat.ToLogDebug(),
                 config.Mode,
                 config.TimeoutSeconds,
                 jobId);
@@ -357,11 +357,11 @@ public class WelcomeService : IWelcomeService
             return;
         }
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Callback query received: {Data} from {User} in {Chat}",
             data,
-            user.ToLogInfo(),
-            message.Chat.ToLogInfo());
+            user.ToLogDebug(),
+            message.Chat.ToLogDebug());
 
         // Use extracted parser for callback data
         var parsedCallback = WelcomeCallbackParser.ParseCallbackData(data);
@@ -484,10 +484,10 @@ public class WelcomeService : IWelcomeService
         Message message,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Exam callback received: {Data} from {User}",
             data,
-            user.ToLogInfo());
+            user.ToLogDebug());
 
         try
         {
@@ -581,29 +581,29 @@ public class WelcomeService : IWelcomeService
             var botInfo = await operations.GetMeAsync(cancellationToken);
             keyboard = WelcomeKeyboardBuilder.BuildDmModeKeyboard(config, chatId, user.Id, botInfo.Username!);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Sending DM welcome message to {User} in {Chat}",
-                user.ToLogInfo(),
-                chatInfo.ToLogInfo());
+                user.ToLogDebug(),
+                chatInfo.ToLogDebug());
         }
         else if (config.Mode == WelcomeMode.EntranceExam)
         {
             var botInfo = await operations.GetMeAsync(cancellationToken);
             keyboard = WelcomeKeyboardBuilder.BuildExamModeKeyboard(config, chatId, user.Id, botInfo.Username!);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Sending entrance exam teaser to {User} in {Chat}",
-                user.ToLogInfo(),
-                chatInfo.ToLogInfo());
+                user.ToLogDebug(),
+                chatInfo.ToLogDebug());
         }
         else
         {
             keyboard = WelcomeKeyboardBuilder.BuildChatModeKeyboard(config, user.Id);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Sending chat accept/deny welcome message to {User} in {Chat}",
-                user.ToLogInfo(),
-                chatInfo.ToLogInfo());
+                user.ToLogDebug(),
+                chatInfo.ToLogDebug());
         }
 
         var message = await operations.SendMessageAsync(
@@ -629,10 +629,10 @@ public class WelcomeService : IWelcomeService
                 permissions: WelcomeChatPermissions.Restricted,
                 cancellationToken: cancellationToken);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Restricted permissions for {User} in {Chat}",
-                user.ToLogInfo(),
-                chat.ToLogInfo());
+                user.ToLogDebug(),
+                chat.ToLogDebug());
         }
         catch (Exception ex)
         {
@@ -657,10 +657,10 @@ public class WelcomeService : IWelcomeService
             await operations.BanChatMemberAsync(chatId: chat.Id, userId: user.Id, cancellationToken: cancellationToken);
             await operations.UnbanChatMemberAsync(chatId: chat.Id, userId: user.Id, cancellationToken: cancellationToken);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Kicked {User} from {Chat}",
-                user.ToLogInfo(),
-                chat.ToLogInfo());
+                user.ToLogDebug(),
+                chat.ToLogDebug());
         }
         catch (Exception ex)
         {
@@ -703,9 +703,9 @@ public class WelcomeService : IWelcomeService
         // Always attempt this - previous DM sent via /start may have been deleted by user
         var (dmSent, dmFallback) = await SendRulesAsync(operations, chat, user, config, cancellationToken);
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Rules delivery for {User}: DM sent: {DmSent}, Fallback: {DmFallback}",
-            user.ToLogInfo(),
+            user.ToLogDebug(),
             dmSent,
             dmFallback);
 
@@ -934,10 +934,10 @@ public class WelcomeService : IWelcomeService
                 messageId: welcomeResponse.WelcomeMessageId,
                 cancellationToken: cancellationToken);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Deleted welcome message {MessageId} in {Chat}",
                 welcomeResponse.WelcomeMessageId,
-                groupChat.ToLogInfo());
+                groupChat.ToLogDebug());
         }
         catch (Exception ex)
         {
@@ -987,9 +987,9 @@ public class WelcomeService : IWelcomeService
             {
                 keyboard = WelcomeKeyboardBuilder.BuildReturnToChatKeyboard(chatName, chatDeepLink);
 
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "Sent confirmation with chat deep link to {User}: {DeepLink}",
-                    user.ToLogInfo(),
+                    user.ToLogDebug(),
                     chatDeepLink);
             }
 
@@ -1030,9 +1030,9 @@ public class WelcomeService : IWelcomeService
             autoDeleteSeconds: 30,
             cancellationToken: cancellationToken);
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Rules sent to {User}: DmSent={DmSent}, FallbackUsed={FallbackUsed}",
-            user.ToLogInfo(),
+            user.ToLogDebug(),
             result.DmSent,
             result.FallbackUsed);
 
@@ -1041,10 +1041,10 @@ public class WelcomeService : IWelcomeService
 
     private async Task HandleUserLeftAsync(Chat chat, User user, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation(
+        _logger.LogDebug(
             "{User} left {Chat}, recording welcome response if pending",
-            user.ToLogInfo(),
-            chat.ToLogInfo());
+            user.ToLogDebug(),
+            chat.ToLogDebug());
 
         try
         {
@@ -1054,10 +1054,10 @@ public class WelcomeService : IWelcomeService
             if (await examFlowService.HasActiveSessionAsync(chat.Id, user.Id, cancellationToken))
             {
                 await examFlowService.CancelSessionAsync(chat.Id, user.Id, cancellationToken);
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "Cancelled exam session for {User} who left {Chat}",
-                    user.ToLogInfo(),
-                    chat.ToLogInfo());
+                    user.ToLogDebug(),
+                    chat.ToLogDebug());
             }
 
             // Find any pending welcome response for this user
@@ -1084,10 +1084,10 @@ public class WelcomeService : IWelcomeService
             // Mark as left
             await WithRepositoryAsync((repo, cancellationToken) => repo.UpdateResponseAsync(response.Id, WelcomeResponseType.Left, dmSent: false, dmFallback: false, cancellationToken), cancellationToken);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Recorded welcome response 'left' for {User} in {Chat}",
-                user.ToLogInfo(),
-                chat.ToLogInfo());
+                user.ToLogDebug(),
+                chat.ToLogDebug());
         }
         catch (Exception ex)
         {

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Services/Backup/BackupFileInfoTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Services/Backup/BackupFileInfoTests.cs
@@ -1,0 +1,98 @@
+using TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
+
+namespace TelegramGroupsAdmin.UnitTests.BackgroundJobs.Services.Backup;
+
+[TestFixture]
+public class BackupFileInfoTests
+{
+    [Test]
+    public void ParseTimestampFromFilename_ValidFilename_ReturnsCorrectTimestamp()
+    {
+        var result = BackupFileInfo.ParseTimestampFromFilename("/data/backups/backup_2026-01-27_14-30-45.tar.gz");
+
+        Assert.That(result.Year, Is.EqualTo(2026));
+        Assert.That(result.Month, Is.EqualTo(1));
+        Assert.That(result.Day, Is.EqualTo(27));
+        Assert.That(result.Hour, Is.EqualTo(14));
+        Assert.That(result.Minute, Is.EqualTo(30));
+        Assert.That(result.Second, Is.EqualTo(45));
+        Assert.That(result.Offset, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void ParseTimestampFromFilename_FilenameOnly_ReturnsCorrectTimestamp()
+    {
+        // Uses a temp file so the fallback path doesn't crash on missing file
+        var tempFile = Path.GetTempFileName();
+        var renamedPath = Path.Combine(Path.GetDirectoryName(tempFile)!, "backup_2025-12-31_23-59-59.tar.gz");
+        File.Move(tempFile, renamedPath);
+
+        try
+        {
+            var result = BackupFileInfo.ParseTimestampFromFilename(renamedPath);
+
+            Assert.That(result.Year, Is.EqualTo(2025));
+            Assert.That(result.Month, Is.EqualTo(12));
+            Assert.That(result.Day, Is.EqualTo(31));
+            Assert.That(result.Hour, Is.EqualTo(23));
+            Assert.That(result.Minute, Is.EqualTo(59));
+            Assert.That(result.Second, Is.EqualTo(59));
+        }
+        finally
+        {
+            File.Delete(renamedPath);
+        }
+    }
+
+    [Test]
+    public void ParseTimestampFromFilename_LeapYearDate_ParsesCorrectly()
+    {
+        var result = BackupFileInfo.ParseTimestampFromFilename("/data/backups/backup_2024-02-29_12-00-00.tar.gz");
+
+        Assert.That(result.Year, Is.EqualTo(2024));
+        Assert.That(result.Month, Is.EqualTo(2));
+        Assert.That(result.Day, Is.EqualTo(29));
+    }
+
+    [Test]
+    public void ParseTimestampFromFilename_InvalidFilename_FallsBackToFileTime()
+    {
+        // Create a real temp file with a non-matching name so the fallback reads modification time
+        var tempFile = Path.GetTempFileName();
+        var renamedPath = Path.Combine(Path.GetDirectoryName(tempFile)!, "not-a-backup.tar.gz");
+        File.Move(tempFile, renamedPath);
+
+        try
+        {
+            var result = BackupFileInfo.ParseTimestampFromFilename(renamedPath);
+
+            // Should return the file's last write time (just created, so recent)
+            Assert.That(result, Is.EqualTo(new DateTimeOffset(File.GetLastWriteTimeUtc(renamedPath), TimeSpan.Zero))
+                .Within(TimeSpan.FromSeconds(2)));
+        }
+        finally
+        {
+            File.Delete(renamedPath);
+        }
+    }
+
+    [Test]
+    public void ParseTimestampFromFilename_ShortFilename_FallsBackToFileTime()
+    {
+        var tempFile = Path.GetTempFileName();
+        var renamedPath = Path.Combine(Path.GetDirectoryName(tempFile)!, "short.tar.gz");
+        File.Move(tempFile, renamedPath);
+
+        try
+        {
+            var result = BackupFileInfo.ParseTimestampFromFilename(renamedPath);
+
+            Assert.That(result, Is.EqualTo(new DateTimeOffset(File.GetLastWriteTimeUtc(renamedPath), TimeSpan.Zero))
+                .Within(TimeSpan.FromSeconds(2)));
+        }
+        finally
+        {
+            File.Delete(renamedPath);
+        }
+    }
+}


### PR DESCRIPTION
Closes #306

## Summary
- Downgrades 30 `LogInformation` → `LogDebug` calls across 6 services following the CAS "gold standard" pattern: Debug for routine operations, Info only for noteworthy events (actions taken, anomalies, meaningful outcomes)
- Switches `ToLogInfo()` → `ToLogDebug()` on downgraded lines so Debug logs use the ID-rich format for better troubleshooting
- Estimated ~70-80% reduction in Info-level console noise during normal operation

### Files changed
| File | Downgrades | Rationale |
|------|-----------|-----------|
| `ContentCheckCoordinator.cs` | 6 | Per-message pipeline logs (trust check, config lookup, skip/run decisions) |
| `ContentDetectionOrchestrator.cs` | 1 | Pipeline entry log |
| `ContentDetectionEngineV2.cs` | 3 | Routine check results (keeps AI veto override at Info) |
| `WelcomeService.cs` | 16 | Delivery mechanics, DB bookkeeping, UI cleanup |
| `TelegramPhotoService.cs` | 3 | Routine caching operations |
| `MessageProcessingService.cs` | 1 | Service message detection |

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] Code review — no issues found
- [ ] CI build and test pass
- [x] Verify Seq still receives Debug-level logs for troubleshooting

🤖 Generated with [Claude Code](https://claude.com/claude-code)