### PR TITLE
fix: align report callback actions, thread identities, and fix FK violation

### DIFF
--- a/TelegramGroupsAdmin.ComponentTests/Components/ExamReviewCardTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/ExamReviewCardTests.cs
@@ -11,6 +11,7 @@ using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.Configuration.Models.Welcome;
 using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Constants;
 using TelegramGroupsAdmin.Telegram.Repositories;
 
 namespace TelegramGroupsAdmin.ComponentTests.Components;
@@ -144,10 +145,8 @@ public class ExamReviewCardTests : ExamReviewCardTestContext
             ReviewedBy = reviewedBy,
             ReviewedAt = reviewedAt,
             ActionTaken = actionTaken,
-            UserName = userName,
-            UserFirstName = userFirstName,
-            UserLastName = userLastName,
-            ChatName = chatName
+            User = new UserIdentity(userId, userFirstName, userLastName, userName),
+            Chat = new ChatIdentity(chatId, chatName)
         };
     }
 
@@ -467,12 +466,12 @@ public class ExamReviewCardTests : ExamReviewCardTestContext
     public async Task InvokesOnAction_WhenApproveClicked()
     {
         // Arrange
-        (ExamFailureRecord failure, string action)? receivedAction = null;
+        (ExamFailureRecord failure, ExamAction action)? receivedAction = null;
         var failure = CreateExamFailure(reviewedAt: null);
 
         var cut = Render<ExamReviewCard>(p => p
             .Add(x => x.ExamFailure, failure)
-            .Add(x => x.OnAction, EventCallback.Factory.Create<(ExamFailureRecord, string)>(
+            .Add(x => x.OnAction, EventCallback.Factory.Create<(ExamFailureRecord, ExamAction)>(
                 this, args => receivedAction = args)));
 
         // Act
@@ -481,7 +480,7 @@ public class ExamReviewCardTests : ExamReviewCardTestContext
 
         // Assert
         Assert.That(receivedAction, Is.Not.Null);
-        Assert.That(receivedAction!.Value.action, Is.EqualTo("approve"));
+        Assert.That(receivedAction!.Value.action, Is.EqualTo(ExamAction.Approve));
         Assert.That(receivedAction!.Value.failure.Id, Is.EqualTo(failure.Id));
     }
 
@@ -489,12 +488,12 @@ public class ExamReviewCardTests : ExamReviewCardTestContext
     public async Task InvokesOnAction_WhenDenyClicked()
     {
         // Arrange
-        (ExamFailureRecord failure, string action)? receivedAction = null;
+        (ExamFailureRecord failure, ExamAction action)? receivedAction = null;
         var failure = CreateExamFailure(reviewedAt: null);
 
         var cut = Render<ExamReviewCard>(p => p
             .Add(x => x.ExamFailure, failure)
-            .Add(x => x.OnAction, EventCallback.Factory.Create<(ExamFailureRecord, string)>(
+            .Add(x => x.OnAction, EventCallback.Factory.Create<(ExamFailureRecord, ExamAction)>(
                 this, args => receivedAction = args)));
 
         // Act
@@ -504,19 +503,19 @@ public class ExamReviewCardTests : ExamReviewCardTestContext
 
         // Assert
         Assert.That(receivedAction, Is.Not.Null);
-        Assert.That(receivedAction!.Value.action, Is.EqualTo("deny"));
+        Assert.That(receivedAction!.Value.action, Is.EqualTo(ExamAction.Deny));
     }
 
     [Test]
     public async Task InvokesOnAction_WhenDenyAndBanClicked()
     {
         // Arrange
-        (ExamFailureRecord failure, string action)? receivedAction = null;
+        (ExamFailureRecord failure, ExamAction action)? receivedAction = null;
         var failure = CreateExamFailure(reviewedAt: null);
 
         var cut = Render<ExamReviewCard>(p => p
             .Add(x => x.ExamFailure, failure)
-            .Add(x => x.OnAction, EventCallback.Factory.Create<(ExamFailureRecord, string)>(
+            .Add(x => x.OnAction, EventCallback.Factory.Create<(ExamFailureRecord, ExamAction)>(
                 this, args => receivedAction = args)));
 
         // Act
@@ -525,7 +524,7 @@ public class ExamReviewCardTests : ExamReviewCardTestContext
 
         // Assert
         Assert.That(receivedAction, Is.Not.Null);
-        Assert.That(receivedAction!.Value.action, Is.EqualTo("deny_ban"));
+        Assert.That(receivedAction!.Value.action, Is.EqualTo(ExamAction.DenyAndBan));
     }
 
     #endregion

--- a/TelegramGroupsAdmin.ComponentTests/Components/ImpersonationAlertCardTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/ImpersonationAlertCardTests.cs
@@ -8,6 +8,7 @@ using TelegramGroupsAdmin.ContentDetection.Models;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Constants;
 using TelegramGroupsAdmin.Telegram.Repositories;
 
 namespace TelegramGroupsAdmin.ComponentTests.Components;
@@ -302,9 +303,9 @@ public class ImpersonationAlertCardTests : ImpersonationAlertCardTestContext
         var cut = Render<ImpersonationAlertCard>(p => p
             .Add(x => x.Alert, CreateAlert(reviewedAt: null)));
 
-        // Assert - Component shows: Confirm Scam, False Positive, Trust
-        Assert.That(cut.Markup, Does.Contain("Confirm Scam"));
-        Assert.That(cut.Markup, Does.Contain("False Positive"));
+        // Assert - Component shows: Confirm, Dismiss, Trust
+        Assert.That(cut.Markup, Does.Contain("Confirm"));
+        Assert.That(cut.Markup, Does.Contain("Dismiss"));
         Assert.That(cut.Markup, Does.Contain("Trust"));
     }
 
@@ -319,8 +320,8 @@ public class ImpersonationAlertCardTests : ImpersonationAlertCardTestContext
                 verdict: ImpersonationVerdict.ConfirmedScam)));
 
         // Assert - Action buttons hidden when already reviewed
-        Assert.That(cut.Markup, Does.Not.Contain("Confirm Scam"));
-        Assert.That(cut.Markup, Does.Not.Contain(">False Positive<")); // Not in button form
+        Assert.That(cut.Markup, Does.Not.Contain(">Confirm<")); // Not in button form
+        Assert.That(cut.Markup, Does.Not.Contain(">Dismiss<")); // Not in button form
         Assert.That(cut.Markup, Does.Not.Contain(">Trust<")); // Not in button form
     }
 
@@ -359,24 +360,24 @@ public class ImpersonationAlertCardTests : ImpersonationAlertCardTestContext
     #region Event Callback Tests
 
     [Test]
-    public async Task InvokesOnAction_WhenConfirmScamClicked()
+    public async Task InvokesOnAction_WhenConfirmClicked()
     {
         // Arrange
-        (ImpersonationAlertRecord alert, string action)? receivedAction = null;
+        (ImpersonationAlertRecord alert, ImpersonationAction action)? receivedAction = null;
         var alert = CreateAlert(reviewedAt: null);
 
         var cut = Render<ImpersonationAlertCard>(p => p
             .Add(x => x.Alert, alert)
-            .Add(x => x.OnAction, EventCallback.Factory.Create<(ImpersonationAlertRecord, string)>(
+            .Add(x => x.OnAction, EventCallback.Factory.Create<(ImpersonationAlertRecord, ImpersonationAction)>(
                 this, args => receivedAction = args)));
 
         // Act
-        var confirmButton = cut.FindAll("button").First(b => b.TextContent.Contains("Confirm Scam"));
+        var confirmButton = cut.FindAll("button").First(b => b.TextContent.Contains("Confirm"));
         await confirmButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
 
         // Assert
         Assert.That(receivedAction, Is.Not.Null);
-        Assert.That(receivedAction!.Value.action, Is.EqualTo("confirm"));
+        Assert.That(receivedAction!.Value.action, Is.EqualTo(ImpersonationAction.Confirm));
         Assert.That(receivedAction!.Value.alert.Id, Is.EqualTo(alert.Id));
     }
 
@@ -384,12 +385,12 @@ public class ImpersonationAlertCardTests : ImpersonationAlertCardTestContext
     public async Task InvokesOnAction_WhenTrustClicked()
     {
         // Arrange
-        (ImpersonationAlertRecord alert, string action)? receivedAction = null;
+        (ImpersonationAlertRecord alert, ImpersonationAction action)? receivedAction = null;
         var alert = CreateAlert(reviewedAt: null);
 
         var cut = Render<ImpersonationAlertCard>(p => p
             .Add(x => x.Alert, alert)
-            .Add(x => x.OnAction, EventCallback.Factory.Create<(ImpersonationAlertRecord, string)>(
+            .Add(x => x.OnAction, EventCallback.Factory.Create<(ImpersonationAlertRecord, ImpersonationAction)>(
                 this, args => receivedAction = args)));
 
         // Act
@@ -398,28 +399,28 @@ public class ImpersonationAlertCardTests : ImpersonationAlertCardTestContext
 
         // Assert
         Assert.That(receivedAction, Is.Not.Null);
-        Assert.That(receivedAction!.Value.action, Is.EqualTo("trust"));
+        Assert.That(receivedAction!.Value.action, Is.EqualTo(ImpersonationAction.Trust));
     }
 
     [Test]
-    public async Task InvokesOnAction_WhenFalsePositiveClicked()
+    public async Task InvokesOnAction_WhenDismissClicked()
     {
         // Arrange
-        (ImpersonationAlertRecord alert, string action)? receivedAction = null;
+        (ImpersonationAlertRecord alert, ImpersonationAction action)? receivedAction = null;
         var alert = CreateAlert(reviewedAt: null);
 
         var cut = Render<ImpersonationAlertCard>(p => p
             .Add(x => x.Alert, alert)
-            .Add(x => x.OnAction, EventCallback.Factory.Create<(ImpersonationAlertRecord, string)>(
+            .Add(x => x.OnAction, EventCallback.Factory.Create<(ImpersonationAlertRecord, ImpersonationAction)>(
                 this, args => receivedAction = args)));
 
         // Act
-        var falsePositiveButton = cut.FindAll("button").First(b => b.TextContent.Contains("False Positive"));
-        await falsePositiveButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
+        var dismissButton = cut.FindAll("button").First(b => b.TextContent.Contains("Dismiss"));
+        await dismissButton.ClickAsync(new Microsoft.AspNetCore.Components.Web.MouseEventArgs());
 
         // Assert
         Assert.That(receivedAction, Is.Not.Null);
-        Assert.That(receivedAction!.Value.action, Is.EqualTo("dismiss"));
+        Assert.That(receivedAction!.Value.action, Is.EqualTo(ImpersonationAction.Dismiss));
     }
 
     #endregion

--- a/TelegramGroupsAdmin.ComponentTests/Components/ModerationReportCardTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/ModerationReportCardTests.cs
@@ -10,6 +10,7 @@ using TelegramGroupsAdmin.Core.Models;
 using TelegramModels = TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Constants;
 using TelegramGroupsAdmin.Telegram.Repositories;
 
 namespace TelegramGroupsAdmin.ComponentTests.Components;
@@ -571,7 +572,7 @@ public class ModerationReportCardTests : ModerationReportCardTestContext
     public async Task InvokesOnAction_WhenSpamButtonClicked()
     {
         // Arrange
-        (Report report, string action)? receivedAction = null;
+        (Report report, ReportAction action)? receivedAction = null;
         var report = CreateReport(status: ReportStatus.Pending);
         var message = CreateSpamMessage();
 
@@ -582,7 +583,7 @@ public class ModerationReportCardTests : ModerationReportCardTestContext
 
         var cut = Render<ModerationReportCard>(p => p
             .Add(x => x.Report, report)
-            .Add(x => x.OnAction, EventCallback.Factory.Create<(Report, string)>(
+            .Add(x => x.OnAction, EventCallback.Factory.Create<(Report, ReportAction)>(
                 this, args => receivedAction = args)));
 
         // Wait for component to load before finding button
@@ -594,7 +595,7 @@ public class ModerationReportCardTests : ModerationReportCardTestContext
 
         // Assert
         Assert.That(receivedAction, Is.Not.Null);
-        Assert.That(receivedAction!.Value.action, Is.EqualTo("spam"));
+        Assert.That(receivedAction!.Value.action, Is.EqualTo(ReportAction.Spam));
         Assert.That(receivedAction!.Value.report.Id, Is.EqualTo(report.Id));
     }
 
@@ -602,7 +603,7 @@ public class ModerationReportCardTests : ModerationReportCardTestContext
     public async Task InvokesOnAction_WhenDismissButtonClicked()
     {
         // Arrange
-        (Report report, string action)? receivedAction = null;
+        (Report report, ReportAction action)? receivedAction = null;
         var report = CreateReport(status: ReportStatus.Pending);
         var message = CreateSpamMessage();
 
@@ -613,7 +614,7 @@ public class ModerationReportCardTests : ModerationReportCardTestContext
 
         var cut = Render<ModerationReportCard>(p => p
             .Add(x => x.Report, report)
-            .Add(x => x.OnAction, EventCallback.Factory.Create<(Report, string)>(
+            .Add(x => x.OnAction, EventCallback.Factory.Create<(Report, ReportAction)>(
                 this, args => receivedAction = args)));
 
         // Wait for component to load before finding button
@@ -625,7 +626,7 @@ public class ModerationReportCardTests : ModerationReportCardTestContext
 
         // Assert
         Assert.That(receivedAction, Is.Not.Null);
-        Assert.That(receivedAction!.Value.action, Is.EqualTo("dismiss"));
+        Assert.That(receivedAction!.Value.action, Is.EqualTo(ReportAction.Dismiss));
     }
 
     #endregion

--- a/TelegramGroupsAdmin.Core/Models/ExamFailureRecord.cs
+++ b/TelegramGroupsAdmin.Core/Models/ExamFailureRecord.cs
@@ -56,10 +56,8 @@ public record ExamFailureRecord
     public string? ActionTaken { get; init; }
     public string? AdminNotes { get; init; }
 
-    // Denormalized for display (joined data)
-    public string? UserName { get; init; }
-    public string? UserFirstName { get; init; }
-    public string? UserLastName { get; init; }
+    // Identity objects (populated from view joins on read path)
+    public required UserIdentity User { get; init; }
+    public required ChatIdentity Chat { get; init; }
     public string? UserPhotoPath { get; init; }
-    public string? ChatName { get; init; }
 }

--- a/TelegramGroupsAdmin.Core/Repositories/Mappings/EnrichedReportMappings.cs
+++ b/TelegramGroupsAdmin.Core/Repositories/Mappings/EnrichedReportMappings.cs
@@ -114,11 +114,9 @@ internal static class EnrichedReportMappings
             AiEvaluation = examContext.AiEvaluation,
 
             // From view joins (no more N+1!)
-            UserName = view.ExamUsername,
-            UserFirstName = view.ExamFirstName,
-            UserLastName = view.ExamLastName,
-            UserPhotoPath = view.ExamPhotoPath,
-            ChatName = view.ChatName
+            User = new UserIdentity(examContext.UserId, view.ExamFirstName, view.ExamLastName, view.ExamUsername),
+            Chat = new ChatIdentity(view.ChatId, view.ChatName),
+            UserPhotoPath = view.ExamPhotoPath
         };
     }
 

--- a/TelegramGroupsAdmin.E2ETests/Infrastructure/TestExamFailureBuilder.cs
+++ b/TelegramGroupsAdmin.E2ETests/Infrastructure/TestExamFailureBuilder.cs
@@ -247,12 +247,10 @@ public class TestExamFailureBuilder
             ReviewedAt = _reviewedAt,
             ActionTaken = _actionTaken,
             AdminNotes = _adminNotes,
-            // Denormalized display fields
-            UserName = _userName,
-            UserFirstName = _userFirstName,
-            UserLastName = _userLastName,
-            UserPhotoPath = _userPhotoPath,
-            ChatName = _chatName
+            // Identity objects
+            User = new UserIdentity(_userId, _userFirstName, _userLastName, _userName),
+            Chat = new ChatIdentity(_chatId, _chatName),
+            UserPhotoPath = _userPhotoPath
         };
 
         var id = await reportsRepository.InsertExamFailureAsync(examFailure, cancellationToken);

--- a/TelegramGroupsAdmin.E2ETests/Infrastructure/TestImpersonationAlertBuilder.cs
+++ b/TelegramGroupsAdmin.E2ETests/Infrastructure/TestImpersonationAlertBuilder.cs
@@ -192,9 +192,9 @@ public class TestImpersonationAlertBuilder
     }
 
     /// <summary>
-    /// Marks as false positive.
+    /// Marks as dismissed.
     /// </summary>
-    public TestImpersonationAlertBuilder AsFalsePositive(string reviewedByUserId)
+    public TestImpersonationAlertBuilder AsDismissed(string reviewedByUserId)
     {
         return AsReviewed(reviewedByUserId, ImpersonationVerdict.FalsePositive);
     }

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/ReportsPage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/ReportsPage.cs
@@ -439,9 +439,9 @@ public class ReportsPage
     }
 
     /// <summary>
-    /// Clicks the "Dismiss" button on a moderation report card.
+    /// Clicks the "Dismiss" button on a report card.
     /// This is a NO-CONFIRMATION action that immediately dismisses the report.
-    /// Note: For impersonation alerts, use ClickFalsePositiveAsync instead.
+    /// Works for both moderation reports and impersonation alerts.
     /// </summary>
     public async Task ClickDismissAsync()
     {
@@ -454,26 +454,12 @@ public class ReportsPage
     }
 
     /// <summary>
-    /// Clicks the "Confirm Scam" button on an impersonation alert card.
+    /// Clicks the "Confirm" button on an impersonation alert card.
     /// This is a NO-CONFIRMATION action.
     /// </summary>
-    public async Task ClickConfirmScamAsync()
+    public async Task ClickConfirmAsync()
     {
-        var button = _page.Locator("button:has-text('Confirm Scam')").First;
-
-        // Wait for Blazor SignalR circuit to be fully established before clicking
-        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
-        await button.ClickAsync();
-    }
-
-    /// <summary>
-    /// Clicks the "False Positive" button on an impersonation alert card.
-    /// This is a NO-CONFIRMATION action that dismisses the alert.
-    /// </summary>
-    public async Task ClickFalsePositiveAsync()
-    {
-        var button = _page.Locator("button:has-text('False Positive')").First;
+        var button = _page.Locator("button:has-text('Confirm')").First;
 
         // Wait for Blazor SignalR circuit to be fully established before clicking
         await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);

--- a/TelegramGroupsAdmin.E2ETests/Tests/Reports/ReportsTests.cs
+++ b/TelegramGroupsAdmin.E2ETests/Tests/Reports/ReportsTests.cs
@@ -723,8 +723,8 @@ public class ReportsTests : SharedAuthenticatedTestBase
         // Verify alert exists
         await Expect(Page.GetByText("Impersonation Alert", new() { Exact = true })).ToBeVisibleAsync();
 
-        // Click Confirm Scam - NO CONFIRMATION DIALOG
-        await _reportsPage.ClickConfirmScamAsync();
+        // Click Confirm - NO CONFIRMATION DIALOG
+        await _reportsPage.ClickConfirmAsync();
 
         // Assert - snackbar confirms action
         var snackbarText = await _reportsPage.WaitForSnackbarAsync();
@@ -786,10 +786,10 @@ public class ReportsTests : SharedAuthenticatedTestBase
     }
 
     /// <summary>
-    /// Tests that the False Positive action on an impersonation alert executes immediately.
+    /// Tests that the Dismiss action on an impersonation alert executes immediately.
     /// </summary>
     [Test]
-    public async Task ImpersonationAlert_FalsePositive_ProcessesImmediately()
+    public async Task ImpersonationAlert_Dismiss_ProcessesImmediately()
     {
         // Arrange
         await LoginAsOwnerAsync();
@@ -827,8 +827,8 @@ public class ReportsTests : SharedAuthenticatedTestBase
         // Verify alert exists
         await Expect(Page.GetByText("Impersonation Alert", new() { Exact = true })).ToBeVisibleAsync();
 
-        // Click False Positive - NO CONFIRMATION DIALOG
-        await _reportsPage.ClickFalsePositiveAsync();
+        // Click Dismiss - NO CONFIRMATION DIALOG
+        await _reportsPage.ClickDismissAsync();
 
         // Assert - snackbar confirms action
         var snackbarText = await _reportsPage.WaitForSnackbarAsync();

--- a/TelegramGroupsAdmin.IntegrationTests/ContentDetection/Repositories/ReportsRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/ContentDetection/Repositories/ReportsRepositoryTests.cs
@@ -182,7 +182,7 @@ public class ReportsRepositoryTests
             reportId,
             ReportStatus.Dismissed,
             reviewedBy: "moderator@example.com",
-            actionTaken: "FalsePositive",
+            actionTaken: "Dismiss",
             notes: "Not spam, legitimate message");
 
         // Assert
@@ -190,7 +190,7 @@ public class ReportsRepositoryTests
         Assert.That(updated, Is.Not.Null);
         Assert.That(updated!.Status, Is.EqualTo(ReportStatus.Dismissed));
         Assert.That(updated.ReviewedBy, Is.EqualTo("moderator@example.com"));
-        Assert.That(updated.ActionTaken, Is.EqualTo("FalsePositive"));
+        Assert.That(updated.ActionTaken, Is.EqualTo("Dismiss"));
         Assert.That(updated.AdminNotes, Is.EqualTo("Not spam, legitimate message"));
         Assert.That(updated.ReviewedAt, Is.Not.Null);
         Assert.That(updated.ReviewedAt!.Value, Is.GreaterThanOrEqualTo(beforeUpdate));
@@ -384,6 +384,8 @@ public class ReportsRepositoryTests
         {
             ChatId = chatId,
             UserId = userId,
+            User = new UserIdentity(userId, "Test", "User", null),
+            Chat = new ChatIdentity(chatId, "Test Chat"),
             McAnswers = mcAnswers ?? new Dictionary<int, string>
             {
                 { 0, "A" },
@@ -658,7 +660,7 @@ public class ReportsRepositoryTests
             id,
             ReportStatus.Reviewed,
             reviewedBy: "admin@test.com",
-            actionTaken: "ConfirmScam");
+            actionTaken: "Confirm");
 
         // Act
         var hasPending = await _repository.HasPendingImpersonationAlertAsync(suspectedUserId);

--- a/TelegramGroupsAdmin.Telegram/Constants/CallbackConstants.cs
+++ b/TelegramGroupsAdmin.Telegram/Constants/CallbackConstants.cs
@@ -18,18 +18,6 @@ public static class CallbackConstants
     /// </summary>
     public const string BanCancelPrefix = "ban_cancel:";
 
-    // TODO: Remove ReportActionPrefix after 2026-02-01 (see GitHub issue #281)
-    // Legacy prefix kept temporarily for existing DM buttons that haven't expired yet.
-    // DM callback contexts expire after 7 days, so this can be removed ~2 weeks after
-    // the unified ReportCallbackHandler is deployed.
-    /// <summary>
-    /// Prefix for report moderation action callbacks (legacy, kept for existing DM buttons).
-    /// Format: rpt:{contextId}:{actionInt}
-    /// Uses compact format to stay within Telegram's 64-byte callback data limit.
-    /// New code should use ReportActionPrefix.
-    /// </summary>
-    public const string ReportActionPrefix = "rpt:";
-
     /// <summary>
     /// Prefix for unified review action callbacks.
     /// Format: rev:{contextId}:{actionInt}

--- a/TelegramGroupsAdmin.Telegram/Constants/ImpersonationAction.cs
+++ b/TelegramGroupsAdmin.Telegram/Constants/ImpersonationAction.cs
@@ -7,11 +7,11 @@ namespace TelegramGroupsAdmin.Telegram.Constants;
 public enum ImpersonationAction
 {
     /// <summary>Confirm as scammer, ban user</summary>
-    ConfirmScam = 0,
+    Confirm = 0,
 
-    /// <summary>Mark as false positive, restore permissions</summary>
-    FalsePositive = 1,
+    /// <summary>Dismiss alert as false positive, no action</summary>
+    Dismiss = 1,
 
-    /// <summary>Add user to whitelist for this target</summary>
-    Whitelist = 2
+    /// <summary>Trust user (prevents future impersonation alerts)</summary>
+    Trust = 2
 }

--- a/TelegramGroupsAdmin.Telegram/Constants/ReportAction.cs
+++ b/TelegramGroupsAdmin.Telegram/Constants/ReportAction.cs
@@ -9,11 +9,11 @@ public enum ReportAction
     /// <summary>Mark as spam, delete message, ban user</summary>
     Spam = 0,
 
-    /// <summary>Send warning to user, mark report reviewed</summary>
-    Warn = 1,
+    /// <summary>Delete message and ban user (not spam-classified)</summary>
+    Ban = 1,
 
-    /// <summary>Temporarily ban user, mark report reviewed</summary>
-    TempBan = 2,
+    /// <summary>Send warning to user</summary>
+    Warn = 2,
 
     /// <summary>Dismiss report without action</summary>
     Dismiss = 3

--- a/TelegramGroupsAdmin.Telegram/Services/IExamFlowService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/IExamFlowService.cs
@@ -131,15 +131,15 @@ public interface IExamFlowService
     /// Approve an exam failure after admin review.
     /// Restores user permissions, deletes teaser message, updates welcome response.
     /// </summary>
-    /// <param name="userId">Telegram user ID</param>
-    /// <param name="chatId">Chat ID where user failed exam</param>
+    /// <param name="user">Identity of the user being approved</param>
+    /// <param name="chat">Identity of the chat where the exam was taken</param>
     /// <param name="examFailureId">ID of the exam failure record</param>
     /// <param name="executor">Actor performing the approval</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result indicating success or failure</returns>
     Task<ModerationResult> ApproveExamFailureAsync(
-        long userId,
-        long chatId,
+        UserIdentity user,
+        ChatIdentity chat,
         long examFailureId,
         Actor executor,
         CancellationToken cancellationToken = default);
@@ -148,14 +148,14 @@ public interface IExamFlowService
     /// Deny an exam failure after admin review (kick user, allow rejoin).
     /// Kicks user from chat, deletes teaser message, updates welcome response, sends notification.
     /// </summary>
-    /// <param name="userId">Telegram user ID</param>
-    /// <param name="chatId">Chat ID where user failed exam</param>
+    /// <param name="user">Identity of the user being denied</param>
+    /// <param name="chat">Identity of the chat where the exam was taken</param>
     /// <param name="executor">Actor performing the denial</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result indicating success or failure</returns>
     Task<ModerationResult> DenyExamFailureAsync(
-        long userId,
-        long chatId,
+        UserIdentity user,
+        ChatIdentity chat,
         Actor executor,
         CancellationToken cancellationToken = default);
 
@@ -163,14 +163,14 @@ public interface IExamFlowService
     /// Deny an exam failure after admin review and ban the user globally.
     /// Bans user from all managed chats, deletes teaser message, updates welcome response, sends notification.
     /// </summary>
-    /// <param name="userId">Telegram user ID</param>
-    /// <param name="chatId">Chat ID where user failed exam</param>
+    /// <param name="user">Identity of the user being denied and banned</param>
+    /// <param name="chat">Identity of the chat where the exam was taken</param>
     /// <param name="executor">Actor performing the denial</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result indicating success or failure</returns>
     Task<ModerationResult> DenyAndBanExamFailureAsync(
-        long userId,
-        long chatId,
+        UserIdentity user,
+        ChatIdentity chat,
         Actor executor,
         CancellationToken cancellationToken = default);
 }

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/UpdateRouterTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/UpdateRouterTests.cs
@@ -379,15 +379,15 @@ public class UpdateRouterTests
     public async Task RouteUpdateAsync_WithReportCallback_RoutesToReportCallbackService()
     {
         // Arrange
-        _mockReportCallbackService.CanHandle("rpt:12345:0").Returns(true);
-        var update = CreateCallbackQueryUpdate(data: "rpt:12345:0");
+        _mockReportCallbackService.CanHandle("rev:12345:0").Returns(true);
+        var update = CreateCallbackQueryUpdate(data: "rev:12345:0");
 
         // Act
         await _sut.RouteUpdateAsync(update);
 
         // Assert
         await _mockReportCallbackService.Received(1).HandleCallbackAsync(
-            Arg.Is<CallbackQuery>(q => q.Data == "rpt:12345:0"),
+            Arg.Is<CallbackQuery>(q => q.Data == "rev:12345:0"),
             Arg.Any<CancellationToken>());
     }
 
@@ -395,8 +395,8 @@ public class UpdateRouterTests
     public async Task RouteUpdateAsync_WithReportCallback_DoesNotRouteToWelcomeService()
     {
         // Arrange - report service claims the callback
-        _mockReportCallbackService.CanHandle("rpt:12345:0").Returns(true);
-        var update = CreateCallbackQueryUpdate(data: "rpt:12345:0");
+        _mockReportCallbackService.CanHandle("rev:12345:0").Returns(true);
+        var update = CreateCallbackQueryUpdate(data: "rev:12345:0");
 
         // Act
         await _sut.RouteUpdateAsync(update);

--- a/TelegramGroupsAdmin/Components/Pages/Reports.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Reports.razor
@@ -10,6 +10,7 @@
 @using TelegramGroupsAdmin.Telegram.Services.Bot
 @using TelegramGroupsAdmin.Telegram.Models
 @using TelegramGroupsAdmin.Components.Reports
+@using TelegramGroupsAdmin.Telegram.Constants
 @using TelegramGroupsAdmin.Core.Repositories
 @inject IReportsRepository ReportsRepository
 @inject IReportActionsService ReportActionsService
@@ -257,7 +258,7 @@
                     ExamFailure = examFailure,
                     DisplayTitle = "Exam Review",
                     UserId = examFailure.UserId,
-                    UserName = examFailure.UserName
+                    UserName = examFailure.User.Username
                 });
             }
 
@@ -355,35 +356,31 @@
         return (int)(200 - age); // Higher base priority than reports
     }
 
-    private async Task HandleSpamAction((Report Report, string Action) args)
+    private async Task HandleSpamAction((Report Report, ReportAction Action) args)
     {
         try
         {
             switch (args.Action)
             {
-                case "spam":
+                case ReportAction.Spam:
                     await ReportActionsService.HandleSpamActionAsync(args.Report.Id, _currentUserId);
                     Snackbar.Add($"Report #{args.Report.Id} processed: Message deleted as spam", Severity.Success);
                     break;
 
-                case "ban":
+                case ReportAction.Ban:
                     await ReportActionsService.HandleBanActionAsync(args.Report.Id, _currentUserId);
                     Snackbar.Add($"Report #{args.Report.Id} processed: User banned", Severity.Success);
                     break;
 
-                case "warn":
+                case ReportAction.Warn:
                     await ReportActionsService.HandleWarnActionAsync(args.Report.Id, _currentUserId);
                     Snackbar.Add($"Report #{args.Report.Id} processed: Warning issued", Severity.Success);
                     break;
 
-                case "dismiss":
+                case ReportAction.Dismiss:
                     await ReportActionsService.HandleDismissActionAsync(args.Report.Id, _currentUserId);
                     Snackbar.Add($"Report #{args.Report.Id} dismissed", Severity.Info);
                     break;
-
-                default:
-                    Snackbar.Add($"Unknown action: {args.Action}", Severity.Error);
-                    return;
             }
 
             await LoadReportsAsync();
@@ -395,7 +392,7 @@
         }
     }
 
-    private async Task HandleImpersonationAction((ImpersonationAlertRecord Alert, string Action) args)
+    private async Task HandleImpersonationAction((ImpersonationAlertRecord Alert, ImpersonationAction Action) args)
     {
         try
         {
@@ -403,7 +400,7 @@
 
             switch (args.Action)
             {
-                case "confirm":
+                case ImpersonationAction.Confirm:
                     // Ban the suspected impersonator globally
                     var banResult = await ModerationOrchestrator.BanUserAsync(
                         new BanIntent
@@ -417,25 +414,25 @@
                         args.Alert.Id,
                         ReportStatus.Reviewed,
                         _currentUserDisplayName,
-                        "confirm_scam",
+                        "confirm",
                         $"Confirmed impersonation, banned from {banResult.ChatsAffected} chats");
 
                     Snackbar.Add($"Impersonation confirmed: User banned from {banResult.ChatsAffected} chats", Severity.Success);
                     break;
 
-                case "dismiss":
+                case ImpersonationAction.Dismiss:
                     // Mark as false positive
                     await ReportsRepository.UpdateStatusAsync(
                         args.Alert.Id,
                         ReportStatus.Dismissed,
                         _currentUserDisplayName,
-                        "false_positive",
-                        "Marked as false positive");
+                        "dismiss",
+                        "Dismissed as false positive");
 
-                    Snackbar.Add("Alert dismissed as false positive", Severity.Info);
+                    Snackbar.Add("Alert dismissed", Severity.Info);
                     break;
 
-                case "trust":
+                case ImpersonationAction.Trust:
                     // Trust the suspected user (they're legitimate)
                     await ModerationOrchestrator.TrustUserAsync(
                         new TrustIntent
@@ -454,10 +451,6 @@
 
                     Snackbar.Add("User marked as trusted", Severity.Success);
                     break;
-
-                default:
-                    Snackbar.Add($"Unknown action: {args.Action}", Severity.Error);
-                    return;
             }
 
             await LoadReportsAsync();
@@ -469,7 +462,7 @@
         }
     }
 
-    private async Task HandleExamAction((ExamFailureRecord ExamFailure, string Action) args)
+    private async Task HandleExamAction((ExamFailureRecord ExamFailure, ExamAction Action) args)
     {
         Logger.LogInformation("HandleExamAction called: Action={Action}, ExamFailureId={Id}, UserId={UserId}",
             args.Action, args.ExamFailure.Id, args.ExamFailure.UserId);
@@ -480,13 +473,13 @@
 
             switch (args.Action)
             {
-                case "approve":
+                case ExamAction.Approve:
                     // Approve via service (restores permissions, deletes teaser, updates welcome response)
                     var approveResult = await ExamFlowService.ApproveExamFailureAsync(
-                        userId: args.ExamFailure.UserId,
-                        chatId: args.ExamFailure.ChatId,
-                        examFailureId: args.ExamFailure.Id,
-                        executor: executor);
+                        args.ExamFailure.User,
+                        args.ExamFailure.Chat,
+                        args.ExamFailure.Id,
+                        executor);
 
                     if (!approveResult.Success)
                     {
@@ -504,12 +497,12 @@
                     Snackbar.Add("User approved - permissions restored", Severity.Success);
                     break;
 
-                case "deny":
+                case ExamAction.Deny:
                     // Deny via service (deletes teaser, updates welcome response, kicks user, sends DM)
                     var denyResult = await ExamFlowService.DenyExamFailureAsync(
-                        userId: args.ExamFailure.UserId,
-                        chatId: args.ExamFailure.ChatId,
-                        executor: executor);
+                        args.ExamFailure.User,
+                        args.ExamFailure.Chat,
+                        executor);
 
                     if (!denyResult.Success)
                     {
@@ -527,12 +520,12 @@
                     Snackbar.Add("User denied - they can re-join to try again", Severity.Warning);
                     break;
 
-                case "deny_ban":
+                case ExamAction.DenyAndBan:
                     // Deny and ban via service (deletes teaser, updates welcome response, bans globally, sends DM)
                     var denyBanResult = await ExamFlowService.DenyAndBanExamFailureAsync(
-                        userId: args.ExamFailure.UserId,
-                        chatId: args.ExamFailure.ChatId,
-                        executor: executor);
+                        args.ExamFailure.User,
+                        args.ExamFailure.Chat,
+                        executor);
 
                     if (!denyBanResult.Success)
                     {
@@ -549,10 +542,6 @@
 
                     Snackbar.Add("User denied and banned globally", Severity.Error);
                     break;
-
-                default:
-                    Snackbar.Add($"Unknown action: {args.Action}", Severity.Error);
-                    return;
             }
 
             await LoadReportsAsync();

--- a/TelegramGroupsAdmin/Components/Reports/ExamReviewCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ExamReviewCard.razor
@@ -5,6 +5,7 @@
 @using TelegramGroupsAdmin.Telegram.Models
 @using TelegramGroupsAdmin.Core
 @using TelegramGroupsAdmin.Core.Utilities
+@using TelegramGroupsAdmin.Telegram.Constants
 
 @inject IConfigService ConfigService
 @inject ITelegramUserRepository TelegramUserRepository
@@ -51,9 +52,9 @@
                     </MudAvatar>
                 }
                 <MudStack Spacing="1">
-                    <MudText Typo="Typo.h6">@GetUserDisplayName()</MudText>
+                    <MudText Typo="Typo.h6">@ExamFailure.User.DisplayName</MudText>
                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                        @(ExamFailure.UserName != null ? $"@{ExamFailure.UserName}" : "No username") · ID: @ExamFailure.UserId
+                        @(ExamFailure.User.Username != null ? $"@{ExamFailure.User.Username}" : "No username") · ID: @ExamFailure.UserId
                     </MudText>
                     @if (_user != null)
                     {
@@ -105,7 +106,7 @@
                     @* Chat *@
                     <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                         <MudIcon Icon="@Icons.Material.Filled.Chat" Size="Size.Small" Color="Color.Secondary" />
-                        <MudText Typo="Typo.body2">Chat: @(ExamFailure.ChatName ?? "Unknown")</MudText>
+                        <MudText Typo="Typo.body2">Chat: @(ExamFailure.Chat.ChatName ?? "Unknown")</MudText>
                     </MudStack>
                 </MudStack>
             </MudPaper>
@@ -278,7 +279,7 @@
     public required ExamFailureRecord ExamFailure { get; set; }
 
     [Parameter]
-    public EventCallback<(ExamFailureRecord ExamFailure, string Action)> OnAction { get; set; }
+    public EventCallback<(ExamFailureRecord ExamFailure, ExamAction Action)> OnAction { get; set; }
 
     private bool _actionInProgress;
     private TelegramUser? _user;
@@ -406,15 +407,6 @@
         return (isCorrect, answerLetter, selectedText, correctLetter, correctText);
     }
 
-    private string GetUserDisplayName()
-    {
-        return TelegramDisplayName.Format(
-            ExamFailure.UserFirstName,
-            ExamFailure.UserLastName,
-            ExamFailure.UserName,
-            ExamFailure.UserId);
-    }
-
     private string GetCardStyle()
     {
         if (!ExamFailure.ReviewedAt.HasValue)
@@ -438,21 +430,21 @@
     private async Task OnApprove()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((ExamFailure, "approve"));
+        await OnAction.InvokeAsync((ExamFailure, ExamAction.Approve));
         _actionInProgress = false;
     }
 
     private async Task OnDeny()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((ExamFailure, "deny"));
+        await OnAction.InvokeAsync((ExamFailure, ExamAction.Deny));
         _actionInProgress = false;
     }
 
     private async Task OnDenyAndBan()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((ExamFailure, "deny_ban"));
+        await OnAction.InvokeAsync((ExamFailure, ExamAction.DenyAndBan));
         _actionInProgress = false;
     }
 }

--- a/TelegramGroupsAdmin/Components/Reports/ImpersonationAlertCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ImpersonationAlertCard.razor
@@ -4,6 +4,7 @@
 @using TelegramGroupsAdmin.Telegram.Models
 @using TelegramGroupsAdmin.Core
 @using TelegramGroupsAdmin.Core.Utilities
+@using TelegramGroupsAdmin.Telegram.Constants
 
 @inject ITelegramUserRepository TelegramUserRepository
 @inject IMessageHistoryRepository MessageRepository
@@ -214,17 +215,17 @@
             <MudButton Variant="Variant.Filled"
                        Color="Color.Error"
                        StartIcon="@Icons.Material.Filled.Block"
-                       OnClick="@OnConfirmScam"
+                       OnClick="@OnConfirm"
                        Disabled="@_actionInProgress">
-                Confirm Scam
+                Confirm
             </MudButton>
 
             <MudButton Variant="Variant.Outlined"
                        Color="Color.Default"
                        StartIcon="@Icons.Material.Filled.Close"
-                       OnClick="@OnFalsePositive"
+                       OnClick="@OnDismiss"
                        Disabled="@_actionInProgress">
-                False Positive
+                Dismiss
             </MudButton>
 
             <MudButton Variant="Variant.Filled"
@@ -249,7 +250,7 @@
     public required ImpersonationAlertRecord Alert { get; set; }
 
     [Parameter]
-    public EventCallback<(ImpersonationAlertRecord Alert, string Action)> OnAction { get; set; }
+    public EventCallback<(ImpersonationAlertRecord Alert, ImpersonationAction Action)> OnAction { get; set; }
 
     private bool _actionInProgress;
     private TelegramUser? _suspectedUser;
@@ -334,24 +335,24 @@
         return $"/api/photos/{fileName}";
     }
 
-    private async Task OnConfirmScam()
+    private async Task OnConfirm()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((Alert, "confirm"));
+        await OnAction.InvokeAsync((Alert, ImpersonationAction.Confirm));
         _actionInProgress = false;
     }
 
-    private async Task OnFalsePositive()
+    private async Task OnDismiss()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((Alert, "dismiss"));
+        await OnAction.InvokeAsync((Alert, ImpersonationAction.Dismiss));
         _actionInProgress = false;
     }
 
     private async Task OnTrust()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((Alert, "trust"));
+        await OnAction.InvokeAsync((Alert, ImpersonationAction.Trust));
         _actionInProgress = false;
     }
 }

--- a/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
@@ -3,6 +3,7 @@
 @using TelegramGroupsAdmin.Telegram.Models
 @using TelegramGroupsAdmin.Core
 @using TelegramGroupsAdmin.Core.Utilities
+@using TelegramGroupsAdmin.Telegram.Constants
 
 @inject IMessageHistoryRepository MessageRepository
 @inject ITelegramUserRepository TelegramUserRepository
@@ -145,7 +146,7 @@
     public EventCallback OnActionCompleted { get; set; }
 
     [Parameter]
-    public EventCallback<(Report Report, string Action)> OnAction { get; set; }
+    public EventCallback<(Report Report, ReportAction Action)> OnAction { get; set; }
 
     private MessageRecord? _message;
     private TelegramUser? _reportedUser;
@@ -197,28 +198,28 @@
     private async Task OnMarkSpam()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((Report, "spam"));
+        await OnAction.InvokeAsync((Report, ReportAction.Spam));
         _actionInProgress = false;
     }
 
     private async Task OnBan()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((Report, "ban"));
+        await OnAction.InvokeAsync((Report, ReportAction.Ban));
         _actionInProgress = false;
     }
 
     private async Task OnWarn()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((Report, "warn"));
+        await OnAction.InvokeAsync((Report, ReportAction.Warn));
         _actionInProgress = false;
     }
 
     private async Task OnDismiss()
     {
         _actionInProgress = true;
-        await OnAction.InvokeAsync((Report, "dismiss"));
+        await OnAction.InvokeAsync((Report, ReportAction.Dismiss));
         _actionInProgress = false;
     }
 

--- a/TelegramGroupsAdmin/Services/NotificationService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationService.cs
@@ -384,19 +384,32 @@ public class NotificationService : INotificationService
                     InlineKeyboardButton.WithCallbackData("🚫 Deny & Ban", $"rev:{contextId}:{(int)ExamAction.DenyAndBan}")
                 }
             }),
-            _ => new InlineKeyboardMarkup(new[]
+            ReportType.ContentReport => new InlineKeyboardMarkup(new[]
             {
                 new[]
                 {
                     InlineKeyboardButton.WithCallbackData("🚫 Spam", $"rev:{contextId}:{(int)ReportAction.Spam}"),
-                    InlineKeyboardButton.WithCallbackData("⚠️ Warn", $"rev:{contextId}:{(int)ReportAction.Warn}")
+                    InlineKeyboardButton.WithCallbackData("⛔ Ban", $"rev:{contextId}:{(int)ReportAction.Ban}")
                 },
                 new[]
                 {
-                    InlineKeyboardButton.WithCallbackData("⏱️ TempBan", $"rev:{contextId}:{(int)ReportAction.TempBan}"),
+                    InlineKeyboardButton.WithCallbackData("⚠️ Warn", $"rev:{contextId}:{(int)ReportAction.Warn}"),
                     InlineKeyboardButton.WithCallbackData("✓ Dismiss", $"rev:{contextId}:{(int)ReportAction.Dismiss}")
                 }
-            })
+            }),
+            ReportType.ImpersonationAlert => new InlineKeyboardMarkup(new[]
+            {
+                new[]
+                {
+                    InlineKeyboardButton.WithCallbackData("🚫 Confirm", $"rev:{contextId}:{(int)ImpersonationAction.Confirm}"),
+                    InlineKeyboardButton.WithCallbackData("✓ Dismiss", $"rev:{contextId}:{(int)ImpersonationAction.Dismiss}")
+                },
+                new[]
+                {
+                    InlineKeyboardButton.WithCallbackData("🤝 Trust User", $"rev:{contextId}:{(int)ImpersonationAction.Trust}")
+                }
+            }),
+            _ => throw new ArgumentOutOfRangeException(nameof(reportType), reportType, "Unknown report type")
         };
     }
 


### PR DESCRIPTION
Closes #281

## Summary

- **Thread identities through callback handlers**: `UserIdentity`/`ChatIdentity` now flow through report and impersonation handlers in `ReportCallbackService`, eliminating redundant Telegram API calls (`GetChatAsync`) and aligning with the pattern established in #325
- **Align content report actions**: Replace `ReportAction.TempBan` with `ReportAction.Ban` (delete+ban). Spam action now uses `SpamBanIntent` (delete+ban+spam flag) instead of bare `BanUserAsync`. DM notification keyboard updated to match web UI: Spam, Ban, Warn, Dismiss
- **Fix impersonation action alignment**: Rename enum values (`ConfirmScam` to `Confirm`, `FalsePositive` to `Dismiss`, `Whitelist` to `Trust`), add impersonation-specific DM keyboard, wire `HandleTrustActionAsync` body (was a TODO no-op)
- **Replace magic strings with enums in UI**: All 3 card components (`ModerationReportCard`, `ImpersonationAlertCard`, `ExamReviewCard`) and the `Reports.razor` page now use `ReportAction`, `ImpersonationAction`, and `ExamAction` enums instead of magic strings like `"spam"`, `"confirm"`, `"deny_ban"`
- **Fix FK constraint violation on new user join**: Reorder `WelcomeService.HandleChatMemberUpdateAsync` to create the `telegram_users` record BEFORE `RestrictUserPermissionsAsync`, so the audit handler INSERT into `user_actions` has the required FK target
- **Remove dead code**: `GetChatNameForNotificationAsync` and `TrySendUserNotificationAsync` (zero callers after identity threading)
- **Remove expired legacy `rpt:` callback prefix**: Deadline was 2026-02-01, DM contexts expire after 7 days, no active DMs use the old prefix

### Note on enum value reordering

`ReportAction` and `ImpersonationAction` enum integer values changed (e.g., `ReportAction.Warn` moved from `1` to `2`, `ImpersonationAction` values fully renumbered). This is safe because:

1. Enum values are only persisted in `report_callback_contexts` rows (the DM button payloads), which expire after 7 days
2. There are currently **no active DM notification buttons** using the old enum values -- the system has no pending callback contexts that would be misinterpreted
3. The `actionTaken` strings stored in `reports` table are text (`"Spam"`, `"Dismiss"`, etc.), not integer enum values, so historical data is unaffected

## Test plan

- [x] `dotnet build` -- 0 errors, 0 warnings
- [x] `dotnet test TelegramGroupsAdmin.UnitTests` -- 1380 passed
- [x] `dotnet test TelegramGroupsAdmin.ComponentTests` -- 1055 passed
- [x] `dotnet run -- --migrate-only` -- DI wiring verified
- [ ] Manual: verify DM notification buttons show correct actions for content reports
- [ ] Manual: verify DM notification buttons show correct actions for impersonation alerts
- [ ] Manual: verify new user join flow creates user record before restriction (check audit log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
