### PR TITLE
fix: log email in intermediate auth token creation

### DIFF
--- a/TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs
+++ b/TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs
@@ -42,7 +42,7 @@ public static class AuthEndpoints
             if (result.RequiresTotp)
             {
                 // Generate intermediate authentication token (valid for 5 minutes)
-                var intermediateToken = intermediateAuthService.CreateToken(result.UserId!);
+                var intermediateToken = intermediateAuthService.CreateToken(result.UserId!, request.Email);
 
                 return Results.Json(new
                 {
@@ -57,7 +57,7 @@ public static class AuthEndpoints
             if (result.TotpEnabled)
             {
                 // Generate intermediate authentication token for TOTP setup flow
-                var intermediateToken = intermediateAuthService.CreateToken(result.UserId!);
+                var intermediateToken = intermediateAuthService.CreateToken(result.UserId!, request.Email);
 
                 return Results.Json(new
                 {

--- a/TelegramGroupsAdmin/Services/Auth/IIntermediateAuthService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/IIntermediateAuthService.cs
@@ -11,8 +11,9 @@ public interface IIntermediateAuthService
     /// Token is valid for 5 minutes and can only be used once.
     /// </summary>
     /// <param name="userId">The user ID who passed password verification</param>
+    /// <param name="email">Optional email for structured logging</param>
     /// <returns>A cryptographically secure token string</returns>
-    string CreateToken(string userId);
+    string CreateToken(string userId, string? email = null);
 
     /// <summary>
     /// Validates a temporary authentication token without consuming it.

--- a/TelegramGroupsAdmin/Services/Auth/IntermediateAuthService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/IntermediateAuthService.cs
@@ -18,7 +18,7 @@ public class IntermediateAuthService : IIntermediateAuthService
         _logger = logger;
     }
 
-    public string CreateToken(string userId)
+    public string CreateToken(string userId, string? email = null)
     {
         // Generate cryptographically secure random token (32 bytes = 256 bits)
         var tokenBytes = RandomNumberGenerator.GetBytes(AuthenticationConstants.IntermediateTokenByteLength);
@@ -26,13 +26,14 @@ public class IntermediateAuthService : IIntermediateAuthService
 
         var tokenData = new TokenData(
             UserId: userId,
+            Email: email,
             ExpiresAt: DateTimeOffset.UtcNow.Add(AuthenticationConstants.IntermediateTokenLifetime)
         );
 
         _tokens[token] = tokenData;
 
-        _logger.LogInformation("Created intermediate auth token for user {UserId}, expires at {ExpiresAt}",
-            userId, tokenData.ExpiresAt);
+        _logger.LogInformation("Created intermediate auth token for {Email} ({UserId}), expires at {ExpiresAt}",
+            tokenData.Email, userId, tokenData.ExpiresAt);
 
         // Clean up expired tokens (fire and forget)
         _ = Task.Run(() =>
@@ -144,5 +145,5 @@ public class IntermediateAuthService : IIntermediateAuthService
         }
     }
 
-    private record TokenData(string UserId, DateTimeOffset ExpiresAt);
+    private record TokenData(string UserId, string? Email, DateTimeOffset ExpiresAt);
 }


### PR DESCRIPTION
## Summary
- Intermediate auth token log message now shows email alongside userId for easier log correlation
- Previously only logged a bare GUID, making it hard to match with the login/audit lines above it

## Test plan
- [x] Auth unit tests pass (48/48)
- [x] Auth E2E tests pass (77/77)

🤖 Generated with [Claude Code](https://claude.com/claude-code)