### PR TITLE
chore: update all NuGet packages to latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,15 +6,15 @@
     <!-- UI / Web -->
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="6.1.0" />
-    <PackageVersion Include="bunit" Version="2.5.3" />
+    <PackageVersion Include="bunit" Version="2.6.2" />
     <PackageVersion Include="MudBlazor" Version="9.1.0" />
 
     <!-- Markdown -->
-    <PackageVersion Include="Markdig" Version="1.0.0" />
+    <PackageVersion Include="Markdig" Version="1.1.1" />
     <PackageVersion Include="Markdown.ColorCode" Version="3.0.1" />
 
     <!-- Database -->
-    <PackageVersion Include="Dapper" Version="2.1.66" />
+    <PackageVersion Include="Dapper" Version="2.1.72" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
     <PackageVersion Include="Npgsql" Version="10.0.1" />
@@ -39,22 +39,22 @@
 
     <!-- AI / ML -->
     <PackageVersion Include="Microsoft.ML" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.72.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.72.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.73.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.73.0" />
 
     <!-- Telegram -->
-    <PackageVersion Include="Telegram.Bot" Version="22.9.0" />
-    <PackageVersion Include="WTelegramClient" Version="4.4.1" />
+    <PackageVersion Include="Telegram.Bot" Version="22.9.5.3" />
+    <PackageVersion Include="WTelegramClient" Version="4.4.2" />
 
     <!-- Background Jobs -->
     <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
     <PackageVersion Include="HumanCron" Version="0.5.0" />
     <PackageVersion Include="HumanCron.Quartz" Version="0.5.0" />
-    <PackageVersion Include="Quartz" Version="3.15.1" />
-    <PackageVersion Include="Quartz.AspNetCore" Version="3.15.1" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.15.1" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.15.1" />
-    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.15.1" />
+    <PackageVersion Include="Quartz" Version="3.16.1" />
+    <PackageVersion Include="Quartz.AspNetCore" Version="3.16.1" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.16.1" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.16.1" />
+    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.16.1" />
 
     <!-- Observability -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
@@ -72,8 +72,8 @@
     <PackageVersion Include="ByteSize" Version="2.1.2" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="DiffPlex" Version="1.9.0" />
-    <PackageVersion Include="Humanizer" Version="3.0.1" />
-    <PackageVersion Include="Humanizer.Core" Version="3.0.1" />
+    <PackageVersion Include="Humanizer" Version="3.0.10" />
+    <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="Lib.Net.Http.WebPush" Version="3.3.1" />
     <PackageVersion Include="nClam" Version="9.0.0" />
     <PackageVersion Include="Otp.NET" Version="1.4.1" />
@@ -87,12 +87,12 @@
 
     <!-- Testing -->
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.58.0" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.58.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NUnit" Version="4.5.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
+    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageVersion Include="Testably.Abstractions.Testing" Version="5.3.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/MessageHistoryRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/MessageHistoryRepositoryTests.cs
@@ -1337,7 +1337,7 @@ public class MessageHistoryRepositoryTests
                 using (Assert.EnterMultipleScope())
                 {
                     Assert.That(detection.MessageId, Is.GreaterThan(0));
-                    Assert.That(detection.DetectionMethod, Is.Not.Null.Or.Empty);
+                    Assert.That(detection.DetectionMethod, Is.Not.Null.And.Not.Empty);
                     Assert.That(detection.Score, Is.GreaterThanOrEqualTo(0));
                 }
             }

--- a/TelegramGroupsAdmin/Dockerfile
+++ b/TelegramGroupsAdmin/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Download FFmpeg static build (architecture-specific) with checksum validation
 # Uses TARGETPLATFORM to download correct binary during cross-compilation
 # Example: TARGETPLATFORM=linux/arm64 downloads arm64 binary on amd64 host
-# Currently pinned to: version 7.0.2 (via release channel with MD5 validation)
+# Uses rolling "release" channel — always downloads latest stable version
 # Security: MD5 validation ensures binary integrity and reproducible builds
 RUN case "$TARGETPLATFORM" in \
         "linux/amd64") FFMPEG_ARCH="amd64" ;; \
@@ -259,9 +259,6 @@ ENTRYPOINT ["dotnet", "TelegramGroupsAdmin.dll"]
 # Multi-architecture build (uses BuildKit cross-compilation):
 # docker buildx build --platform linux/amd64,linux/arm64 -t telegramgroupsadmin:latest -f TelegramGroupsAdmin/Dockerfile .
 #
-# Build with specific FFmpeg version:
-# docker build --build-arg FFMPEG_VERSION=7.0.1 -t telegramgroupsadmin:latest -f TelegramGroupsAdmin/Dockerfile .
-#
 # Build with custom user/group ID:
 # docker build --build-arg PUID=1000 --build-arg PGID=1000 -t telegramgroupsadmin:latest -f TelegramGroupsAdmin/Dockerfile .
 #
@@ -290,5 +287,5 @@ ENTRYPOINT ["dotnet", "TelegramGroupsAdmin.dll"]
 # - Read-only filesystem (except /app/data volume)
 # - Diagnostics disabled in production
 # - Single HTTP port exposure (HTTPS via reverse proxy)
-# - FFmpeg version pinned (7.0.2 default, override via build arg)
+# - FFmpeg uses rolling release channel with MD5 integrity validation
 # =============================================================================


### PR DESCRIPTION
## Summary

- Update 13 NuGet packages to latest stable versions via Central Package Management
- Fix NUnit2058 analyzer error caught by NUnit.Analyzers 4.12.0 (`Is.Not.Null.Or.Empty` was always true — fixed to `Is.Not.Null.And.Not.Empty`)
- Fix stale FFmpeg version comments in Dockerfile (was claiming "pinned to 7.0.2" when actually using rolling release channel)

### Package Updates

| Package | Old | New |
|---------|-----|-----|
| Dapper | 2.1.66 | 2.1.72 |
| Markdig | 1.0.0 | 1.1.1 |
| Telegram.Bot | 22.9.0 | 22.9.5.3 |
| WTelegramClient | 4.4.1 | 4.4.2 |
| Humanizer / Humanizer.Core | 3.0.1 | 3.0.10 |
| Microsoft.SemanticKernel (+Abstractions) | 1.72.0 | 1.73.0 |
| Quartz (all 5 packages) | 3.15.1 | 3.16.1 |
| bunit | 2.5.3 | 2.6.2 |
| Microsoft.NET.Test.Sdk | 18.0.1 | 18.3.0 |
| NUnit | 4.5.0 | 4.5.1 |
| NUnit.Analyzers | 4.11.2 | 4.12.0 |

EF Core stays at 10.0.0 (Npgsql.EntityFrameworkCore.PostgreSQL compatibility).

## Test plan

- [x] Clean build: 0 errors, 0 warnings
- [x] Full test suite: 3,602 tests passed (unit, component, integration, E2E)
- [x] Verify Quartz.NET background jobs page in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>