### PR TITLE
fix: detect video content disguised as GIF via magic byte inspection

### DIFF
--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/FetchUserPhotoJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/FetchUserPhotoJob.cs
@@ -86,7 +86,7 @@ public class FetchUserPhotoJob(
                     try
                     {
                         // Resolve relative path to absolute for disk operations
-                        var absolutePath = MediaPathUtilities.ToAbsolutePath(photoResult.RelativePath, appOptions.Value.DataPath);
+                        var absolutePath = MediaUtilities.ToAbsolutePath(photoResult.RelativePath, appOptions.Value.DataPath);
                         var photoHashBytes = await photoHashService.ComputePhotoHashAsync(absolutePath);
                         if (photoHashBytes != null)
                         {

--- a/TelegramGroupsAdmin.Core/Utilities/MediaPathUtilities.cs
+++ b/TelegramGroupsAdmin.Core/Utilities/MediaPathUtilities.cs
@@ -1,11 +1,53 @@
 namespace TelegramGroupsAdmin.Core.Utilities;
 
 /// <summary>
-/// Utilities for constructing media file paths
+/// Utilities for constructing media file paths and detecting media formats.
 /// Phase 4.X: Media attachments (Animation, Video, Audio, Voice, Sticker, VideoNote, Document)
 /// </summary>
 public static class MediaPathUtilities
 {
+    /// <summary>
+    /// Detects whether a file contains video content by examining its magic bytes (file signature),
+    /// regardless of file extension. Giphy and other services often serve MP4/WebM video content
+    /// from URLs with .gif extensions.
+    /// </summary>
+    /// <param name="filePath">Full path to the file to inspect</param>
+    /// <returns>True if the file's magic bytes match a known video format (MP4/MOV/M4V, WebM/MKV, AVI)</returns>
+    public static bool IsVideoContent(string filePath)
+    {
+        try
+        {
+            Span<byte> header = stackalloc byte[12];
+            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+            var bytesRead = fs.Read(header);
+            if (bytesRead < 4) return false;
+
+            // MP4/MOV/M4V: "ftyp" at offset 4
+            if (bytesRead >= 8
+                && header[4] == (byte)'f' && header[5] == (byte)'t'
+                && header[6] == (byte)'y' && header[7] == (byte)'p')
+                return true;
+
+            // WebM/MKV: EBML header 0x1A45DFA3
+            if (header[0] == 0x1A && header[1] == 0x45 && header[2] == 0xDF && header[3] == 0xA3)
+                return true;
+
+            // AVI: "RIFF....AVI "
+            if (bytesRead >= 12
+                && header[0] == (byte)'R' && header[1] == (byte)'I'
+                && header[2] == (byte)'F' && header[3] == (byte)'F'
+                && header[8] == (byte)'A' && header[9] == (byte)'V'
+                && header[10] == (byte)'I' && header[11] == (byte)' ')
+                return true;
+
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     /// <summary>
     /// Get the subdirectory name for a given media type
     /// </summary>

--- a/TelegramGroupsAdmin.Core/Utilities/MediaUtilities.cs
+++ b/TelegramGroupsAdmin.Core/Utilities/MediaUtilities.cs
@@ -1,15 +1,23 @@
 namespace TelegramGroupsAdmin.Core.Utilities;
 
 /// <summary>
-/// Utilities for constructing media file paths and detecting media formats.
-/// Phase 4.X: Media attachments (Animation, Video, Audio, Voice, Sticker, VideoNote, Document)
+/// Utilities for constructing media file paths, detecting media formats, and identifying video content.
 /// </summary>
-public static class MediaPathUtilities
+public static class MediaUtilities
 {
+    /// <summary>
+    /// File extensions recognized as video formats. Used for extension-based routing before
+    /// falling back to <see cref="IsVideoContent"/> magic byte detection.
+    /// </summary>
+    public static readonly IReadOnlySet<string> VideoExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ".mp4", ".webm", ".mov", ".avi", ".mkv", ".m4v"
+    };
+
     /// <summary>
     /// Detects whether a file contains video content by examining its magic bytes (file signature),
     /// regardless of file extension. Giphy and other services often serve MP4/WebM video content
-    /// from URLs with .gif extensions.
+    /// from URLs with .gif extensions. Returns false for files shorter than 4 bytes or that cannot be read.
     /// </summary>
     /// <param name="filePath">Full path to the file to inspect</param>
     /// <returns>True if the file's magic bytes match a known video format (MP4/MOV/M4V, WebM/MKV, AVI)</returns>
@@ -18,7 +26,7 @@ public static class MediaPathUtilities
         try
         {
             Span<byte> header = stackalloc byte[12];
-            using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+            using var fs = File.OpenRead(filePath);
             var bytesRead = fs.Read(header);
             if (bytesRead < 4) return false;
 
@@ -42,7 +50,11 @@ public static class MediaPathUtilities
 
             return false;
         }
-        catch
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
         {
             return false;
         }

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/BanCelebrationGifRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/BanCelebrationGifRepositoryTests.cs
@@ -862,6 +862,66 @@ public class BanCelebrationGifRepositoryTests
             Assert.That(result.FilePath, Does.EndWith(".gif"));
         }
 
+        // Verify file exists on disk
+        var fullPath = _repository.GetFullPath(result.FilePath);
+        Assert.That(File.Exists(fullPath), Is.True, "Converted GIF should exist on disk");
+
+        // Verify FFmpeg conversion was called (magic byte fallback caught it)
+        await _mockVideoService!.Received(1).ConvertVideoToGifAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task AddFromFileAsync_GifExtensionWithWebMContent_TriggersConversion()
+    {
+        // Arrange - File upload named .gif but containing WebM magic bytes
+        using var stream = new MemoryStream(CreateMinimalWebMBytes());
+
+        // Act
+        var result = await _repository!.AddFromFileAsync(stream, "from-tenor.gif", "Disguised WebM");
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.FilePath, Does.EndWith(".gif"));
+        }
+
+        // Verify FFmpeg conversion was called (magic byte fallback caught it)
+        await _mockVideoService!.Received(1).ConvertVideoToGifAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region AddFromUrlAsync - WebM Disguised as GIF (Magic Byte Fallback)
+
+    [Test]
+    public async Task AddFromUrlAsync_ServerReturnsWebMBytesWithGifContentType_DetectsAndConverts()
+    {
+        // Arrange - WireMock serves WebM bytes but lies about content type
+        var webmBytes = CreateMinimalWebMBytes();
+
+        _mockServer
+            .Given(Request.Create().WithPath("/media/tenor.gif").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "image/gif")
+                .WithBody(webmBytes));
+
+        var url = $"{_mockServer.Urls[0]}/media/tenor.gif";
+
+        // Act
+        var result = await _repository!.AddFromUrlAsync(url, "Tenor Disguised WebM");
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Name, Is.EqualTo("Tenor Disguised WebM"));
+            Assert.That(result.FilePath, Does.EndWith(".gif"));
+        }
+
         // Verify FFmpeg conversion was called (magic byte fallback caught it)
         await _mockVideoService!.Received(1).ConvertVideoToGifAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/BanCelebrationGifRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/BanCelebrationGifRepositoryTests.cs
@@ -7,6 +7,9 @@ using TelegramGroupsAdmin.ContentDetection.Services;
 using TelegramGroupsAdmin.Data;
 using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
 using TelegramGroupsAdmin.Telegram.Repositories;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace TelegramGroupsAdmin.IntegrationTests.Repositories;
 
@@ -30,6 +33,8 @@ public class BanCelebrationGifRepositoryTests
     private MigrationTestHelper? _testHelper;
     private IServiceProvider? _serviceProvider;
     private IBanCelebrationGifRepository? _repository;
+    private IVideoFrameExtractionService? _mockVideoService;
+    private WireMockServer _mockServer = null!;
     private string _tempMediaPath = null!;
 
     [SetUp]
@@ -38,6 +43,10 @@ public class BanCelebrationGifRepositoryTests
         // Create unique test database with migrations applied
         _testHelper = new MigrationTestHelper();
         await _testHelper.CreateDatabaseAndApplyMigrationsAsync();
+
+        // Start WireMock server for URL download tests
+        _mockServer = WireMockServer.Start();
+        _mockServer.Reset();
 
         // Create temp directory for media files
         _tempMediaPath = Path.Combine(Path.GetTempPath(), $"BanCelebrationGifTests_{Guid.NewGuid():N}");
@@ -60,22 +69,22 @@ public class BanCelebrationGifRepositoryTests
         services.AddHttpClient();
 
         // Mock IVideoFrameExtractionService for video conversion tests
-        var mockVideoService = Substitute.For<IVideoFrameExtractionService>();
-        mockVideoService.IsAvailable.Returns(true);
-        // Mock successful conversion - writes an empty file to the output path
-        mockVideoService.ConvertVideoToGifAsync(
+        _mockVideoService = Substitute.For<IVideoFrameExtractionService>();
+        _mockVideoService.IsAvailable.Returns(true);
+        // Mock successful conversion - writes a valid GIF to the output path
+        _mockVideoService.ConvertVideoToGifAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<int>(),
             Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                // Create an empty file at the output path to simulate successful conversion
+                // Create a valid GIF at the output path to simulate successful conversion
                 var outputPath = callInfo.ArgAt<string>(1);
                 File.WriteAllBytes(outputPath, CreateMinimalGifBytes());
                 return true;
             });
-        services.AddSingleton(mockVideoService);
+        services.AddSingleton(_mockVideoService);
 
         services.AddScoped<IBanCelebrationGifRepository, BanCelebrationGifRepository>();
 
@@ -89,6 +98,8 @@ public class BanCelebrationGifRepositoryTests
     {
         (_serviceProvider as IDisposable)?.Dispose();
         _testHelper?.Dispose();
+        _mockServer.Stop();
+        _mockServer.Dispose();
 
         // Clean up temp directory
         if (Directory.Exists(_tempMediaPath))
@@ -705,6 +716,159 @@ public class BanCelebrationGifRepositoryTests
 
     #endregion
 
+    #region AddFromUrlAsync - Video Content Detection (WireMock)
+
+    [Test]
+    public async Task AddFromUrlAsync_ServerReturnsMp4ContentType_TriggersConversion()
+    {
+        // Arrange - WireMock serves MP4 bytes with correct video content type
+        var mp4Bytes = CreateMinimalMp4Bytes();
+
+        _mockServer
+            .Given(Request.Create().WithPath("/media/funny.gif").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "video/mp4")
+                .WithBody(mp4Bytes));
+
+        var url = $"{_mockServer.Urls[0]}/media/funny.gif";
+
+        // Act
+        var result = await _repository!.AddFromUrlAsync(url, "MP4 as GIF");
+
+        // Assert - File saved and conversion triggered
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Name, Is.EqualTo("MP4 as GIF"));
+            Assert.That(result.FilePath, Does.EndWith(".gif"));
+        }
+
+        // Verify FFmpeg conversion was called (content-type detection caught it)
+        await _mockVideoService!.Received(1).ConvertVideoToGifAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task AddFromUrlAsync_ServerReturnsMp4BytesWithGifContentType_DetectsAndConverts()
+    {
+        // Arrange - WireMock serves MP4 bytes but lies about content type (the Giphy scenario)
+        var mp4Bytes = CreateMinimalMp4Bytes();
+
+        _mockServer
+            .Given(Request.Create().WithPath("/media/giphy.gif").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "image/gif")
+                .WithBody(mp4Bytes));
+
+        var url = $"{_mockServer.Urls[0]}/media/giphy.gif";
+
+        // Act
+        var result = await _repository!.AddFromUrlAsync(url, "Giphy Disguised MP4");
+
+        // Assert - File saved and magic byte detection triggered conversion
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Name, Is.EqualTo("Giphy Disguised MP4"));
+            Assert.That(result.FilePath, Does.EndWith(".gif"));
+        }
+
+        // Verify FFmpeg conversion was called (magic byte fallback caught it)
+        await _mockVideoService!.Received(1).ConvertVideoToGifAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task AddFromUrlAsync_ServerReturnsWebMContentType_TriggersConversion()
+    {
+        // Arrange - WireMock serves WebM bytes with video/webm content type
+        var webmBytes = CreateMinimalWebMBytes();
+
+        _mockServer
+            .Given(Request.Create().WithPath("/media/clip.gif").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "video/webm")
+                .WithBody(webmBytes));
+
+        var url = $"{_mockServer.Urls[0]}/media/clip.gif";
+
+        // Act
+        var result = await _repository!.AddFromUrlAsync(url, "WebM as GIF");
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Name, Is.EqualTo("WebM as GIF"));
+            Assert.That(result.FilePath, Does.EndWith(".gif"));
+        }
+
+        // Verify FFmpeg conversion was called (video/* content-type detection caught it)
+        await _mockVideoService!.Received(1).ConvertVideoToGifAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task AddFromUrlAsync_ServerReturnsRealGif_NoConversion()
+    {
+        // Arrange - WireMock serves actual GIF content (no conversion needed)
+        var gifBytes = CreateMinimalGifBytes();
+
+        _mockServer
+            .Given(Request.Create().WithPath("/media/real.gif").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "image/gif")
+                .WithBody(gifBytes));
+
+        var url = $"{_mockServer.Urls[0]}/media/real.gif";
+
+        // Act
+        var result = await _repository!.AddFromUrlAsync(url, "Real GIF");
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Name, Is.EqualTo("Real GIF"));
+            Assert.That(result.FilePath, Does.EndWith(".gif"));
+        }
+
+        // Verify FFmpeg conversion was NOT called (real GIF needs no conversion)
+        await _mockVideoService!.DidNotReceive().ConvertVideoToGifAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region AddFromFileAsync - Magic Byte Detection
+
+    [Test]
+    public async Task AddFromFileAsync_GifExtensionWithMp4Content_TriggersConversion()
+    {
+        // Arrange - File upload named .gif but containing MP4 magic bytes
+        using var stream = new MemoryStream(CreateMinimalMp4Bytes());
+
+        // Act
+        var result = await _repository!.AddFromFileAsync(stream, "from-giphy.gif", "Disguised MP4");
+
+        // Assert
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.FilePath, Does.EndWith(".gif"));
+        }
+
+        // Verify FFmpeg conversion was called (magic byte fallback caught it)
+        await _mockVideoService!.Received(1).ConvertVideoToGifAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
     #region Helper Methods
 
     /// <summary>
@@ -729,6 +893,33 @@ public class BanCelebrationGifRepositoryTests
     /// Creates a minimal valid GIF stream for testing.
     /// </summary>
     private static MemoryStream CreateTestGifStream() => new(CreateMinimalGifBytes());
+
+    /// <summary>
+    /// Creates bytes with a valid MP4 file signature (ftyp box).
+    /// Only the magic bytes matter — FFmpeg conversion is mocked.
+    /// </summary>
+    private static byte[] CreateMinimalMp4Bytes() =>
+    [
+        0x00, 0x00, 0x00, 0x1C,       // box size (28 bytes)
+        0x66, 0x74, 0x79, 0x70,       // "ftyp" — MP4/MOV/M4V signature
+        0x69, 0x73, 0x6F, 0x6D,       // brand: "isom"
+        0x00, 0x00, 0x02, 0x00,       // minor version
+        0x69, 0x73, 0x6F, 0x6D,       // compatible brand: "isom"
+        0x69, 0x73, 0x6F, 0x32,       // compatible brand: "iso2"
+        0x6D, 0x70, 0x34, 0x31,       // compatible brand: "mp41"
+    ];
+
+    /// <summary>
+    /// Creates bytes with a valid WebM/MKV file signature (EBML header).
+    /// Only the magic bytes matter — FFmpeg conversion is mocked.
+    /// </summary>
+    private static byte[] CreateMinimalWebMBytes() =>
+    [
+        0x1A, 0x45, 0xDF, 0xA3,       // EBML header — WebM/MKV signature
+        0x93, 0x42, 0x86, 0x81,       // EBML version element
+        0x01, 0x42, 0xF7, 0x81,       // EBML read version element
+        0x01, 0x42, 0xF2, 0x81,       // padding
+    ];
 
     #endregion
 }

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/BanCelebrationGifRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/BanCelebrationGifRepositoryTests.cs
@@ -892,6 +892,27 @@ public class BanCelebrationGifRepositoryTests
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
+    [Test]
+    public async Task AddFromFileAsync_GifExtensionWithVideoContent_ConversionFails_CleansUpAndThrows()
+    {
+        // Arrange - Override the default mock to return false (conversion failure)
+        _mockVideoService!.ConvertVideoToGifAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        using var stream = new MemoryStream(CreateMinimalMp4Bytes());
+
+        // Act & Assert — should throw since FFmpeg "failed"
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await _repository!.AddFromFileAsync(stream, "bad-video.gif", "Fails Conversion"));
+
+        Assert.That(ex!.Message, Does.Contain("FFmpeg conversion failed"));
+
+        // Verify DB record was cleaned up (no orphaned records)
+        var allGifs = await _repository!.GetAllAsync();
+        Assert.That(allGifs, Is.Empty, "DB record should be removed after conversion failure");
+    }
+
     #endregion
 
     #region AddFromUrlAsync - WebM Disguised as GIF (Magic Byte Fallback)

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/MessageHistoryRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/MessageHistoryRepositoryTests.cs
@@ -771,7 +771,7 @@ public class MessageHistoryRepositoryTests
         Assert.That(retrievedBefore!.MediaLocalPath, Is.Null);
 
         // Create test media file on disk (required by ValidateMediaPath)
-        // MediaPathUtilities.GetMediaStoragePath returns: "media/video/filename.mp4"
+        // MediaUtilities.GetMediaStoragePath returns: "media/video/filename.mp4"
         // So full path is: {_imageStoragePath}/media/video/filename.mp4
         const string testMediaFileName = "test_video_999003.mp4";
         var mediaVideoSubfolder = Path.Combine(_imageStoragePath!, "media", "video");

--- a/TelegramGroupsAdmin.Telegram/Repositories/BanCelebrationGifRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/BanCelebrationGifRepository.cs
@@ -187,7 +187,6 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
                     }
                 }
 
-                isVideo = true;
             }
         }
 

--- a/TelegramGroupsAdmin.Telegram/Repositories/BanCelebrationGifRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/BanCelebrationGifRepository.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using TelegramGroupsAdmin.Configuration;
 using TelegramGroupsAdmin.ContentDetection.Services;
 using TelegramGroupsAdmin.Core.Utilities;
+using static TelegramGroupsAdmin.Core.Utilities.MediaPathUtilities;
 using TelegramGroupsAdmin.Data;
 using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.Telegram.Models;
@@ -158,6 +159,41 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
             {
                 await fileStream.CopyToAsync(fileStreamWrite, ct);
             }
+
+            // Check if the saved file is actually video content despite non-video extension.
+            // Giphy and similar services often serve MP4 from .gif URLs with misleading content types.
+            if (IsVideoContent(fullPath))
+            {
+                _logger.LogInformation(
+                    "File {FileName} has non-video extension but contains video content, converting to GIF",
+                    fileName);
+
+                var tempPath = fullPath + ".tmp";
+                File.Move(fullPath, tempPath);
+
+                try
+                {
+                    var success = await _videoService.ConvertVideoToGifAsync(tempPath, fullPath, maxSize: 480, ct);
+                    if (!success)
+                    {
+                        // Conversion failed — keep the original file (Telegram can still send it as-is)
+                        File.Move(tempPath, fullPath, overwrite: true);
+                        _logger.LogWarning(
+                            "Video-to-GIF conversion failed for misidentified video {FileName}, keeping original",
+                            fileName);
+                    }
+                }
+                finally
+                {
+                    if (File.Exists(tempPath))
+                    {
+                        try { File.Delete(tempPath); }
+                        catch { /* ignore cleanup errors */ }
+                    }
+                }
+
+                isVideo = true;
+            }
         }
 
         // Update the file path
@@ -181,19 +217,23 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
         using var response = await _httpClient.GetAsync(url, ct);
         response.EnsureSuccessStatusCode();
 
-        // Determine extension from content type or URL
+        // Determine extension from content type or URL.
+        // Any video/* content type is treated as .mp4 for FFmpeg conversion,
+        // since Giphy and similar services may serve video from .gif URLs.
         var extension = ".gif";
         var contentType = response.Content.Headers.ContentType?.MediaType;
-        if (contentType == "video/mp4")
-            extension = ".mp4";
-        else if (contentType == "image/gif")
-            extension = ".gif";
-        else
+        if (contentType != null && contentType.StartsWith("video/", StringComparison.OrdinalIgnoreCase))
         {
-            // Try to get from URL
+            extension = ".mp4";
+        }
+        else if (contentType is not "image/gif")
+        {
+            // Unknown or missing content type — check URL extension
             var urlExtension = Path.GetExtension(new Uri(url).AbsolutePath).ToLowerInvariant();
-            if (urlExtension is ".gif" or ".mp4")
+            if (VideoExtensions.Contains(urlExtension))
                 extension = urlExtension;
+            else if (urlExtension is ".gif")
+                extension = ".gif";
         }
 
         await using var downloadStream = await response.Content.ReadAsStreamAsync(ct);

--- a/TelegramGroupsAdmin.Telegram/Repositories/BanCelebrationGifRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/BanCelebrationGifRepository.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Options;
 using TelegramGroupsAdmin.Configuration;
 using TelegramGroupsAdmin.ContentDetection.Services;
 using TelegramGroupsAdmin.Core.Utilities;
-using static TelegramGroupsAdmin.Core.Utilities.MediaPathUtilities;
 using TelegramGroupsAdmin.Data;
 using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.Telegram.Models;
@@ -25,11 +24,7 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
     private readonly HttpClient _httpClient;
 
     private const string GifSubdirectory = "ban-gifs";
-
-    private static readonly HashSet<string> VideoExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".mp4", ".webm", ".mov", ".avi", ".mkv", ".m4v"
-    };
+    private const long MaxDownloadSize = 50 * 1024 * 1024; // 50 MB — matches file upload limit and Telegram API ceiling
 
     public BanCelebrationGifRepository(
         IDbContextFactory<AppDbContext> contextFactory,
@@ -112,7 +107,7 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
         await context.SaveChangesAsync(ct);
 
         var sourceExtension = Path.GetExtension(fileName).ToLowerInvariant();
-        var isVideo = VideoExtensions.Contains(sourceExtension);
+        var isVideo = MediaUtilities.VideoExtensions.Contains(sourceExtension);
 
         // Final file is always .gif
         var relativePath = $"{GifSubdirectory}/{dto.Id}.gif";
@@ -148,7 +143,7 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
                 if (File.Exists(tempPath))
                 {
                     try { File.Delete(tempPath); }
-                    catch { /* ignore cleanup errors */ }
+                    catch (IOException ex) { _logger.LogDebug(ex, "Failed to clean up temp file: {Path}", tempPath); }
                 }
             }
         }
@@ -162,7 +157,7 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
 
             // Check if the saved file is actually video content despite non-video extension.
             // Giphy and similar services often serve MP4 from .gif URLs with misleading content types.
-            if (IsVideoContent(fullPath))
+            if (MediaUtilities.IsVideoContent(fullPath))
             {
                 _logger.LogInformation(
                     "File {FileName} has non-video extension but contains video content, converting to GIF",
@@ -176,11 +171,11 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
                     var success = await _videoService.ConvertVideoToGifAsync(tempPath, fullPath, maxSize: 480, ct);
                     if (!success)
                     {
-                        // Conversion failed — keep the original file (Telegram can still send it as-is)
-                        File.Move(tempPath, fullPath, overwrite: true);
-                        _logger.LogWarning(
-                            "Video-to-GIF conversion failed for misidentified video {FileName}, keeping original",
-                            fileName);
+                        // Conversion failed — clean up DB record and throw, same as the explicit-video path
+                        context.BanCelebrationGifs.Remove(dto);
+                        await context.SaveChangesAsync(ct);
+                        throw new InvalidOperationException(
+                            $"Failed to convert video to GIF. FFmpeg conversion failed for: {fileName}");
                     }
                 }
                 finally
@@ -188,7 +183,7 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
                     if (File.Exists(tempPath))
                     {
                         try { File.Delete(tempPath); }
-                        catch { /* ignore cleanup errors */ }
+                        catch (IOException ex) { _logger.LogDebug(ex, "Failed to clean up temp file: {Path}", tempPath); }
                     }
                 }
 
@@ -213,9 +208,14 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
 
         _logger.LogInformation("Downloading ban celebration GIF from URL: {Url}", url);
 
-        // Download the file
-        using var response = await _httpClient.GetAsync(url, ct);
+        // Download the file with size limit matching file upload (50 MB)
+        using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
         response.EnsureSuccessStatusCode();
+
+        var contentLength = response.Content.Headers.ContentLength;
+        if (contentLength > MaxDownloadSize)
+            throw new InvalidOperationException(
+                $"File too large: {contentLength} bytes exceeds {MaxDownloadSize / (1024 * 1024)} MB limit");
 
         // Determine extension from content type or URL.
         // Any video/* content type is treated as .mp4 for FFmpeg conversion,
@@ -230,14 +230,29 @@ public class BanCelebrationGifRepository : IBanCelebrationGifRepository
         {
             // Unknown or missing content type — check URL extension
             var urlExtension = Path.GetExtension(new Uri(url).AbsolutePath).ToLowerInvariant();
-            if (VideoExtensions.Contains(urlExtension))
+            if (MediaUtilities.VideoExtensions.Contains(urlExtension))
                 extension = urlExtension;
             else if (urlExtension is ".gif")
                 extension = ".gif";
         }
 
+        // Copy to a size-capped MemoryStream (guards against servers that omit Content-Length)
         await using var downloadStream = await response.Content.ReadAsStreamAsync(ct);
-        return await AddFromFileAsync(downloadStream, $"download{extension}", name, ct);
+        using var cappedStream = new MemoryStream();
+        var buffer = new byte[81920];
+        long totalRead = 0;
+        int bytesRead;
+        while ((bytesRead = await downloadStream.ReadAsync(buffer, ct)) > 0)
+        {
+            totalRead += bytesRead;
+            if (totalRead > MaxDownloadSize)
+                throw new InvalidOperationException(
+                    $"Download exceeded {MaxDownloadSize / (1024 * 1024)} MB limit");
+            cappedStream.Write(buffer, 0, bytesRead);
+        }
+
+        cappedStream.Position = 0;
+        return await AddFromFileAsync(cappedStream, $"download{extension}", name, ct);
     }
 
     public async Task DeleteAsync(int id, CancellationToken ct = default)

--- a/TelegramGroupsAdmin.Telegram/Repositories/MessageHistoryRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/MessageHistoryRepository.cs
@@ -208,7 +208,7 @@ public class MessageHistoryRepository : IMessageHistoryRepository
 
         // Validate media path exists on filesystem (nulls if missing)
         // REFACTOR-3: Now uses shared utility to avoid duplication with MessageQueryService
-        var validatedPath = MediaPathUtilities.ValidateMediaPath(
+        var validatedPath = MediaUtilities.ValidateMediaPath(
             messageModel.MediaLocalPath,
             (int?)messageModel.MediaType,
             _imageStoragePath,

--- a/TelegramGroupsAdmin.Telegram/Services/MessageQueryService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/MessageQueryService.cs
@@ -179,7 +179,7 @@ public class MessageQueryService : IMessageQueryService
 
             // Validate media path exists on filesystem (nulls if missing)
             // REFACTOR-3: Now uses shared utility to avoid duplication with MessageHistoryRepository
-            var validatedPath = MediaPathUtilities.ValidateMediaPath(
+            var validatedPath = MediaUtilities.ValidateMediaPath(
                 messageModel.MediaLocalPath,
                 (int?)messageModel.MediaType,
                 _imageStoragePath,
@@ -355,7 +355,7 @@ public class MessageQueryService : IMessageQueryService
         var messageModel = enrichedMessage.ToModel();
 
         // Validate media path exists on filesystem
-        var validatedPath = MediaPathUtilities.ValidateMediaPath(
+        var validatedPath = MediaUtilities.ValidateMediaPath(
             messageModel.MediaLocalPath,
             (int?)messageModel.MediaType,
             _imageStoragePath,

--- a/TelegramGroupsAdmin.Telegram/Services/TelegramMediaService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/TelegramMediaService.cs
@@ -52,7 +52,7 @@ public class TelegramMediaService(
             var uniqueFileName = $"{mediaType.ToString().ToLowerInvariant()}_{messageId}_{file.FileUniqueId}{extension}";
 
             // Get subdirectory from centralized utility
-            var subDir = MediaPathUtilities.GetMediaSubdirectory((int)mediaType);
+            var subDir = MediaUtilities.GetMediaSubdirectory((int)mediaType);
 
             // Ensure media subdirectory exists (e.g., /data/media/video/)
             var mediaDir = Path.Combine(_mediaStoragePath, "media", subDir);

--- a/TelegramGroupsAdmin.Telegram/Services/ThumbnailService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ThumbnailService.cs
@@ -3,6 +3,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using TelegramGroupsAdmin.ContentDetection.Services;
+using TelegramGroupsAdmin.Core.Utilities;
 
 namespace TelegramGroupsAdmin.Telegram.Services;
 
@@ -38,9 +39,11 @@ public class ThumbnailService : IThumbnailService
                 return false;
             }
 
-            // Check if this is a video file
+            // Check if this is a video file by extension or actual content (magic bytes).
+            // Giphy and similar services often serve MP4 content from .gif URLs,
+            // so the file extension alone is unreliable.
             var extension = Path.GetExtension(sourcePath);
-            if (VideoExtensions.Contains(extension))
+            if (VideoExtensions.Contains(extension) || MediaPathUtilities.IsVideoContent(sourcePath))
             {
                 return await GenerateVideoThumbnailAsync(sourcePath, destinationPath, maxSize, ct);
             }

--- a/TelegramGroupsAdmin.Telegram/Services/ThumbnailService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ThumbnailService.cs
@@ -16,11 +16,6 @@ public class ThumbnailService : IThumbnailService
     private readonly IVideoFrameExtractionService _videoFrameService;
     private readonly ILogger<ThumbnailService> _logger;
 
-    private static readonly HashSet<string> VideoExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".mp4", ".webm", ".mov", ".avi", ".mkv", ".m4v"
-    };
-
     public ThumbnailService(
         IVideoFrameExtractionService videoFrameService,
         ILogger<ThumbnailService> logger)
@@ -43,7 +38,7 @@ public class ThumbnailService : IThumbnailService
             // Giphy and similar services often serve MP4 content from .gif URLs,
             // so the file extension alone is unreliable.
             var extension = Path.GetExtension(sourcePath);
-            if (VideoExtensions.Contains(extension) || MediaPathUtilities.IsVideoContent(sourcePath))
+            if (MediaUtilities.VideoExtensions.Contains(extension) || MediaUtilities.IsVideoContent(sourcePath))
             {
                 return await GenerateVideoThumbnailAsync(sourcePath, destinationPath, maxSize, ct);
             }

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/ThumbnailServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/ThumbnailServiceTests.cs
@@ -453,4 +453,83 @@ public class ThumbnailServiceTests
     }
 
     #endregion
+
+    #region Magic Byte Detection - Video Content Disguised as GIF
+
+    [Test]
+    public async Task GenerateThumbnailAsync_GifExtensionWithMp4Content_DelegatesToVideoService()
+    {
+        // Arrange - File named .gif but containing MP4 magic bytes (ftyp at offset 4)
+        var sourcePath = Path.Combine(_tempDir, "disguised.gif");
+        var destPath = Path.Combine(_tempDir, "thumb.png");
+
+        await File.WriteAllBytesAsync(sourcePath, CreateMinimalMp4Bytes());
+
+        _mockVideoService.IsAvailable.Returns(true);
+        _mockVideoService.ExtractThumbnailAsync(sourcePath, destPath, 100, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var result = await _service.GenerateThumbnailAsync(sourcePath, destPath);
+
+        // Assert - Should route to video service despite .gif extension
+        Assert.That(result, Is.True);
+        await _mockVideoService.Received(1).ExtractThumbnailAsync(
+            sourcePath, destPath, 100, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task GenerateThumbnailAsync_GifExtensionWithWebMContent_DelegatesToVideoService()
+    {
+        // Arrange - File named .gif but containing WebM/EBML magic bytes
+        var sourcePath = Path.Combine(_tempDir, "disguised.gif");
+        var destPath = Path.Combine(_tempDir, "thumb.png");
+
+        await File.WriteAllBytesAsync(sourcePath, CreateMinimalWebMBytes());
+
+        _mockVideoService.IsAvailable.Returns(true);
+        _mockVideoService.ExtractThumbnailAsync(sourcePath, destPath, 100, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var result = await _service.GenerateThumbnailAsync(sourcePath, destPath);
+
+        // Assert - Should route to video service despite .gif extension
+        Assert.That(result, Is.True);
+        await _mockVideoService.Received(1).ExtractThumbnailAsync(
+            sourcePath, destPath, 100, Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Creates bytes with a valid MP4 file signature (ftyp box).
+    /// Only the magic bytes matter — the rest is padding since FFmpeg is mocked.
+    /// </summary>
+    private static byte[] CreateMinimalMp4Bytes() =>
+    [
+        0x00, 0x00, 0x00, 0x1C,       // box size (28 bytes)
+        0x66, 0x74, 0x79, 0x70,       // "ftyp" — MP4/MOV/M4V signature
+        0x69, 0x73, 0x6F, 0x6D,       // brand: "isom"
+        0x00, 0x00, 0x02, 0x00,       // minor version
+        0x69, 0x73, 0x6F, 0x6D,       // compatible brand: "isom"
+        0x69, 0x73, 0x6F, 0x32,       // compatible brand: "iso2"
+        0x6D, 0x70, 0x34, 0x31,       // compatible brand: "mp41"
+    ];
+
+    /// <summary>
+    /// Creates bytes with a valid WebM/MKV file signature (EBML header).
+    /// Only the magic bytes matter — the rest is padding since FFmpeg is mocked.
+    /// </summary>
+    private static byte[] CreateMinimalWebMBytes() =>
+    [
+        0x1A, 0x45, 0xDF, 0xA3,       // EBML header — WebM/MKV signature
+        0x93, 0x42, 0x86, 0x81,       // EBML version element
+        0x01, 0x42, 0xF7, 0x81,       // EBML read version element
+        0x01, 0x42, 0xF2, 0x81,       // padding
+    ];
+
+    #endregion
 }

--- a/TelegramGroupsAdmin.UnitTests/Utilities/MediaUtilitiesTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Utilities/MediaUtilitiesTests.cs
@@ -3,11 +3,11 @@ using TelegramGroupsAdmin.Core.Utilities;
 namespace TelegramGroupsAdmin.UnitTests.Utilities;
 
 /// <summary>
-/// Unit tests for MediaPathUtilities.ValidateMediaPath
+/// Unit tests for MediaUtilities.ValidateMediaPath
 /// Tests the static utility method directly without database dependencies
 /// </summary>
 [TestFixture]
-public class MediaPathUtilitiesTests
+public class MediaUtilitiesTests
 {
     private string _tempDir = null!;
 
@@ -15,7 +15,7 @@ public class MediaPathUtilitiesTests
     public void SetUp()
     {
         // Create a temp directory for test files
-        _tempDir = Path.Combine(Path.GetTempPath(), $"MediaPathUtilitiesTests_{Guid.NewGuid():N}");
+        _tempDir = Path.Combine(Path.GetTempPath(), $"MediaUtilitiesTests_{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
         Directory.CreateDirectory(Path.Combine(_tempDir, "media", "video"));
         Directory.CreateDirectory(Path.Combine(_tempDir, "media", "audio"));
@@ -42,7 +42,7 @@ public class MediaPathUtilitiesTests
         int? mediaType = 1; // Animation
 
         // Act
-        var result = MediaPathUtilities.ValidateMediaPath(mediaLocalPath, mediaType, _tempDir, out var fullPath);
+        var result = MediaUtilities.ValidateMediaPath(mediaLocalPath, mediaType, _tempDir, out var fullPath);
 
         using (Assert.EnterMultipleScope())
         {
@@ -60,7 +60,7 @@ public class MediaPathUtilitiesTests
         int? mediaType = 1; // Animation
 
         // Act
-        var result = MediaPathUtilities.ValidateMediaPath(mediaLocalPath, mediaType, _tempDir, out var fullPath);
+        var result = MediaUtilities.ValidateMediaPath(mediaLocalPath, mediaType, _tempDir, out var fullPath);
 
         using (Assert.EnterMultipleScope())
         {
@@ -78,7 +78,7 @@ public class MediaPathUtilitiesTests
         int? mediaType = null;
 
         // Act
-        var result = MediaPathUtilities.ValidateMediaPath(mediaLocalPath, mediaType, _tempDir, out var fullPath);
+        var result = MediaUtilities.ValidateMediaPath(mediaLocalPath, mediaType, _tempDir, out var fullPath);
 
         using (Assert.EnterMultipleScope())
         {
@@ -102,7 +102,7 @@ public class MediaPathUtilitiesTests
         int mediaType = 1; // Animation -> "video" subdirectory
 
         // Act
-        var result = MediaPathUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
+        var result = MediaUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
 
         using (Assert.EnterMultipleScope())
         {
@@ -122,7 +122,7 @@ public class MediaPathUtilitiesTests
         int mediaType = 2; // Video -> "video" subdirectory
 
         // Act
-        var result = MediaPathUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
+        var result = MediaUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
 
         using (Assert.EnterMultipleScope())
         {
@@ -143,7 +143,7 @@ public class MediaPathUtilitiesTests
         int mediaType = 3; // Audio -> "audio" subdirectory
 
         // Act
-        var result = MediaPathUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
+        var result = MediaUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
 
         using (Assert.EnterMultipleScope())
         {
@@ -165,7 +165,7 @@ public class MediaPathUtilitiesTests
         int mediaType = 1; // Animation
 
         // Act
-        var result = MediaPathUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
+        var result = MediaUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
 
         using (Assert.EnterMultipleScope())
         {
@@ -184,7 +184,7 @@ public class MediaPathUtilitiesTests
         int mediaType = 5; // Sticker -> "sticker" subdirectory
 
         // Act
-        var result = MediaPathUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
+        var result = MediaUtilities.ValidateMediaPath(filename, mediaType, _tempDir, out var fullPath);
 
         using (Assert.EnterMultipleScope())
         {
@@ -209,9 +209,152 @@ public class MediaPathUtilitiesTests
     [TestCase(99, "other", Description = "Unknown maps to other")]
     public void GetMediaSubdirectory_ReturnsCorrectSubdirectory(int mediaType, string expected)
     {
-        var result = MediaPathUtilities.GetMediaSubdirectory(mediaType);
+        var result = MediaUtilities.GetMediaSubdirectory(mediaType);
         Assert.That(result, Is.EqualTo(expected));
     }
+
+    #endregion
+
+    #region IsVideoContent - Magic Byte Detection
+
+    [Test]
+    public void IsVideoContent_Mp4FtypSignature_ReturnsTrue()
+    {
+        var path = Path.Combine(_tempDir, "test.dat");
+        File.WriteAllBytes(path, CreateMinimalMp4Bytes());
+
+        Assert.That(MediaUtilities.IsVideoContent(path), Is.True);
+    }
+
+    [Test]
+    public void IsVideoContent_WebMEbmlSignature_ReturnsTrue()
+    {
+        var path = Path.Combine(_tempDir, "test.dat");
+        File.WriteAllBytes(path, CreateMinimalWebMBytes());
+
+        Assert.That(MediaUtilities.IsVideoContent(path), Is.True);
+    }
+
+    [Test]
+    public void IsVideoContent_AviRiffSignature_ReturnsTrue()
+    {
+        var path = Path.Combine(_tempDir, "test.dat");
+        File.WriteAllBytes(path, CreateMinimalAviBytes());
+
+        Assert.That(MediaUtilities.IsVideoContent(path), Is.True);
+    }
+
+    [Test]
+    public void IsVideoContent_RealGifBytes_ReturnsFalse()
+    {
+        var path = Path.Combine(_tempDir, "test.gif");
+        File.WriteAllBytes(path,
+        [
+            0x47, 0x49, 0x46, 0x38, 0x39, 0x61, // GIF89a
+            0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00
+        ]);
+
+        Assert.That(MediaUtilities.IsVideoContent(path), Is.False);
+    }
+
+    [Test]
+    public void IsVideoContent_FileShorterThan4Bytes_ReturnsFalse()
+    {
+        var path = Path.Combine(_tempDir, "tiny.dat");
+        File.WriteAllBytes(path, [0x00, 0x01, 0x02]);
+
+        Assert.That(MediaUtilities.IsVideoContent(path), Is.False);
+    }
+
+    [Test]
+    public void IsVideoContent_EmptyFile_ReturnsFalse()
+    {
+        var path = Path.Combine(_tempDir, "empty.dat");
+        File.WriteAllBytes(path, []);
+
+        Assert.That(MediaUtilities.IsVideoContent(path), Is.False);
+    }
+
+    [Test]
+    public void IsVideoContent_NonexistentFile_ReturnsFalse()
+    {
+        var path = Path.Combine(_tempDir, "doesnotexist.dat");
+
+        Assert.That(MediaUtilities.IsVideoContent(path), Is.False);
+    }
+
+    [Test]
+    public void IsVideoContent_FtypAtWrongOffset_ReturnsFalse()
+    {
+        // "ftyp" at offset 0 instead of offset 4 — should NOT match
+        var path = Path.Combine(_tempDir, "wrong_offset.dat");
+        File.WriteAllBytes(path,
+        [
+            (byte)'f', (byte)'t', (byte)'y', (byte)'p',
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ]);
+
+        Assert.That(MediaUtilities.IsVideoContent(path), Is.False);
+    }
+
+    #endregion
+
+    #region VideoExtensions
+
+    [TestCase(".mp4")]
+    [TestCase(".webm")]
+    [TestCase(".mov")]
+    [TestCase(".avi")]
+    [TestCase(".mkv")]
+    [TestCase(".m4v")]
+    public void VideoExtensions_ContainsExpectedExtension(string ext)
+    {
+        Assert.That(MediaUtilities.VideoExtensions.Contains(ext), Is.True);
+    }
+
+    [TestCase(".gif")]
+    [TestCase(".png")]
+    [TestCase(".jpg")]
+    public void VideoExtensions_DoesNotContainImageExtensions(string ext)
+    {
+        Assert.That(MediaUtilities.VideoExtensions.Contains(ext), Is.False);
+    }
+
+    [Test]
+    public void VideoExtensions_IsCaseInsensitive()
+    {
+        Assert.That(MediaUtilities.VideoExtensions.Contains(".MP4"), Is.True);
+    }
+
+    #endregion
+
+    #region Magic Byte Helpers
+
+    private static byte[] CreateMinimalMp4Bytes() =>
+    [
+        0x00, 0x00, 0x00, 0x1C,       // box size
+        0x66, 0x74, 0x79, 0x70,       // "ftyp"
+        0x69, 0x73, 0x6F, 0x6D,       // brand: "isom"
+        0x00, 0x00, 0x02, 0x00,
+        0x69, 0x73, 0x6F, 0x6D,
+        0x69, 0x73, 0x6F, 0x32,
+        0x6D, 0x70, 0x34, 0x31,
+    ];
+
+    private static byte[] CreateMinimalWebMBytes() =>
+    [
+        0x1A, 0x45, 0xDF, 0xA3,       // EBML header
+        0x93, 0x42, 0x86, 0x81,
+        0x01, 0x42, 0xF7, 0x81,
+        0x01, 0x42, 0xF2, 0x81,
+    ];
+
+    private static byte[] CreateMinimalAviBytes() =>
+    [
+        (byte)'R', (byte)'I', (byte)'F', (byte)'F',  // "RIFF"
+        0x00, 0x00, 0x00, 0x00,                       // file size (don't care)
+        (byte)'A', (byte)'V', (byte)'I', (byte)' ',   // "AVI "
+    ];
 
     #endregion
 }

--- a/TelegramGroupsAdmin/Components/Reports/ExamReviewCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ExamReviewCard.razor
@@ -422,7 +422,7 @@
 
     private string? GetPhotoUrl(string photoPath)
     {
-        return MediaPathUtilities.GetPhotoWebPath(photoPath);
+        return MediaUtilities.GetPhotoWebPath(photoPath);
     }
 
     private async Task OnApprove()

--- a/TelegramGroupsAdmin/Components/Reports/ImpersonationAlertCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ImpersonationAlertCard.razor
@@ -330,7 +330,7 @@
 
     private string? GetPhotoUrl(string photoPath)
     {
-        return MediaPathUtilities.GetPhotoWebPath(photoPath);
+        return MediaUtilities.GetPhotoWebPath(photoPath);
     }
 
     private async Task OnConfirm()

--- a/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
@@ -43,7 +43,7 @@
 
                 @if (_message.PhotoLocalPath != null)
                 {
-                    <MudImage Src="@MediaPathUtilities.GetPhotoWebPath(_message.PhotoLocalPath)"
+                    <MudImage Src="@MediaUtilities.GetPhotoWebPath(_message.PhotoLocalPath)"
                               Alt="Reported image"
                               ObjectFit="ObjectFit.Contain"
                               Width="300"

--- a/TelegramGroupsAdmin/Components/Reports/ProfileScanAlertCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ProfileScanAlertCard.razor
@@ -227,7 +227,7 @@
     {
         _user = await TelegramUserRepository.GetByTelegramIdAsync(Alert.User.Id);
         _userPhotoUrl = _user?.UserPhotoPath != null
-            ? MediaPathUtilities.GetPhotoWebPath(_user.UserPhotoPath)
+            ? MediaUtilities.GetPhotoWebPath(_user.UserPhotoPath)
             : null;
     }
 

--- a/TelegramGroupsAdmin/Components/Shared/ImagePreviewDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ImagePreviewDialog.razor
@@ -6,7 +6,7 @@
     </TitleContent>
     <DialogContent>
         <div style="display: flex; justify-content: center; align-items: center; min-height: 200px;">
-            <img src="@MediaPathUtilities.GetPhotoWebPath(ImagePath)"
+            <img src="@MediaUtilities.GetPhotoWebPath(ImagePath)"
                  alt="@Title"
                  style="max-width: 100%; max-height: 70vh; border-radius: 8px;" />
         </div>

--- a/TelegramGroupsAdmin/Components/Shared/MessageBubbleTelegram.razor
+++ b/TelegramGroupsAdmin/Components/Shared/MessageBubbleTelegram.razor
@@ -551,7 +551,7 @@
             return string.Empty;
 
         // Use centralized utility to construct media path
-        return Core.Utilities.MediaPathUtilities.GetMediaWebPath(filename, (int)mediaType);
+        return Core.Utilities.MediaUtilities.GetMediaWebPath(filename, (int)mediaType);
     }
 
     private bool IsManuallyMarkedAsHam()

--- a/TelegramGroupsAdmin/Components/Shared/Settings/BanCelebrationSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/BanCelebrationSettings.razor
@@ -70,8 +70,8 @@
                     <div class="gif-preview-container" style="width: 100px; height: 60px; position: relative; cursor: pointer;" @onclick="@(() => PreviewGif(context))">
                         @if (!string.IsNullOrEmpty(context.ThumbnailPath))
                         {
-                            <img src="@MediaPathUtilities.GetPhotoWebPath(context.ThumbnailPath)" alt="@(context.Name ?? "GIF")" class="gif-thumbnail" style="max-height: 60px; max-width: 100px; border-radius: 4px;" />
-                            <img src="@MediaPathUtilities.GetPhotoWebPath(context.FilePath)" alt="@(context.Name ?? "GIF")" class="gif-animated" style="max-height: 60px; max-width: 100px; border-radius: 4px; position: absolute; top: 0; left: 0;" />
+                            <img src="@MediaUtilities.GetPhotoWebPath(context.ThumbnailPath)" alt="@(context.Name ?? "GIF")" class="gif-thumbnail" style="max-height: 60px; max-width: 100px; border-radius: 4px;" />
+                            <img src="@MediaUtilities.GetPhotoWebPath(context.FilePath)" alt="@(context.Name ?? "GIF")" class="gif-animated" style="max-height: 60px; max-width: 100px; border-radius: 4px; position: absolute; top: 0; left: 0;" />
                         }
                         else
                         {
@@ -200,7 +200,7 @@
                 <MudCardContent>
                     <MudStack Row="true" Spacing="4" AlignItems="AlignItems.Start">
                         <MudStack AlignItems="AlignItems.Center" Spacing="1">
-                            <img src="@MediaPathUtilities.GetPhotoWebPath(_previewGif.FilePath)" alt="@(_previewGif.Name ?? "GIF")" style="max-height: 120px; max-width: 200px; border-radius: 4px;" />
+                            <img src="@MediaUtilities.GetPhotoWebPath(_previewGif.FilePath)" alt="@(_previewGif.Name ?? "GIF")" style="max-height: 120px; max-width: 200px; border-radius: 4px;" />
                             <MudText Typo="Typo.caption" Color="Color.Secondary">@(_previewGif.Name ?? "GIF")</MudText>
                         </MudStack>
                         <MudStack Spacing="2">


### PR DESCRIPTION
## Summary

- Fix `UnknownImageFormatException` when generating thumbnails for ban celebration GIFs uploaded from Giphy/Tenor — these services serve MP4/WebM video from `.gif` URLs with misleading content types
- Add `MediaUtilities.IsVideoContent()` magic byte detection (MP4 ftyp, WebM EBML, AVI RIFF) so video content is correctly routed through FFmpeg regardless of file extension or HTTP headers
- Rename `MediaPathUtilities` → `MediaUtilities` and centralize duplicate `VideoExtensions` HashSet
- Add 50 MB download size limit to `AddFromUrlAsync` (matches file upload limit)
- Fix conversion failure path: magic-byte fallback now removes DB record and throws instead of leaving a broken entry
- Narrow `IsVideoContent` catch blocks to `IOException`/`UnauthorizedAccessException`
- Add logging to temp file cleanup catch blocks

## Test Plan

- [x] 8 unit tests for `IsVideoContent()` (MP4, WebM, AVI signatures + GIF, short file, empty file, missing file, wrong offset)
- [x] 2 unit tests for `ThumbnailService` magic byte routing (MP4-as-GIF, WebM-as-GIF)
- [x] 5 WireMock integration tests for `AddFromUrlAsync` (MP4 content-type, MP4 bytes with GIF content-type, WebM content-type, WebM bytes with GIF content-type, real GIF)
- [x] 2 integration tests for `AddFromFileAsync` magic byte detection (MP4, WebM)
- [x] `VideoExtensions` unit tests (expected extensions, non-video extensions, case insensitivity)
- [x] All 1812 unit tests pass
- [x] All 43 BanCelebrationGifRepository integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)