### PR TITLE
feat: Username blacklist - auto-ban persistent sock puppets on join

### DIFF
--- a/TelegramGroupsAdmin.ComponentTests/Components/WelcomeSystemConfigTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/WelcomeSystemConfigTests.cs
@@ -6,6 +6,7 @@ using TelegramGroupsAdmin.Components.Shared;
 using TelegramGroupsAdmin.Configuration;
 using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Configuration.Models.Welcome;
+using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Telegram.Models;
 
@@ -30,6 +31,8 @@ public class WelcomeSystemConfigTestContext : BunitContext
 
         // Register mocks
         Services.AddSingleton(ConfigService);
+        Services.AddSingleton(Substitute.For<IUsernameBlacklistRepository>());
+        Services.AddSingleton(Substitute.For<IAuditService>());
 
         // Add MudBlazor services
         Services.AddMudServices(options =>

--- a/TelegramGroupsAdmin.Configuration/Models/Welcome/JoinSecurityConfig.cs
+++ b/TelegramGroupsAdmin.Configuration/Models/Welcome/JoinSecurityConfig.cs
@@ -20,4 +20,9 @@ public class JoinSecurityConfig
     /// User API profile scanning configuration.
     /// </summary>
     public ProfileScanConfig ProfileScan { get; set; } = new();
+
+    /// <summary>
+    /// Username blacklist configuration - auto-ban users with blacklisted display names on join.
+    /// </summary>
+    public UsernameBlacklistConfig UsernameBlacklist { get; set; } = new();
 }

--- a/TelegramGroupsAdmin.Configuration/Models/Welcome/UsernameBlacklistConfig.cs
+++ b/TelegramGroupsAdmin.Configuration/Models/Welcome/UsernameBlacklistConfig.cs
@@ -1,0 +1,11 @@
+namespace TelegramGroupsAdmin.Configuration.Models.Welcome;
+
+/// <summary>
+/// Configuration for username blacklist check on join.
+/// Enabled flag only — entries are managed in a separate database table.
+/// </summary>
+public class UsernameBlacklistConfig
+{
+    /// <summary>Whether the username blacklist check is enabled</summary>
+    public bool Enabled { get; set; } = true;
+}

--- a/TelegramGroupsAdmin.Core/Models/Actor.cs
+++ b/TelegramGroupsAdmin.Core/Models/Actor.cs
@@ -53,6 +53,7 @@ public record Actor
     public static readonly Actor TempbanExpiry = FromSystem("tempban_expiry"); // Scheduled tempban expiry
     public static readonly Actor Unknown = FromSystem("unknown");
     public static readonly Actor ProfileScan = FromSystem("profile_scan");
+    public static readonly Actor UsernameBlacklist = FromSystem("username_blacklist");
     public static readonly Actor Bootstrap = FromSystem("bootstrap");
 
     /// <summary>
@@ -110,6 +111,7 @@ public record Actor
             "tempban_expiry" => "Tempban Expiry",
             "unknown" => "Unknown",
             "profile_scan" => "Profile Scan",
+            "username_blacklist" => "Username Blacklist",
             "bootstrap" => "CLI Bootstrap",
             _ => systemIdentifier
         };

--- a/TelegramGroupsAdmin.Data/AppDbContext.cs
+++ b/TelegramGroupsAdmin.Data/AppDbContext.cs
@@ -85,6 +85,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     // Profile scan results
     public DbSet<ProfileScanResultDto> ProfileScanResults => Set<ProfileScanResultDto>();
 
+    // Username blacklist
+    public DbSet<UsernameBlacklistEntryDto> UsernameBlacklistEntries => Set<UsernameBlacklistEntryDto>();
+
     // Notification tables
     public DbSet<PendingNotificationRecordDto> PendingNotifications => Set<PendingNotificationRecordDto>();
     public DbSet<PushSubscriptionDto> PushSubscriptions => Set<PushSubscriptionDto>();
@@ -512,6 +515,36 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .WithMany()
             .HasForeignKey(tl => tl.LabeledByUserId)
             .OnDelete(DeleteBehavior.SetNull);
+
+        // ============================================================================
+        // Username Blacklist Configuration
+        // Stores display name patterns that trigger auto-ban on join
+        // ============================================================================
+
+        modelBuilder.Entity<UsernameBlacklistEntryDto>(entity =>
+        {
+            entity.Property(e => e.MatchType).HasDefaultValue(0);
+
+            entity.HasOne<UserRecordDto>()
+                .WithMany()
+                .HasForeignKey(e => e.WebUserId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            entity.HasOne<TelegramUserDto>()
+                .WithMany()
+                .HasForeignKey(e => e.TelegramUserId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            entity.ToTable(t => t.HasCheckConstraint(
+                "CK_username_blacklist_exclusive_actor",
+                "(web_user_id IS NOT NULL)::int + (telegram_user_id IS NOT NULL)::int + (system_identifier IS NOT NULL)::int = 1"));
+
+            // Prevent duplicate patterns (case-insensitive, only enabled entries)
+            entity.HasIndex(e => e.Pattern)
+                .IsUnique()
+                .HasFilter("enabled = true")
+                .HasDatabaseName("IX_username_blacklist_unique_enabled_pattern");
+        });
 
     }
 

--- a/TelegramGroupsAdmin.Data/Migrations/20260321035626_AddUsernameBlacklistTable.Designer.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260321035626_AddUsernameBlacklistTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TelegramGroupsAdmin.Data;
@@ -11,9 +12,11 @@ using TelegramGroupsAdmin.Data;
 namespace TelegramGroupsAdmin.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260321035626_AddUsernameBlacklistTable")]
+    partial class AddUsernameBlacklistTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TelegramGroupsAdmin.Data/Migrations/20260321035626_AddUsernameBlacklistTable.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260321035626_AddUsernameBlacklistTable.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TelegramGroupsAdmin.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUsernameBlacklistTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "username_blacklist",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    pattern = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    match_type = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    enabled = table.Column<bool>(type: "boolean", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    web_user_id = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    telegram_user_id = table.Column<long>(type: "bigint", nullable: true),
+                    system_identifier = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    notes = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_username_blacklist", x => x.id);
+                    table.CheckConstraint("CK_username_blacklist_exclusive_actor", "(web_user_id IS NOT NULL)::int + (telegram_user_id IS NOT NULL)::int + (system_identifier IS NOT NULL)::int = 1");
+                    table.ForeignKey(
+                        name: "FK_username_blacklist_telegram_users_telegram_user_id",
+                        column: x => x.telegram_user_id,
+                        principalTable: "telegram_users",
+                        principalColumn: "telegram_user_id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_username_blacklist_users_web_user_id",
+                        column: x => x.web_user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_username_blacklist_telegram_user_id",
+                table: "username_blacklist",
+                column: "telegram_user_id");
+
+            migrationBuilder.Sql(
+                "CREATE UNIQUE INDEX \"IX_username_blacklist_unique_enabled_pattern\" " +
+                "ON username_blacklist (LOWER(pattern)) WHERE enabled = true;");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_username_blacklist_web_user_id",
+                table: "username_blacklist",
+                column: "web_user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "username_blacklist");
+        }
+    }
+}

--- a/TelegramGroupsAdmin.Data/Models/BlacklistMatchType.cs
+++ b/TelegramGroupsAdmin.Data/Models/BlacklistMatchType.cs
@@ -1,0 +1,12 @@
+namespace TelegramGroupsAdmin.Data.Models;
+
+/// <summary>
+/// How a username blacklist pattern is matched against display names.
+/// Stored as int in database for forward compatibility.
+/// </summary>
+public enum BlacklistMatchType
+{
+    /// <summary>Case-insensitive exact match against UserIdentity.DisplayName</summary>
+    Exact = 0
+    // Future: Contains = 1, Regex = 2, Fuzzy = 3
+}

--- a/TelegramGroupsAdmin.Data/Models/UsernameBlacklistEntryDto.cs
+++ b/TelegramGroupsAdmin.Data/Models/UsernameBlacklistEntryDto.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TelegramGroupsAdmin.Data.Models;
+
+/// <summary>
+/// EF Core entity for username_blacklist table.
+/// Stores display name patterns that trigger auto-ban on join.
+/// </summary>
+[Table("username_blacklist")]
+public class UsernameBlacklistEntryDto
+{
+    [Key]
+    [Column("id")]
+    public long Id { get; set; }
+
+    [Column("pattern")]
+    [Required]
+    [MaxLength(200)]
+    public string Pattern { get; set; } = string.Empty;
+
+    [Column("match_type")]
+    public int MatchType { get; set; } // BlacklistMatchType as int
+
+    [Column("enabled")]
+    public bool Enabled { get; set; } = true;
+
+    [Column("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    // Exclusive Arc actor system - exactly one must be non-null
+    [Column("web_user_id")]
+    [MaxLength(450)]
+    public string? WebUserId { get; set; }
+
+    [Column("telegram_user_id")]
+    public long? TelegramUserId { get; set; }
+
+    [Column("system_identifier")]
+    [MaxLength(50)]
+    public string? SystemIdentifier { get; set; }
+
+    [Column("notes")]
+    [MaxLength(500)]
+    public string? Notes { get; set; }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
@@ -242,7 +242,7 @@ public class BackupServiceTests
             FROM information_schema.tables
             WHERE table_schema = 'public'
             AND table_type = 'BASE TABLE'
-            AND table_name NOT IN ('__EFMigrationsHistory', 'cached_blocked_domains', 'file_scan_quota', 'file_scan_results')
+            AND table_name NOT IN ('__EFMigrationsHistory', 'cached_blocked_domains', 'file_scan_quota', 'file_scan_results', 'username_blacklist')
         ");
 
         Assert.That(metadata.TableCount, Is.EqualTo(actualTableCount),

--- a/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
@@ -170,6 +170,9 @@ public static class ServiceCollectionExtensions
             // CAS (Combot Anti-Spam) check on user join
             services.AddSingleton<ICasCheckService, CasCheckService>();
 
+            // Username blacklist check on user join
+            services.AddScoped<IUsernameBlacklistService, UsernameBlacklistService>();
+
             // Bot command system (Keyed Services pattern)
             // Commands are Scoped (to allow injecting Scoped services like BotModerationService)
             // CommandRouter is Singleton (creates scopes internally when executing commands)

--- a/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ public static class ServiceCollectionExtensions
             services.AddScoped<IPendingNotificationsRepository, PendingNotificationsRepository>(); // DM notification system
             services.AddScoped<IReportCallbackContextRepository, ReportCallbackContextRepository>(); // DM action button contexts
             services.AddScoped<ILinkedChannelsRepository, LinkedChannelsRepository>(); // Linked channel impersonation detection
+            services.AddScoped<IUsernameBlacklistRepository, UsernameBlacklistRepository>();
             // Note: IAuditLogRepository is registered in AddCoreServices() - it's a cross-cutting concern
             services.AddScoped<IMessageHistoryRepository, MessageHistoryRepository>();
             services.AddScoped<IExamSessionRepository, ExamSessionRepository>(); // Phase 2: Entrance exam state tracking

--- a/TelegramGroupsAdmin.Telegram/Models/BlacklistMatchType.cs
+++ b/TelegramGroupsAdmin.Telegram/Models/BlacklistMatchType.cs
@@ -1,4 +1,4 @@
-namespace TelegramGroupsAdmin.Data.Models;
+namespace TelegramGroupsAdmin.Telegram.Models;
 
 /// <summary>
 /// How a username blacklist pattern is matched against display names.

--- a/TelegramGroupsAdmin.Telegram/Models/UsernameBlacklistEntry.cs
+++ b/TelegramGroupsAdmin.Telegram/Models/UsernameBlacklistEntry.cs
@@ -1,0 +1,17 @@
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Data.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Models;
+
+/// <summary>
+/// Domain model for a username blacklist entry.
+/// Repos accept/return this; never expose the Dto.
+/// </summary>
+public sealed record UsernameBlacklistEntry(
+    long Id,
+    string Pattern,
+    BlacklistMatchType MatchType,
+    bool Enabled,
+    DateTimeOffset CreatedAt,
+    Actor CreatedBy,
+    string? Notes);

--- a/TelegramGroupsAdmin.Telegram/Models/UsernameBlacklistEntry.cs
+++ b/TelegramGroupsAdmin.Telegram/Models/UsernameBlacklistEntry.cs
@@ -1,5 +1,4 @@
 using TelegramGroupsAdmin.Core.Models;
-using TelegramGroupsAdmin.Data.Models;
 
 namespace TelegramGroupsAdmin.Telegram.Models;
 

--- a/TelegramGroupsAdmin.Telegram/Repositories/IUsernameBlacklistRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/IUsernameBlacklistRepository.cs
@@ -1,0 +1,14 @@
+using TelegramGroupsAdmin.Telegram.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories;
+
+public interface IUsernameBlacklistRepository
+{
+    Task<IReadOnlyList<UsernameBlacklistEntry>> GetEnabledEntriesAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<UsernameBlacklistEntry>> GetAllEntriesAsync(CancellationToken cancellationToken = default);
+    Task<long> AddEntryAsync(UsernameBlacklistEntry entry, CancellationToken cancellationToken = default);
+    Task<bool> ExistsAsync(string pattern, CancellationToken cancellationToken = default);
+    Task<bool> SetEnabledAsync(long id, bool enabled, CancellationToken cancellationToken = default);
+    Task<bool> DeleteEntryAsync(long id, CancellationToken cancellationToken = default);
+    Task<bool> UpdateNotesAsync(long id, string? notes, CancellationToken cancellationToken = default);
+}

--- a/TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameBlacklistMappings.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameBlacklistMappings.cs
@@ -1,0 +1,50 @@
+using DataModels = TelegramGroupsAdmin.Data.Models;
+using UiModels = TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Core.Repositories.Mappings;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories.Mappings;
+
+internal static class UsernameBlacklistMappings
+{
+    extension(DataModels.UsernameBlacklistEntryDto data)
+    {
+        public UiModels.UsernameBlacklistEntry ToModel(
+            string? webUserEmail = null,
+            string? telegramUsername = null,
+            string? telegramFirstName = null,
+            string? telegramLastName = null)
+        {
+            return new UiModels.UsernameBlacklistEntry(
+                Id: data.Id,
+                Pattern: data.Pattern,
+                MatchType: (DataModels.BlacklistMatchType)data.MatchType,
+                Enabled: data.Enabled,
+                CreatedAt: data.CreatedAt,
+                CreatedBy: ActorMappings.ToActor(
+                    data.WebUserId, data.TelegramUserId, data.SystemIdentifier,
+                    webUserEmail, telegramUsername, telegramFirstName, telegramLastName),
+                Notes: data.Notes);
+        }
+    }
+
+    extension(UiModels.UsernameBlacklistEntry ui)
+    {
+        public DataModels.UsernameBlacklistEntryDto ToDto()
+        {
+            ActorMappings.SetActorColumns(ui.CreatedBy, out var webUserId, out var telegramUserId, out var systemIdentifier);
+
+            return new()
+            {
+                Id = ui.Id,
+                Pattern = ui.Pattern,
+                MatchType = (int)ui.MatchType,
+                Enabled = ui.Enabled,
+                CreatedAt = ui.CreatedAt,
+                WebUserId = webUserId,
+                TelegramUserId = telegramUserId,
+                SystemIdentifier = systemIdentifier,
+                Notes = ui.Notes
+            };
+        }
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameBlacklistMappings.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameBlacklistMappings.cs
@@ -17,7 +17,7 @@ internal static class UsernameBlacklistMappings
             return new UiModels.UsernameBlacklistEntry(
                 Id: data.Id,
                 Pattern: data.Pattern,
-                MatchType: (DataModels.BlacklistMatchType)data.MatchType,
+                MatchType: (UiModels.BlacklistMatchType)data.MatchType,
                 Enabled: data.Enabled,
                 CreatedAt: data.CreatedAt,
                 CreatedBy: ActorMappings.ToActor(

--- a/TelegramGroupsAdmin.Telegram/Repositories/UsernameBlacklistRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/UsernameBlacklistRepository.cs
@@ -52,7 +52,7 @@ public class UsernameBlacklistRepository(
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
         return await context.UsernameBlacklistEntries
             .AsNoTracking()
-            .AnyAsync(e => e.Enabled && EF.Functions.ILike(e.Pattern, pattern), cancellationToken);
+            .AnyAsync(e => e.Enabled && e.Pattern.ToLower() == pattern.ToLower(), cancellationToken);
     }
 
     public async Task<bool> SetEnabledAsync(long id, bool enabled,

--- a/TelegramGroupsAdmin.Telegram/Repositories/UsernameBlacklistRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/UsernameBlacklistRepository.cs
@@ -1,0 +1,86 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories.Mappings;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories;
+
+public class UsernameBlacklistRepository(
+    IDbContextFactory<AppDbContext> contextFactory,
+    ILogger<UsernameBlacklistRepository> logger) : IUsernameBlacklistRepository
+{
+    public async Task<IReadOnlyList<UsernameBlacklistEntry>> GetEnabledEntriesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        var dtos = await context.UsernameBlacklistEntries
+            .AsNoTracking()
+            .Where(e => e.Enabled)
+            .OrderBy(e => e.Pattern)
+            .ToListAsync(cancellationToken);
+
+        return dtos.Select(d => d.ToModel()).ToList();
+    }
+
+    public async Task<IReadOnlyList<UsernameBlacklistEntry>> GetAllEntriesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        var dtos = await context.UsernameBlacklistEntries
+            .AsNoTracking()
+            .OrderByDescending(e => e.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        return dtos.Select(d => d.ToModel()).ToList();
+    }
+
+    public async Task<long> AddEntryAsync(UsernameBlacklistEntry entry,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        var dto = entry.ToDto();
+        context.UsernameBlacklistEntries.Add(dto);
+        await context.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Added username blacklist entry: {Pattern} (ID: {Id})", entry.Pattern, dto.Id);
+        return dto.Id;
+    }
+
+    public async Task<bool> ExistsAsync(string pattern, CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        return await context.UsernameBlacklistEntries
+            .AsNoTracking()
+            .AnyAsync(e => e.Enabled && EF.Functions.ILike(e.Pattern, pattern), cancellationToken);
+    }
+
+    public async Task<bool> SetEnabledAsync(long id, bool enabled,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        var rows = await context.UsernameBlacklistEntries
+            .Where(e => e.Id == id)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.Enabled, enabled), cancellationToken);
+        return rows > 0;
+    }
+
+    public async Task<bool> DeleteEntryAsync(long id, CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        var rows = await context.UsernameBlacklistEntries
+            .Where(e => e.Id == id)
+            .ExecuteDeleteAsync(cancellationToken);
+        return rows > 0;
+    }
+
+    public async Task<bool> UpdateNotesAsync(long id, string? notes,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        var rows = await context.UsernameBlacklistEntries
+            .Where(e => e.Id == id)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.Notes, notes), cancellationToken);
+        return rows > 0;
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Services/IUsernameBlacklistService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/IUsernameBlacklistService.cs
@@ -1,0 +1,19 @@
+using TelegramGroupsAdmin.Telegram.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Services;
+
+/// <summary>
+/// Checks user display names against the username blacklist.
+/// Designed behind an interface so the same matching logic can be
+/// reused in the content detection pipeline later.
+/// </summary>
+public interface IUsernameBlacklistService
+{
+    /// <summary>
+    /// Check if a display name matches any enabled blacklist entry.
+    /// Returns the matched entry or null if no match.
+    /// </summary>
+    Task<UsernameBlacklistEntry?> CheckDisplayNameAsync(
+        string displayName,
+        CancellationToken cancellationToken = default);
+}

--- a/TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs
@@ -1,0 +1,40 @@
+using TelegramGroupsAdmin.Data.Models;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+
+namespace TelegramGroupsAdmin.Telegram.Services;
+
+public class UsernameBlacklistService(
+    IUsernameBlacklistRepository repository) : IUsernameBlacklistService
+{
+    public async Task<UsernameBlacklistEntry?> CheckDisplayNameAsync(
+        string displayName,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+            return null;
+
+        // Don't match fallback display names like "User 12345" or "Unknown User"
+        if (displayName.StartsWith("User ", StringComparison.Ordinal) ||
+            displayName == "Unknown User")
+            return null;
+
+        var entries = await repository.GetEnabledEntriesAsync(cancellationToken);
+
+        foreach (var entry in entries)
+        {
+            var isMatch = entry.MatchType switch
+            {
+                BlacklistMatchType.Exact =>
+                    string.Equals(displayName, entry.Pattern, StringComparison.OrdinalIgnoreCase),
+                // Future match types go here
+                _ => false
+            };
+
+            if (isMatch)
+                return entry;
+        }
+
+        return null;
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs
@@ -1,4 +1,3 @@
-using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
 

--- a/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
@@ -37,6 +37,7 @@ public class WelcomeService(
     IBotModerationService moderationService,
     IJobScheduler jobScheduler,
     ICasCheckService casCheckService,
+    IUsernameBlacklistService usernameBlacklistService,
     TelegramPhotoService photoService,
     IProfileScanService profileScanService,
     ITelegramSessionManager sessionManager,
@@ -169,11 +170,51 @@ public class WelcomeService(
 
             // ═══════════════════════════════════════════════════════════════════
             // SECURITY CHECKS (always run regardless of config.Enabled)
-            // Order: CAS (fail fast) → Photo fetch → Impersonation → Profile scan
+            // Order: Username blacklist (instant) → CAS (fail fast) → Photo fetch → Impersonation → Profile scan
             // Trusted users skip CAS + profile scan (trust is global)
             // ═══════════════════════════════════════════════════════════════════
 
-            // Step 5: CAS (Combot Anti-Spam) check - auto-ban known spammers FIRST (fail fast)
+            // Step 5: Username blacklist check - auto-ban blacklisted display names FIRST (instant, local DB)
+            // Skip trusted users — trust is global, applied across all groups
+            if (config.JoinSecurity.UsernameBlacklist.Enabled && existingUser?.IsTrusted != true)
+            {
+                var userIdentity = UserIdentity.From(user);
+                var blacklistMatch = await usernameBlacklistService.CheckDisplayNameAsync(
+                    userIdentity.DisplayName, cancellationToken);
+
+                if (blacklistMatch != null)
+                {
+                    logger.LogWarning(
+                        "Username blacklist match: {User} in {Chat} (pattern: {Pattern})",
+                        user.ToLogInfo(),
+                        chatMemberUpdate.Chat.ToLogInfo(),
+                        blacklistMatch.Pattern);
+
+                    // Delete verifying message before ban
+                    await TryDeleteMessageAsync(chatMemberUpdate.Chat.Id, verifyingMessageId.Value, cancellationToken);
+
+                    await moderationService.BanUserAsync(
+                        new BanIntent
+                        {
+                            User = userIdentity,
+                            Executor = Actor.UsernameBlacklist,
+                            Reason = $"Username blacklisted: {blacklistMatch.Pattern}",
+                            Chat = ChatIdentity.From(chatMemberUpdate.Chat)
+                        },
+                        cancellationToken);
+
+                    logger.LogInformation(
+                        "{User} auto-banned (username blacklist), skipping welcome flow",
+                        user.ToLogInfo());
+                    return;
+                }
+            }
+            else
+            {
+                logger.LogDebug("Username blacklist check skipped for {User}", user.ToLogDebug());
+            }
+
+            // Step 6: CAS (Combot Anti-Spam) check - auto-ban known spammers FIRST (fail fast)
             // Skip trusted users — trust is global, applied across all groups
             if (config.JoinSecurity.Cas.Enabled && existingUser?.IsTrusted != true)
             {
@@ -212,7 +253,7 @@ public class WelcomeService(
                 logger.LogDebug("CAS check disabled, skipping for {User}", user.ToLogDebug());
             }
 
-            // Step 6: Photo fetch (sync, ~1.8s) - enables full impersonation detection
+            // Step 7: Photo fetch (sync, ~1.8s) - enables full impersonation detection
             string? userPhotoPath = existingUser?.UserPhotoPath;
             var photoResult = await photoService.GetUserPhotoWithMetadataAsync(
                 user.Id,
@@ -237,7 +278,7 @@ public class WelcomeService(
                     photoResult.RelativePath);
             }
 
-            // Step 7: Impersonation detection (now has photo for full capability)
+            // Step 8: Impersonation detection (now has photo for full capability)
             if (config.JoinSecurity.Impersonation.Enabled)
             {
                 var shouldCheck = await impersonationDetectionService.ShouldCheckUserAsync(user.Id, chatMemberUpdate.Chat.Id);
@@ -291,7 +332,7 @@ public class WelcomeService(
                 logger.LogDebug("Impersonation detection disabled, skipping for {User}", user.ToLogDebug());
             }
 
-            // Step 8: Profile scan via User API (skip trusted users)
+            // Step 9: Profile scan via User API (skip trusted users)
             if (config.JoinSecurity.ProfileScan.Enabled
                 && config.JoinSecurity.ProfileScan.ScanOnJoin
                 && existingUser?.IsTrusted != true)
@@ -416,7 +457,7 @@ public class WelcomeService(
                 chatMemberUpdate.Chat.ToLogDebug(),
                 config.Mode);
 
-            // Step 8: Create welcome response record (pending state)
+            // Step 10: Create welcome response record (pending state)
             var welcomeResponse = new WelcomeResponse(
                 Id: 0, // Will be set by database
                 ChatId: chatMemberUpdate.Chat.Id,
@@ -433,7 +474,7 @@ public class WelcomeService(
 
             var responseId = await welcomeResponsesRepository.InsertAsync(welcomeResponse, cancellationToken);
 
-            // Step 9: Schedule timeout via Quartz.NET
+            // Step 11: Schedule timeout via Quartz.NET
             var payload = new WelcomeTimeoutPayload(
                 UserIdentity.From(user),
                 ChatIdentity.From(chatMemberUpdate.Chat),

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceTests.cs
@@ -1,0 +1,123 @@
+using NSubstitute;
+using TelegramGroupsAdmin.Data.Models;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services;
+
+[TestFixture]
+public class UsernameBlacklistServiceTests
+{
+    private IUsernameBlacklistRepository _repository = null!;
+    private UsernameBlacklistService _sut = null!;
+
+    private static readonly Actor TestActor = Actor.FromSystem("test");
+
+    private static UsernameBlacklistEntry MakeEntry(string pattern,
+        BlacklistMatchType matchType = BlacklistMatchType.Exact,
+        bool enabled = true) =>
+        new(Id: 1, Pattern: pattern, MatchType: matchType,
+            Enabled: enabled, CreatedAt: DateTimeOffset.UtcNow,
+            CreatedBy: TestActor, Notes: null);
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = Substitute.For<IUsernameBlacklistRepository>();
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry>());
+        _sut = new UsernameBlacklistService(_repository);
+    }
+
+    [Test]
+    public async Task CheckDisplayName_NoEntries_ReturnsNull()
+    {
+        var result = await _sut.CheckDisplayNameAsync("Scarlett Lux");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckDisplayName_ExactMatch_ReturnsEntry()
+    {
+        var entry = MakeEntry("Scarlett Lux");
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry> { entry });
+
+        var result = await _sut.CheckDisplayNameAsync("Scarlett Lux");
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Pattern, Is.EqualTo("Scarlett Lux"));
+    }
+
+    [Test]
+    public async Task CheckDisplayName_CaseInsensitive_Matches()
+    {
+        var entry = MakeEntry("Scarlett Lux");
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry> { entry });
+
+        var result = await _sut.CheckDisplayNameAsync("scarlett lux");
+        Assert.That(result, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task CheckDisplayName_DifferentName_ReturnsNull()
+    {
+        var entry = MakeEntry("Scarlett Lux");
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry> { entry });
+
+        var result = await _sut.CheckDisplayNameAsync("John Smith");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckDisplayName_PartialMatch_DoesNotMatchForExactType()
+    {
+        var entry = MakeEntry("Scarlett");
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry> { entry });
+
+        var result = await _sut.CheckDisplayNameAsync("Scarlett Lux");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckDisplayName_MultipleEntries_ReturnsFirstMatch()
+    {
+        var entries = new List<UsernameBlacklistEntry>
+        {
+            MakeEntry("John Doe"),
+            MakeEntry("Scarlett Lux"),
+        };
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(entries);
+
+        var result = await _sut.CheckDisplayNameAsync("Scarlett Lux");
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Pattern, Is.EqualTo("Scarlett Lux"));
+    }
+
+    [Test]
+    public async Task CheckDisplayName_EmptyDisplayName_ReturnsNull()
+    {
+        var entry = MakeEntry("Scarlett Lux");
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry> { entry });
+
+        var result = await _sut.CheckDisplayNameAsync("");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckDisplayName_FallbackDisplayName_UserPrefix_ReturnsNull()
+    {
+        var entry = MakeEntry("User 12345");
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry> { entry });
+
+        var result = await _sut.CheckDisplayNameAsync("User 12345");
+        Assert.That(result, Is.Null);
+    }
+}

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceTests.cs
@@ -1,5 +1,4 @@
 using NSubstitute;
-using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
@@ -118,6 +117,28 @@ public class UsernameBlacklistServiceTests
             .Returns(new List<UsernameBlacklistEntry> { entry });
 
         var result = await _sut.CheckDisplayNameAsync("User 12345");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckDisplayName_UnknownUser_ReturnsNull()
+    {
+        var entry = MakeEntry("Unknown User");
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry> { entry });
+
+        var result = await _sut.CheckDisplayNameAsync("Unknown User");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task CheckDisplayName_WhitespaceOnly_ReturnsNull()
+    {
+        var entry = MakeEntry("Scarlett Lux");
+        _repository.GetEnabledEntriesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameBlacklistEntry> { entry });
+
+        var result = await _sut.CheckDisplayNameAsync("   ");
         Assert.That(result, Is.Null);
     }
 }

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceBlacklistTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceBlacklistTests.cs
@@ -1,0 +1,405 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using global::Telegram.Bot.Types;
+using global::Telegram.Bot.Types.Enums;
+using global::Telegram.Bot.Types.ReplyMarkups;
+using TelegramGroupsAdmin.Configuration;
+using TelegramGroupsAdmin.Configuration.Models.Welcome;
+using TelegramGroupsAdmin.Core.BackgroundJobs;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Services;
+using TelegramGroupsAdmin.Data.Models;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
+using TelegramGroupsAdmin.Telegram.Services.Bot;
+using TelegramGroupsAdmin.Telegram.Services.Moderation;
+using TelegramGroupsAdmin.Telegram.Services.UserApi;
+using TelegramGroupsAdmin.Telegram.Services.Welcome;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services;
+
+/// <summary>
+/// Tests for username blacklist integration within WelcomeService.HandleChatMemberUpdateAsync.
+///
+/// Verifies that:
+/// - Blacklisted users are banned and short-circuit before CAS check
+/// - Non-blacklisted users proceed to CAS as normal
+/// - Trusted users skip the blacklist check entirely
+/// - Disabled blacklist config skips the check entirely
+/// </summary>
+[TestFixture]
+public class WelcomeServiceBlacklistTests
+{
+    private const long TestUserId = 111_222_333L;
+    private const long TestChatId = -100_987_654_321L;
+
+    // --- Substituted dependencies ---
+    private IConfigService _configService = null!;
+    private IWelcomeResponsesRepository _welcomeResponsesRepository = null!;
+    private ITelegramUserRepository _telegramUserRepository = null!;
+    private IExamFlowService _examFlowService = null!;
+    private IImpersonationDetectionService _impersonationDetectionService = null!;
+    private IBotProtectionService _botProtectionService = null!;
+    private IBotDmService _dmDeliveryService = null!;
+    private IBotMessageService _messageService = null!;
+    private IBotUserService _userService = null!;
+    private IBotChatService _chatService = null!;
+    private IBotModerationService _moderationService = null!;
+    private IJobScheduler _jobScheduler = null!;
+    private ICasCheckService _casCheckService = null!;
+    private IProfileScanService _profileScanService = null!;
+    private ITelegramSessionManager _sessionManager = null!;
+    private IWelcomeAdmissionHandler _admissionHandler = null!;
+    private IUsernameBlacklistService _usernameBlacklistService = null!;
+
+    // TelegramPhotoService is concrete — built with mocked sub-dependencies.
+    private TelegramPhotoService _photoService = null!;
+
+    private WelcomeService _sut = null!;
+
+    // Reusable test user (not a bot, not an admin)
+    private static readonly User TestUser = new()
+    {
+        Id = TestUserId,
+        FirstName = "Scarlett",
+        LastName = "Lux",
+        Username = "scarlett_lux",
+        IsBot = false
+    };
+
+    private static readonly TelegramUser NonBannedTelegramUser = new(
+        TelegramUserId: TestUserId,
+        Username: "scarlett_lux",
+        FirstName: "Scarlett",
+        LastName: "Lux",
+        UserPhotoPath: null,
+        PhotoHash: null,
+        PhotoFileUniqueId: null,
+        IsBot: false,
+        IsTrusted: false,
+        IsBanned: false,
+        KickCount: 0,
+        BotDmEnabled: false,
+        FirstSeenAt: DateTimeOffset.UtcNow.AddDays(-1),
+        LastSeenAt: DateTimeOffset.UtcNow,
+        CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
+        UpdatedAt: DateTimeOffset.UtcNow
+    );
+
+    private static readonly TelegramUser TrustedTelegramUser = NonBannedTelegramUser with { IsTrusted = true };
+
+    [SetUp]
+    public void SetUp()
+    {
+        _configService = Substitute.For<IConfigService>();
+        _welcomeResponsesRepository = Substitute.For<IWelcomeResponsesRepository>();
+        _telegramUserRepository = Substitute.For<ITelegramUserRepository>();
+        _examFlowService = Substitute.For<IExamFlowService>();
+        _impersonationDetectionService = Substitute.For<IImpersonationDetectionService>();
+        _botProtectionService = Substitute.For<IBotProtectionService>();
+        _dmDeliveryService = Substitute.For<IBotDmService>();
+        _messageService = Substitute.For<IBotMessageService>();
+        _userService = Substitute.For<IBotUserService>();
+        _chatService = Substitute.For<IBotChatService>();
+        _moderationService = Substitute.For<IBotModerationService>();
+        _jobScheduler = Substitute.For<IJobScheduler>();
+        _casCheckService = Substitute.For<ICasCheckService>();
+        _profileScanService = Substitute.For<IProfileScanService>();
+        _sessionManager = Substitute.For<ITelegramSessionManager>();
+        _admissionHandler = Substitute.For<IWelcomeAdmissionHandler>();
+        _usernameBlacklistService = Substitute.For<IUsernameBlacklistService>();
+
+        // Build TelegramPhotoService with mocked sub-dependencies so it never touches the real
+        // file system. GetUserPhotoWithMetadataAsync calls IBotMediaService, which is mocked to
+        // return zero photos, causing the method to return null immediately.
+        var mockMediaService = Substitute.For<IBotMediaService>();
+        var mockChatServiceForPhoto = Substitute.For<IBotChatService>();
+        var mockAppOptions = Microsoft.Extensions.Options.Options.Create(
+            new AppOptions { DataPath = System.IO.Path.GetTempPath() });
+        _photoService = new TelegramPhotoService(
+            NullLogger<TelegramPhotoService>.Instance,
+            mockMediaService,
+            mockChatServiceForPhoto,
+            mockAppOptions);
+
+        // --- Default mock behaviours ---
+
+        // Config always returns WelcomeConfig.Default (enabled, ChatAcceptDeny mode)
+        _configService
+            .GetEffectiveAsync<WelcomeConfig>(ConfigType.Welcome, Arg.Any<long>())
+            .Returns(WelcomeConfig.Default);
+
+        // User is a regular member (not admin) by default
+        _userService
+            .GetChatMemberAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(new ChatMemberMember { User = TestUser });
+
+        // User exists and is not banned
+        _telegramUserRepository
+            .GetOrCreateAsync(
+                Arg.Any<long>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(NonBannedTelegramUser);
+
+        // Bot protection allows bots by default
+        _botProtectionService
+            .ShouldAllowBotAsync(Arg.Any<Chat>(), Arg.Any<User>(), Arg.Any<ChatMemberUpdated?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Mute (RestrictUserAsync) succeeds
+        _moderationService
+            .RestrictUserAsync(Arg.Any<RestrictIntent>(), Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true });
+
+        // SyncBanToChatAsync succeeds
+        _moderationService
+            .SyncBanToChatAsync(Arg.Any<SyncBanIntent>(), Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true });
+
+        // BanUserAsync succeeds
+        _moderationService
+            .BanUserAsync(Arg.Any<BanIntent>(), Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true });
+
+        // SendAndSaveMessageAsync returns a minimal Message so verifyingMessageId is set
+        _messageService
+            .SendAndSaveMessageAsync(
+                Arg.Any<long>(), Arg.Any<string>(),
+                Arg.Any<ParseMode?>(),
+                Arg.Any<ReplyParameters?>(),
+                Arg.Any<InlineKeyboardMarkup?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new Message { Id = 42, Chat = new Chat { Id = TestChatId } });
+
+        // IBotMediaService returns zero photos (photo service returns null immediately)
+        mockMediaService
+            .GetUserProfilePhotosAsync(Arg.Any<long>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new UserProfilePhotos { TotalCount = 0, Photos = [] });
+
+        // Username blacklist returns no match by default
+        _usernameBlacklistService
+            .CheckDisplayNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((UsernameBlacklistEntry?)null);
+
+        // CAS returns not banned by default
+        _casCheckService
+            .CheckUserAsync(Arg.Any<long>(), Arg.Any<CasConfig>(), Arg.Any<CancellationToken>())
+            .Returns(new CasCheckResult(IsBanned: false, Reason: null));
+
+        _sut = new WelcomeService(
+            _configService,
+            _welcomeResponsesRepository,
+            _telegramUserRepository,
+            _examFlowService,
+            _impersonationDetectionService,
+            _botProtectionService,
+            _dmDeliveryService,
+            _messageService,
+            _userService,
+            _chatService,
+            _moderationService,
+            _jobScheduler,
+            _casCheckService,
+            _usernameBlacklistService,
+            _photoService,
+            _profileScanService,
+            _sessionManager,
+            _admissionHandler,
+            NullLogger<WelcomeService>.Instance);
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await _sessionManager.DisposeAsync();
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Creates a ChatMemberUpdated representing a status transition.
+    /// Defaults to the standard join scenario: Left → Member.
+    /// </summary>
+    private static ChatMemberUpdated CreateJoinUpdate(
+        User? user = null,
+        Chat? chat = null,
+        ChatMemberStatus oldStatus = ChatMemberStatus.Left,
+        ChatMemberStatus newStatus = ChatMemberStatus.Member)
+    {
+        var resolvedUser = user ?? TestUser;
+        var resolvedChat = chat ?? new Chat
+        {
+            Id = TestChatId,
+            Type = ChatType.Supergroup,
+            Title = "Test Group"
+        };
+
+        ChatMember oldMember = oldStatus switch
+        {
+            ChatMemberStatus.Member     => new ChatMemberMember     { User = resolvedUser },
+            ChatMemberStatus.Restricted => new ChatMemberRestricted { User = resolvedUser },
+            ChatMemberStatus.Left       => new ChatMemberLeft       { User = resolvedUser },
+            ChatMemberStatus.Kicked     => new ChatMemberBanned     { User = resolvedUser },
+            ChatMemberStatus.Administrator => new ChatMemberAdministrator { User = resolvedUser },
+            ChatMemberStatus.Creator    => new ChatMemberOwner      { User = resolvedUser },
+            _                           => new ChatMemberLeft       { User = resolvedUser }
+        };
+
+        ChatMember newMember = newStatus switch
+        {
+            ChatMemberStatus.Member     => new ChatMemberMember     { User = resolvedUser },
+            ChatMemberStatus.Restricted => new ChatMemberRestricted { User = resolvedUser },
+            ChatMemberStatus.Left       => new ChatMemberLeft       { User = resolvedUser },
+            ChatMemberStatus.Kicked     => new ChatMemberBanned     { User = resolvedUser },
+            ChatMemberStatus.Administrator => new ChatMemberAdministrator { User = resolvedUser },
+            ChatMemberStatus.Creator    => new ChatMemberOwner      { User = resolvedUser },
+            _                           => new ChatMemberMember     { User = resolvedUser }
+        };
+
+        return new ChatMemberUpdated
+        {
+            Chat = resolvedChat,
+            From = resolvedUser,
+            Date = DateTime.UtcNow,
+            OldChatMember = oldMember,
+            NewChatMember = newMember
+        };
+    }
+
+    #endregion
+
+    #region Test 1: Blacklisted user — ban and return early (before CAS)
+
+    [Test]
+    public async Task HandleChatMemberUpdate_BlacklistedUser_BansAndReturnsEarly()
+    {
+        // Arrange — blacklist service returns a matched entry
+        var matchedEntry = new UsernameBlacklistEntry(
+            Id: 1,
+            Pattern: "Scarlett Lux",
+            MatchType: BlacklistMatchType.Exact,
+            Enabled: true,
+            CreatedAt: DateTimeOffset.UtcNow,
+            CreatedBy: Actor.FromSystem("test"),
+            Notes: null);
+
+        _usernameBlacklistService
+            .CheckDisplayNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(matchedEntry);
+
+        var update = CreateJoinUpdate();
+
+        // Act
+        await _sut.HandleChatMemberUpdateAsync(update, CancellationToken.None);
+
+        // Assert — BanUserAsync must be called with reason containing the pattern
+        await _moderationService.Received(1).BanUserAsync(
+            Arg.Is<BanIntent>(i =>
+                i.User.Id == TestUserId &&
+                i.Reason.Contains("Scarlett Lux")),
+            Arg.Any<CancellationToken>());
+
+        // Early-exit: CAS check must NOT be called (short-circuited by blacklist)
+        await _casCheckService.DidNotReceive().CheckUserAsync(
+            Arg.Any<long>(),
+            Arg.Any<CasConfig>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Test 2: Not blacklisted — proceeds to CAS
+
+    [Test]
+    public async Task HandleChatMemberUpdate_NotBlacklisted_ProceedsToCas()
+    {
+        // Arrange — blacklist returns null (no match), CAS returns not banned
+        _usernameBlacklistService
+            .CheckDisplayNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((UsernameBlacklistEntry?)null);
+
+        _casCheckService
+            .CheckUserAsync(Arg.Any<long>(), Arg.Any<CasConfig>(), Arg.Any<CancellationToken>())
+            .Returns(new CasCheckResult(IsBanned: false, Reason: null));
+
+        var update = CreateJoinUpdate();
+
+        // Act
+        await _sut.HandleChatMemberUpdateAsync(update, CancellationToken.None);
+
+        // Assert — blacklist was consulted
+        await _usernameBlacklistService.Received(1).CheckDisplayNameAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        // CAS was called (blacklist didn't short-circuit)
+        await _casCheckService.Received(1).CheckUserAsync(
+            Arg.Any<long>(),
+            Arg.Any<CasConfig>(),
+            Arg.Any<CancellationToken>());
+
+        // Ban was NOT called (neither blacklist nor CAS triggered)
+        await _moderationService.DidNotReceive().BanUserAsync(
+            Arg.Any<BanIntent>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Test 3: Trusted user — skips blacklist check
+
+    [Test]
+    public async Task HandleChatMemberUpdate_TrustedUser_SkipsBlacklistCheck()
+    {
+        // Arrange — repository returns a trusted user
+        _telegramUserRepository
+            .GetOrCreateAsync(
+                Arg.Any<long>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(TrustedTelegramUser);
+
+        var update = CreateJoinUpdate();
+
+        // Act
+        await _sut.HandleChatMemberUpdateAsync(update, CancellationToken.None);
+
+        // Assert — blacklist check must NOT be called (trusted users skip it)
+        await _usernameBlacklistService.DidNotReceive().CheckDisplayNameAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region Test 4: Blacklist disabled — skips check
+
+    [Test]
+    public async Task HandleChatMemberUpdate_BlacklistDisabled_SkipsCheck()
+    {
+        // Arrange — override config to disable username blacklist
+        var configWithBlacklistDisabled = new WelcomeConfig
+        {
+            Enabled = true,
+            Mode = WelcomeMode.ChatAcceptDeny,
+            TimeoutSeconds = 60,
+            JoinSecurity = new JoinSecurityConfig
+            {
+                UsernameBlacklist = new UsernameBlacklistConfig { Enabled = false },
+                Cas = new CasConfig { Enabled = false }
+            }
+        };
+
+        _configService
+            .GetEffectiveAsync<WelcomeConfig>(ConfigType.Welcome, Arg.Any<long>())
+            .Returns(configWithBlacklistDisabled);
+
+        var update = CreateJoinUpdate();
+
+        // Act
+        await _sut.HandleChatMemberUpdateAsync(update, CancellationToken.None);
+
+        // Assert — blacklist check must NOT be called (disabled in config)
+        await _usernameBlacklistService.DidNotReceive().CheckDisplayNameAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceBlacklistTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceBlacklistTests.cs
@@ -8,7 +8,6 @@ using TelegramGroupsAdmin.Configuration.Models.Welcome;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Services;
-using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services;
@@ -293,11 +292,12 @@ public class WelcomeServiceBlacklistTests
         // Act
         await _sut.HandleChatMemberUpdateAsync(update, CancellationToken.None);
 
-        // Assert — BanUserAsync must be called with reason containing the pattern
+        // Assert — BanUserAsync must be called with reason containing the pattern and correct executor
         await _moderationService.Received(1).BanUserAsync(
-            Arg.Is<BanIntent>(i =>
-                i.User.Id == TestUserId &&
-                i.Reason.Contains("Scarlett Lux")),
+            Arg.Is<BanIntent>(b =>
+                b.User.Id == TestUserId &&
+                b.Reason.Contains("Scarlett Lux") &&
+                b.Executor == Actor.UsernameBlacklist),
             Arg.Any<CancellationToken>());
 
         // Early-exit: CAS check must NOT be called (short-circuited by blacklist)

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceTests.cs
@@ -52,6 +52,7 @@ public class WelcomeServiceTests
     private IProfileScanService _profileScanService = null!;
     private ITelegramSessionManager _sessionManager = null!;
     private IWelcomeAdmissionHandler _admissionHandler = null!;
+    private IUsernameBlacklistService _usernameBlacklistService = null!;
 
     // TelegramPhotoService is concrete — built with mocked sub-dependencies.
     private TelegramPhotoService _photoService = null!;
@@ -107,6 +108,7 @@ public class WelcomeServiceTests
         _profileScanService = Substitute.For<IProfileScanService>();
         _sessionManager = Substitute.For<ITelegramSessionManager>();
         _admissionHandler = Substitute.For<IWelcomeAdmissionHandler>();
+        _usernameBlacklistService = Substitute.For<IUsernameBlacklistService>();
 
         // Build TelegramPhotoService with mocked sub-dependencies so it never touches the real
         // file system. GetUserPhotoWithMetadataAsync calls IBotMediaService, which is mocked to
@@ -184,6 +186,7 @@ public class WelcomeServiceTests
             _moderationService,
             _jobScheduler,
             _casCheckService,
+            _usernameBlacklistService,
             _photoService,
             _profileScanService,
             _sessionManager,

--- a/TelegramGroupsAdmin/Components/Shared/Settings/AddBlacklistEntryData.cs
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/AddBlacklistEntryData.cs
@@ -1,0 +1,3 @@
+namespace TelegramGroupsAdmin.Components.Shared.Settings;
+
+public sealed record AddBlacklistEntryData(string Pattern, string? Notes);

--- a/TelegramGroupsAdmin/Components/Shared/Settings/AddBlacklistEntryDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/AddBlacklistEntryDialog.razor
@@ -1,0 +1,39 @@
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">Add Blacklist Entry</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudTextField @bind-Value="_pattern"
+                      Label="Display Name Pattern"
+                      HelperText="Exact display name to blacklist (case-insensitive)"
+                      Required="true"
+                      RequiredError="Pattern is required"
+                      Immediate="true" />
+        <MudTextField @bind-Value="_notes"
+                      Label="Notes (optional)"
+                      HelperText="Reason for blacklisting"
+                      Class="mt-3" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                   OnClick="Submit"
+                   Disabled="@(string.IsNullOrWhiteSpace(_pattern))">
+            Add
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    private string _pattern = string.Empty;
+    private string? _notes;
+
+    private void Submit() => MudDialog.Close(DialogResult.Ok(
+        new AddBlacklistEntryData(_pattern.Trim(), _notes?.Trim())));
+
+    private void Cancel() => MudDialog.Cancel();
+}
+
+public sealed record AddBlacklistEntryData(string Pattern, string? Notes);

--- a/TelegramGroupsAdmin/Components/Shared/Settings/AddBlacklistEntryDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/AddBlacklistEntryDialog.razor
@@ -35,5 +35,3 @@
 
     private void Cancel() => MudDialog.Cancel();
 }
-
-public sealed record AddBlacklistEntryData(string Pattern, string? Notes);

--- a/TelegramGroupsAdmin/Components/Shared/Settings/UsernameBlacklistSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/UsernameBlacklistSettings.razor
@@ -8,6 +8,7 @@
                Color="Color.Primary"
                Size="Size.Small"
                StartIcon="@Icons.Material.Filled.Add"
+               Disabled="@_busy"
                OnClick="@AddEntry">
         Add Entry
     </MudButton>
@@ -81,8 +82,11 @@
 </MudTable>
 
 @code {
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+
     private IReadOnlyList<UsernameBlacklistEntry> _entries = [];
     private bool _loading = true;
+    private bool _busy;
 
     protected override async Task OnInitializedAsync()
     {
@@ -108,12 +112,14 @@
 
     private async Task AddEntry()
     {
-        var dialog = await DialogService.ShowAsync<AddBlacklistEntryDialog>("Add Blacklist Entry");
-        var result = await dialog.Result;
-
-        if (result is { Canceled: false, Data: AddBlacklistEntryData data })
+        if (_busy) return;
+        _busy = true;
+        try
         {
-            try
+            var dialog = await DialogService.ShowAsync<AddBlacklistEntryDialog>("Add Blacklist Entry");
+            var result = await dialog.Result;
+
+            if (result is { Canceled: false, Data: AddBlacklistEntryData data })
             {
                 if (await BlacklistRepository.ExistsAsync(data.Pattern))
                 {
@@ -124,20 +130,24 @@
                 var entry = new UsernameBlacklistEntry(
                     Id: 0,
                     Pattern: data.Pattern,
-                    MatchType: DataModels.BlacklistMatchType.Exact,
+                    MatchType: BlacklistMatchType.Exact,
                     Enabled: true,
                     CreatedAt: DateTimeOffset.UtcNow,
-                    CreatedBy: Actor.FromSystem("web_admin"),
+                    CreatedBy: WebUser!.ToActor(),
                     Notes: data.Notes);
 
                 await BlacklistRepository.AddEntryAsync(entry);
                 Snackbar.Add($"Blacklisted \"{data.Pattern}\"", Severity.Success);
                 await LoadEntries();
             }
-            catch (Exception ex)
-            {
-                Snackbar.Add($"Error adding entry: {ex.Message}", Severity.Error);
-            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error adding entry: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _busy = false;
         }
     }
 
@@ -146,7 +156,12 @@
         var newState = !entry.Enabled;
         if (await BlacklistRepository.SetEnabledAsync(entry.Id, enabled: newState))
         {
-            Snackbar.Add($"{(newState ? "Enabled" : "Disabled")} \"{entry.Pattern}\"", Severity.Info);
+            Snackbar.Add($"{(newState ? "Enabled" : "Disabled")} \"{entry.Pattern}\"", Severity.Success);
+            await LoadEntries();
+        }
+        else
+        {
+            Snackbar.Add("Entry not found — it may have been deleted", Severity.Warning);
             await LoadEntries();
         }
     }
@@ -164,6 +179,11 @@
             if (await BlacklistRepository.DeleteEntryAsync(entry.Id))
             {
                 Snackbar.Add($"Deleted \"{entry.Pattern}\"", Severity.Success);
+                await LoadEntries();
+            }
+            else
+            {
+                Snackbar.Add("Entry not found — it may have already been deleted", Severity.Warning);
                 await LoadEntries();
             }
         }

--- a/TelegramGroupsAdmin/Components/Shared/Settings/UsernameBlacklistSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/UsernameBlacklistSettings.razor
@@ -1,0 +1,171 @@
+@inject IUsernameBlacklistRepository BlacklistRepository
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-3">
+    <MudText Typo="Typo.subtitle1">Blacklisted Display Names</MudText>
+    <MudButton Variant="Variant.Filled"
+               Color="Color.Primary"
+               Size="Size.Small"
+               StartIcon="@Icons.Material.Filled.Add"
+               OnClick="@AddEntry">
+        Add Entry
+    </MudButton>
+</MudStack>
+
+@if (_loading)
+{
+    <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-4" />
+}
+
+<MudTable Items="@_entries"
+          Hover="true"
+          Dense="true"
+          Loading="@_loading"
+          LoadingProgressColor="Color.Info">
+    <HeaderContent>
+        <MudTh>Pattern</MudTh>
+        <MudTh>Match Type</MudTh>
+        <MudTh>Status</MudTh>
+        <MudTh>Created</MudTh>
+        <MudTh>Notes</MudTh>
+        <MudTh>Actions</MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="Pattern">
+            <MudText Typo="Typo.body2"><strong>@context.Pattern</strong></MudText>
+        </MudTd>
+        <MudTd DataLabel="Match Type">
+            <MudChip T="string" Size="Size.Small" Color="Color.Default">
+                @context.MatchType.ToString()
+            </MudChip>
+        </MudTd>
+        <MudTd DataLabel="Status">
+            <MudChip T="string" Size="Size.Small"
+                     Color="@(context.Enabled ? Color.Success : Color.Error)">
+                @(context.Enabled ? "Enabled" : "Disabled")
+            </MudChip>
+        </MudTd>
+        <MudTd DataLabel="Created">@context.CreatedAt.ToString("yyyy-MM-dd HH:mm")</MudTd>
+        <MudTd DataLabel="Notes">
+            @if (!string.IsNullOrEmpty(context.Notes))
+            {
+                <MudTooltip Text="@context.Notes">
+                    <MudText Typo="Typo.body2"
+                             Style="max-width: 200px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                        @context.Notes
+                    </MudText>
+                </MudTooltip>
+            }
+        </MudTd>
+        <MudTd DataLabel="Actions">
+            <MudStack Row="true" Spacing="1">
+                <MudIconButton Icon="@(context.Enabled ? Icons.Material.Filled.VisibilityOff : Icons.Material.Filled.Visibility)"
+                               Color="@(context.Enabled ? Color.Warning : Color.Success)"
+                               Size="Size.Small"
+                               OnClick="@(() => ToggleEnabled(context))"
+                               title="@(context.Enabled ? "Disable" : "Enable")" />
+                <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                               Color="Color.Error"
+                               Size="Size.Small"
+                               OnClick="@(() => DeleteEntry(context))"
+                               title="Delete" />
+            </MudStack>
+        </MudTd>
+    </RowTemplate>
+    <NoRecordsContent>
+        <MudText Typo="Typo.body1" Align="Align.Center" Class="py-4">
+            No blacklist entries configured yet.
+        </MudText>
+    </NoRecordsContent>
+</MudTable>
+
+@code {
+    private IReadOnlyList<UsernameBlacklistEntry> _entries = [];
+    private bool _loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadEntries();
+    }
+
+    private async Task LoadEntries()
+    {
+        _loading = true;
+        try
+        {
+            _entries = await BlacklistRepository.GetAllEntriesAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error loading blacklist: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task AddEntry()
+    {
+        var dialog = await DialogService.ShowAsync<AddBlacklistEntryDialog>("Add Blacklist Entry");
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false, Data: AddBlacklistEntryData data })
+        {
+            try
+            {
+                if (await BlacklistRepository.ExistsAsync(data.Pattern))
+                {
+                    Snackbar.Add($"Pattern \"{data.Pattern}\" already exists", Severity.Warning);
+                    return;
+                }
+
+                var entry = new UsernameBlacklistEntry(
+                    Id: 0,
+                    Pattern: data.Pattern,
+                    MatchType: DataModels.BlacklistMatchType.Exact,
+                    Enabled: true,
+                    CreatedAt: DateTimeOffset.UtcNow,
+                    CreatedBy: Actor.FromSystem("web_admin"),
+                    Notes: data.Notes);
+
+                await BlacklistRepository.AddEntryAsync(entry);
+                Snackbar.Add($"Blacklisted \"{data.Pattern}\"", Severity.Success);
+                await LoadEntries();
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Error adding entry: {ex.Message}", Severity.Error);
+            }
+        }
+    }
+
+    private async Task ToggleEnabled(UsernameBlacklistEntry entry)
+    {
+        var newState = !entry.Enabled;
+        if (await BlacklistRepository.SetEnabledAsync(entry.Id, enabled: newState))
+        {
+            Snackbar.Add($"{(newState ? "Enabled" : "Disabled")} \"{entry.Pattern}\"", Severity.Info);
+            await LoadEntries();
+        }
+    }
+
+    private async Task DeleteEntry(UsernameBlacklistEntry entry)
+    {
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Delete Blacklist Entry",
+            $"Remove \"{entry.Pattern}\" from the blacklist?",
+            yesText: "Delete",
+            cancelText: "Cancel");
+
+        if (confirmed == true)
+        {
+            if (await BlacklistRepository.DeleteEntryAsync(entry.Id))
+            {
+                Snackbar.Add($"Deleted \"{entry.Pattern}\"", Severity.Success);
+                await LoadEntries();
+            }
+        }
+    }
+}

--- a/TelegramGroupsAdmin/Components/Shared/Settings/UsernameBlacklistSettings.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/UsernameBlacklistSettings.razor
@@ -1,4 +1,6 @@
+@using TelegramGroupsAdmin.Core.Models
 @inject IUsernameBlacklistRepository BlacklistRepository
+@inject IAuditService AuditService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 
@@ -137,6 +139,14 @@
                     Notes: data.Notes);
 
                 await BlacklistRepository.AddEntryAsync(entry);
+
+                var actor = WebUser!.ToActor();
+                await AuditService.LogEventAsync(
+                    AuditEventType.ConfigurationChanged,
+                    actor,
+                    actor,
+                    value: $"username_blacklist:added={data.Pattern}");
+
                 Snackbar.Add($"Blacklisted \"{data.Pattern}\"", Severity.Success);
                 await LoadEntries();
             }
@@ -156,6 +166,14 @@
         var newState = !entry.Enabled;
         if (await BlacklistRepository.SetEnabledAsync(entry.Id, enabled: newState))
         {
+            var actor = WebUser!.ToActor();
+            var action = newState ? "enabled" : "disabled";
+            await AuditService.LogEventAsync(
+                AuditEventType.ConfigurationChanged,
+                actor,
+                actor,
+                value: $"username_blacklist:{action}={entry.Pattern}");
+
             Snackbar.Add($"{(newState ? "Enabled" : "Disabled")} \"{entry.Pattern}\"", Severity.Success);
             await LoadEntries();
         }
@@ -178,6 +196,13 @@
         {
             if (await BlacklistRepository.DeleteEntryAsync(entry.Id))
             {
+                var actor = WebUser!.ToActor();
+                await AuditService.LogEventAsync(
+                    AuditEventType.ConfigurationChanged,
+                    actor,
+                    actor,
+                    value: $"username_blacklist:deleted={entry.Pattern}");
+
                 Snackbar.Add($"Deleted \"{entry.Pattern}\"", Severity.Success);
                 await LoadEntries();
             }

--- a/TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor
+++ b/TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor
@@ -1,4 +1,5 @@
 @using Humanizer
+@using TelegramGroupsAdmin.Components.Shared.Settings
 @using TelegramGroupsAdmin.Configuration
 @using TelegramGroupsAdmin.Configuration.Models.Welcome
 @using TelegramGroupsAdmin.Core.Services

--- a/TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor
+++ b/TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor
@@ -48,6 +48,28 @@
                 @* CAS Check Configuration *@
                 <MudItem xs="12">
                     <MudExpansionPanels>
+                        <MudExpansionPanel Expanded="false">
+                            <TitleContent>
+                                <div class="d-flex align-center gap-2">
+                                    <MudSwitch @bind-Value="_config.JoinSecurity.UsernameBlacklist.Enabled"
+                                               Color="Color.Primary"
+                                               @onclick:stopPropagation="true" />
+                                    <MudText>Username Blacklist</MudText>
+                                    <MudChip T="string" Size="Size.Small"
+                                             Color="@(_config.JoinSecurity.UsernameBlacklist.Enabled ? Color.Success : Color.Default)">
+                                        @(_config.JoinSecurity.UsernameBlacklist.Enabled ? "Enabled" : "Disabled")
+                                    </MudChip>
+                                </div>
+                            </TitleContent>
+                            <ChildContent>
+                                <MudText Typo="Typo.caption" Class="mud-text-secondary mb-3">
+                                    Auto-bans users whose display name matches a blacklisted pattern on join.
+                                    Useful for blocking persistent bot accounts that reuse the same name.
+                                </MudText>
+                                <UsernameBlacklistSettings />
+                            </ChildContent>
+                        </MudExpansionPanel>
+
                         <MudExpansionPanel Text="CAS (Combot Anti-Spam)" Expanded="false">
                             <TitleContent>
                                 <div class="d-flex align-center gap-2">


### PR DESCRIPTION
## Summary
- New `username_blacklist` table with case-insensitive `LOWER(pattern)` partial unique index on enabled entries
- `IUsernameBlacklistService` checks `UserIdentity.DisplayName` against enabled entries (case-insensitive exact match)
- Integrates into WelcomeService join flow as fail-fast check **before** CAS (local DB vs external API)
- Settings UI under Welcome → Security on Join with CRUD management (add/enable/disable/delete)
- Match type enum (`BlacklistMatchType`) supports future fuzzy/regex extensibility without interface changes
- Skips trusted users (consistent with CAS behavior)
- Exclusive arc actor system for audit trail (tracks who added each entry)

## Motivation
Persistent bot creating new accounts with the same display name ("Scarlett Lux") — different user IDs each time, evading identity-based bans. This feature catches them on join by matching the display name against a configurable blacklist.

## Test plan
- [x] Unit tests for matching logic (10 tests: exact, case-insensitive, partial non-match, empty, whitespace, fallback names, unknown user, multiple entries)
- [x] Integration tests for WelcomeService (4 tests: ban on match with executor assertion, skip for trusted, skip when disabled, proceed to CAS on no match)
- [x] All 1826 existing tests still pass
- [ ] Manual: Add "Scarlett Lux" to blacklist via Settings → Welcome → Security on Join → Username Blacklist
- [ ] Manual: Verify new account with that display name is auto-banned on join
- [ ] Manual: Verify non-blacklisted users proceed through normal welcome flow
- [ ] Manual: Toggle enable/disable in settings, verify behavior changes
- [ ] Manual: Verify audit log shows "Username Blacklist" as executor for auto-bans

🤖 Generated with [Claude Code](https://claude.com/claude-code)