### PR TITLE
fix: Add 45s timeout to profile scan preventing welcome flow hangs

### DIFF
--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
@@ -34,6 +34,12 @@ public sealed class ProfileScanService(
     /// </summary>
     private static readonly TimeSpan ScanFreshnessWindow = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    /// Maximum time for the core scan (Telegram API calls, file downloads, AI scoring).
+    /// Prevents hung DC connections from blocking the welcome flow indefinitely.
+    /// </summary>
+    private static readonly TimeSpan ScanTimeout = TimeSpan.FromSeconds(45);
+
     public async Task<ProfileScanResult> ScanUserProfileAsync(
         UserIdentity user,
         ChatIdentity? triggeringChat,
@@ -76,12 +82,36 @@ public sealed class ProfileScanService(
             return EmptyResult(user.Id, "No User API session available. Connect a session in Settings.");
         }
 
-        // Top-level guard: if any API call in Steps 1-8 triggers the flood gate,
-        // bail out immediately without permanently excluding the user.
+        // Top-level guard: WTelegram API calls don't accept CancellationToken, so a hung DC
+        // connection (e.g., file download from DC -4) blocks indefinitely. Task.WhenAny races
+        // the scan against a timeout — if the timeout wins, we abandon the scan and return
+        // gracefully so the welcome flow continues.
+        //
+        // The scan task gets its own scope (via ScanWithOwnedScopeAsync) so that if the timeout
+        // fires and this method returns, the abandoned task's scoped services stay alive until
+        // the task completes or faults — preventing ObjectDisposedException on DbContexts.
         try
         {
-            return await ScanUserProfileCoreAsync(client, user, existingUser, triggeringChat,
-                userRepo, scope.ServiceProvider, ct);
+            var scanTask = ScanWithOwnedScopeAsync(client, user, existingUser, triggeringChat, ct);
+
+            var completedTask = await Task.WhenAny(scanTask, Task.Delay(ScanTimeout, CancellationToken.None));
+
+            if (completedTask != scanTask)
+            {
+                logger.LogWarning(
+                    "Profile scan timed out after {Timeout}s for {User} (WTelegram call hung, likely DC connection issue)",
+                    ScanTimeout.TotalSeconds, user.ToLogDebug());
+
+                // Observe the abandoned task to prevent UnobservedTaskException and log failures
+                _ = scanTask.ContinueWith(
+                    t => logger.LogDebug(t.Exception?.GetBaseException(),
+                        "Abandoned profile scan for {UserId} faulted after timeout", user.Id),
+                    TaskContinuationOptions.OnlyOnFaulted);
+
+                return EmptyResult(user.Id, $"Scan timed out after {ScanTimeout.TotalSeconds}s");
+            }
+
+            return await scanTask; // propagate result or exception
         }
         catch (TelegramFloodWaitException ex)
         {
@@ -89,6 +119,24 @@ public sealed class ProfileScanService(
                 user.ToLogDebug(), ex.Message);
             return EmptyResult(user.Id, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Runs the core scan with its own DI scope. The scope stays alive for the task's full
+    /// lifetime, even if the caller abandons the task due to timeout.
+    /// </summary>
+    private async Task<ProfileScanResult> ScanWithOwnedScopeAsync(
+        IWTelegramApiClient client,
+        UserIdentity user,
+        Models.TelegramUser? existingUser,
+        ChatIdentity? triggeringChat,
+        CancellationToken ct)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
+
+        return await ScanUserProfileCoreAsync(client, user, existingUser, triggeringChat,
+            userRepo, scope.ServiceProvider, ct);
     }
 
     private async Task<ProfileScanResult> ScanUserProfileCoreAsync(

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
@@ -106,7 +106,9 @@ public sealed class ProfileScanService(
                 _ = scanTask.ContinueWith(
                     t => logger.LogDebug(t.Exception?.GetBaseException(),
                         "Abandoned profile scan for {UserId} faulted after timeout", user.Id),
-                    TaskContinuationOptions.OnlyOnFaulted);
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted,
+                    TaskScheduler.Default);
 
                 return EmptyResult(user.Id, $"Scan timed out after {ScanTimeout.TotalSeconds}s");
             }


### PR DESCRIPTION
## Summary

- Profile scan hangs indefinitely when WTelegram can't connect to a file download datacenter (DC -4), blocking the welcome flow and preventing new users from receiving their exam/welcome message
- Adds a 45-second timeout using `Task.WhenAny` since WTelegram API methods don't accept `CancellationToken`
- On timeout, returns `EmptyResult` (clean/score 0) so the welcome flow continues normally

## Root Cause

WTelegram's `DownloadProfilePhotoAsync` triggers a connection to a secondary datacenter (DC -4) for file downloads. When that DC connection hangs (observed: ~14 minutes before TCP timeout), the entire `ScanUserProfileAsync` call blocks indefinitely. This blocks the welcome flow — new users get stuck with a verifying message and never receive their exam.

## Design Decisions

- **`Task.WhenAny` over `CancellationToken`**: WTelegram methods don't accept tokens, so cooperative cancellation isn't possible. `Task.WhenAny` races the scan against a delay and returns immediately when the timeout wins.
- **`ScanWithOwnedScopeAsync`**: The abandoned scan task gets its own DI scope so scoped services (DbContext) stay alive until the task eventually completes or faults — prevents `ObjectDisposedException`.
- **`CancellationToken.None` on delay**: Prevents caller cancellation (app shutdown, job cancellation) from being misreported as a DC timeout in logs.
- **`ContinueWith(OnlyOnFaulted)`**: Observes and logs exceptions from the abandoned task instead of silently swallowing them.

## Test plan

- [x] All 1826 unit tests pass
- [ ] Deploy and verify new users complete the welcome flow within 45s even when DC -4 is unreachable
- [ ] Verify log message "Profile scan timed out after 45s" appears when timeout fires
- [ ] Verify manual profile scan from user detail dialog returns with skip reason on timeout


🤖 Generated with [Claude Code](https://claude.com/claude-code)