### PR TITLE
feat: Add PgBouncer transaction mode compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,7 @@ The Telegram Bot API enforces **one active connection per bot token** (webhook O
 - `OTEL_SERVICE_NAME`: Service name for traces/metrics (default: `TelegramGroupsAdmin`)
 - `ENABLE_METRICS`: Enables Prometheus `/metrics` endpoint without full OTEL/Seq stack (set to any non-empty value)
 - `OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP endpoint for traces and metrics (e.g., `http://seq:5341/ingest/otlp`)
+- `PGBOUNCER_MODE`: Configures connection string for PgBouncer transaction mode compatibility (adds `No Reset On Close=true`). Used when the app connects through PgBouncer instead of directly to PostgreSQL.
 
 When `ENABLE_METRICS` is set (without `OTEL_EXPORTER_OTLP_ENDPOINT`), the application enables:
 - **Prometheus Metrics**: `/metrics` endpoint with runtime, HTTP, and database metrics

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,6 +96,7 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageVersion Include="Testably.Abstractions.Testing" Version="5.3.0" />
+    <PackageVersion Include="Testcontainers" Version="4.10.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
     <PackageVersion Include="WireMock.Net" Version="1.25.0" />
   </ItemGroup>

--- a/TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs
@@ -56,7 +56,7 @@ public static class ServiceCollectionExtensions
     /// Sets No Reset On Close = true to prevent Npgsql from sending DISCARD ALL
     /// when returning connections to its internal pool.
     /// </summary>
-    public static string ApplyPgBouncerSettings(string connectionString)
+    internal static string ApplyPgBouncerSettings(string connectionString)
     {
         var builder = new NpgsqlConnectionStringBuilder(connectionString)
         {

--- a/TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,13 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddDataServices(this IServiceCollection services, string connectionString)
     {
+        // When behind PgBouncer, prevent Npgsql from sending DISCARD ALL on connection return.
+        // PgBouncer handles connection state reset via its own server_reset_query.
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PGBOUNCER_MODE")))
+        {
+            connectionString = ApplyPgBouncerSettings(connectionString);
+        }
+
         // Single NpgsqlDataSource — the ONE connection pool for all app database access.
         // EF Core (via pooled factory) and raw ADO.NET services (BackupService, etc.) share this pool.
         // Quartz.NET is the only consumer with its own separate pool (API limitation).
@@ -42,5 +49,19 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IMigrationHistoryCompactionService, MigrationHistoryCompactionService>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Modifies a connection string for PgBouncer transaction mode compatibility.
+    /// Sets No Reset On Close = true to prevent Npgsql from sending DISCARD ALL
+    /// when returning connections to its internal pool.
+    /// </summary>
+    public static string ApplyPgBouncerSettings(string connectionString)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            NoResetOnClose = true
+        };
+        return builder.ConnectionString;
     }
 }

--- a/TelegramGroupsAdmin.Data/TelegramGroupsAdmin.Data.csproj
+++ b/TelegramGroupsAdmin.Data/TelegramGroupsAdmin.Data.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="TelegramGroupsAdmin.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" />
     <PackageReference Include="Dapper" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" />

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs
@@ -1,0 +1,154 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace TelegramGroupsAdmin.IntegrationTests.PgBouncer;
+
+/// <summary>
+/// Starts a PostgreSQL 18 container and a PgBouncer 1.25.1 container in transaction mode.
+/// PgBouncer sits between tests and PostgreSQL, matching production deployment topology.
+/// </summary>
+public class PgBouncerFixture : IDisposable
+{
+    private INetwork? _network;
+    private PostgreSqlContainer? _postgresContainer;
+    private IContainer? _pgBouncerContainer;
+    private string? _tempConfigPath;
+    private string? _tempUserlistPath;
+    private bool _disposed;
+
+    /// <summary>
+    /// Connection string pointing through PgBouncer (with No Reset On Close=true).
+    /// </summary>
+    public string PgBouncerConnectionString { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Direct connection string to PostgreSQL (bypasses PgBouncer).
+    /// Used for admin operations like CREATE DATABASE.
+    /// </summary>
+    public string DirectConnectionString { get; private set; } = string.Empty;
+
+    public async Task StartAsync()
+    {
+        // 1. Create shared Docker network
+        _network = new NetworkBuilder().Build();
+        await _network.CreateAsync();
+
+        // 2. Start PostgreSQL on the shared network
+        _postgresContainer = new PostgreSqlBuilder("postgres:18")
+            .WithNetwork(_network)
+            .WithNetworkAliases("postgres")
+            .WithCleanUp(true)
+            .Build();
+
+        await _postgresContainer.StartAsync();
+        DirectConnectionString = _postgresContainer.GetConnectionString();
+
+        // 3. Create pgbouncer_auth SUPERUSER role (mirrors production auth_query setup)
+        var adminBuilder = new NpgsqlConnectionStringBuilder(DirectConnectionString) { Database = "postgres" };
+        await using (var connection = new NpgsqlConnection(adminBuilder.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var cmd = new NpgsqlCommand(
+                "CREATE ROLE pgbouncer_auth WITH LOGIN SUPERUSER PASSWORD 'pgbouncer_auth_password'",
+                connection);
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // 5. Extract PgBouncer config from embedded resource
+        var assembly = typeof(PgBouncerFixture).Assembly;
+        var configResourceName = assembly.GetManifestResourceNames()
+            .First(n => n.EndsWith("pgbouncer.ini"));
+
+        _tempConfigPath = Path.Combine(Path.GetTempPath(), $"pgbouncer_{Guid.NewGuid():N}.ini");
+        await using (var stream = assembly.GetManifestResourceStream(configResourceName)!)
+        await using (var fileStream = File.Create(_tempConfigPath))
+        {
+            await stream.CopyToAsync(fileStream);
+        }
+
+        // Extract userlist.txt for PgBouncer auth
+        var userlistResourceName = assembly.GetManifestResourceNames()
+            .First(n => n.EndsWith("userlist.txt"));
+
+        _tempUserlistPath = Path.Combine(Path.GetTempPath(), $"pgbouncer_userlist_{Guid.NewGuid():N}.txt");
+        await using (var stream = assembly.GetManifestResourceStream(userlistResourceName)!)
+        await using (var fileStream = File.Create(_tempUserlistPath))
+        {
+            await stream.CopyToAsync(fileStream);
+        }
+
+        // 6. Start PgBouncer on the same network (random host port to avoid conflicts)
+        // Uses bind mount (not WithResourceMapping) so config exists at container start time
+        _pgBouncerContainer = new ContainerBuilder("ghcr.io/icoretech/pgbouncer-docker:1.25.1")
+            .WithNetwork(_network)
+            .WithPortBinding(5432, assignRandomHostPort: true)
+            .WithBindMount(_tempConfigPath, "/etc/pgbouncer/pgbouncer.ini")
+            .WithBindMount(_tempUserlistPath, "/etc/pgbouncer/userlist.txt")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(5432))
+            .WithCleanUp(true)
+            .Build();
+
+        await _pgBouncerContainer.StartAsync();
+
+        // 7. Build connection string through PgBouncer
+        var pgBouncerPort = _pgBouncerContainer.GetMappedPublicPort(5432);
+        var directBuilder = new NpgsqlConnectionStringBuilder(DirectConnectionString);
+
+        var pgBouncerBuilder = new NpgsqlConnectionStringBuilder
+        {
+            Host = "localhost",
+            Port = pgBouncerPort,
+            Database = directBuilder.Database,
+            Username = directBuilder.Username,
+            Password = directBuilder.Password,
+            NoResetOnClose = true
+        };
+        PgBouncerConnectionString = pgBouncerBuilder.ConnectionString;
+    }
+
+    /// <summary>
+    /// Creates a unique database accessible through both direct and PgBouncer connections.
+    /// </summary>
+    public async Task<(string directConnStr, string pgBouncerConnStr)> CreateUniqueDatabaseAsync()
+    {
+        var dbName = $"test_db_{Guid.NewGuid():N}";
+
+        // Create database via direct connection
+        var adminBuilder = new NpgsqlConnectionStringBuilder(DirectConnectionString)
+        {
+            Database = "postgres"
+        };
+
+        await using (var connection = new NpgsqlConnection(adminBuilder.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var cmd = new NpgsqlCommand($"CREATE DATABASE \"{dbName}\"", connection);
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Return both connection strings for the new database
+        var directBuilder = new NpgsqlConnectionStringBuilder(DirectConnectionString) { Database = dbName };
+        var pgBouncerBuilder = new NpgsqlConnectionStringBuilder(PgBouncerConnectionString) { Database = dbName };
+
+        return (directBuilder.ConnectionString, pgBouncerBuilder.ConnectionString);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _pgBouncerContainer?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _postgresContainer?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _network?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+        if (_tempConfigPath is not null)
+            File.Delete(_tempConfigPath);
+        if (_tempUserlistPath is not null)
+            File.Delete(_tempUserlistPath);
+
+        _disposed = true;
+    }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs
@@ -139,6 +139,7 @@ public class PgBouncerFixture : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         if (_disposed) return;
+        _disposed = true;
 
         if (_pgBouncerContainer is not null)
             await _pgBouncerContainer.DisposeAsync();
@@ -151,7 +152,5 @@ public class PgBouncerFixture : IAsyncDisposable
             File.Delete(_tempConfigPath);
         if (_tempUserlistPath is not null)
             File.Delete(_tempUserlistPath);
-
-        _disposed = true;
     }
 }

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs
@@ -10,7 +10,7 @@ namespace TelegramGroupsAdmin.IntegrationTests.PgBouncer;
 /// Starts a PostgreSQL 18 container and a PgBouncer 1.25.1 container in transaction mode.
 /// PgBouncer sits between tests and PostgreSQL, matching production deployment topology.
 /// </summary>
-public class PgBouncerFixture : IDisposable
+public class PgBouncerFixture : IAsyncDisposable
 {
     private INetwork? _network;
     private PostgreSqlContainer? _postgresContainer;
@@ -57,7 +57,7 @@ public class PgBouncerFixture : IDisposable
             await cmd.ExecuteNonQueryAsync();
         }
 
-        // 5. Extract PgBouncer config from embedded resource
+        // 4. Extract PgBouncer config from embedded resource
         var assembly = typeof(PgBouncerFixture).Assembly;
         var configResourceName = assembly.GetManifestResourceNames()
             .First(n => n.EndsWith("pgbouncer.ini"));
@@ -69,7 +69,7 @@ public class PgBouncerFixture : IDisposable
             await stream.CopyToAsync(fileStream);
         }
 
-        // Extract userlist.txt for PgBouncer auth
+        // 5. Extract userlist.txt for PgBouncer auth
         var userlistResourceName = assembly.GetManifestResourceNames()
             .First(n => n.EndsWith("userlist.txt"));
 
@@ -136,13 +136,16 @@ public class PgBouncerFixture : IDisposable
         return (directBuilder.ConnectionString, pgBouncerBuilder.ConnectionString);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         if (_disposed) return;
 
-        _pgBouncerContainer?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-        _postgresContainer?.DisposeAsync().AsTask().GetAwaiter().GetResult();
-        _network?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        if (_pgBouncerContainer is not null)
+            await _pgBouncerContainer.DisposeAsync();
+        if (_postgresContainer is not null)
+            await _postgresContainer.DisposeAsync();
+        if (_network is not null)
+            await _network.DisposeAsync();
 
         if (_tempConfigPath is not null)
             File.Delete(_tempConfigPath);

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs
@@ -87,10 +87,15 @@ public class PgBouncerMigrationTests
 
         // Act — create and dispose multiple contexts rapidly (simulates IDbContextFactory pattern)
         // If connection pooling through PgBouncer breaks, this will throw
+        var lastCount = -1;
         for (var i = 0; i < 10; i++)
         {
             await using var context = new AppDbContext(optionsBuilder.Options);
-            await context.Configs.CountAsync();
+            lastCount = await context.Configs.CountAsync();
         }
+
+        // Assert — all 10 context cycles completed successfully through PgBouncer
+        Assert.That(lastCount, Is.GreaterThanOrEqualTo(0),
+            "Expected all 10 contexts to complete queries through PgBouncer connection pool");
     }
 }

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+using TelegramGroupsAdmin.Data;
+
+namespace TelegramGroupsAdmin.IntegrationTests.PgBouncer;
+
+/// <summary>
+/// Validates that TGA works correctly through PgBouncer in transaction mode.
+/// These tests use real PostgreSQL + PgBouncer containers matching production config.
+/// </summary>
+[TestFixture]
+[Category("PgBouncer")]
+public class PgBouncerMigrationTests
+{
+    private PgBouncerFixture _fixture = null!;
+
+    [OneTimeSetUp]
+    public async Task FixtureSetup()
+    {
+        _fixture = new PgBouncerFixture();
+        await _fixture.StartAsync();
+    }
+
+    [OneTimeTearDown]
+    public void FixtureTeardown()
+    {
+        _fixture.Dispose();
+    }
+
+    [Test]
+    public async Task MigrateAsync_ThroughPgBouncer_AppliesAllMigrations()
+    {
+        // Arrange — create a fresh database accessible through PgBouncer
+        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseNpgsql(pgBouncerConnStr);
+
+        // Act — run all EF Core migrations through PgBouncer
+        await using var context = new AppDbContext(optionsBuilder.Options);
+        await context.Database.MigrateAsync();
+
+        // Assert — verify migrations applied by checking a known table exists
+        var appliedMigrations = await context.Database
+            .GetAppliedMigrationsAsync();
+        Assert.That(appliedMigrations, Is.Not.Empty,
+            "Expected at least one migration to be applied through PgBouncer");
+    }
+
+    [Test]
+    public async Task EfCoreCrud_ThroughPgBouncer_WorksCorrectly()
+    {
+        // Arrange — create and migrate a fresh database
+        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseNpgsql(pgBouncerConnStr);
+
+        await using var migrationContext = new AppDbContext(optionsBuilder.Options);
+        await migrationContext.Database.MigrateAsync();
+
+        // Act — perform a basic CRUD operation through PgBouncer
+        await using var crudContext = new AppDbContext(optionsBuilder.Options);
+
+        // Insert a config record (configs table is always available after migration)
+        var configCount = await crudContext.Configs.CountAsync();
+
+        // Assert — query succeeded through PgBouncer without errors
+        Assert.That(configCount, Is.GreaterThanOrEqualTo(0),
+            "Expected to query configs table through PgBouncer without errors");
+    }
+
+    [Test]
+    public async Task MultipleContexts_ThroughPgBouncer_ConnectionPoolingWorks()
+    {
+        // Arrange — validates IDbContextFactory pattern works through PgBouncer
+        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseNpgsql(pgBouncerConnStr);
+
+        // Migrate first
+        await using (var migrationContext = new AppDbContext(optionsBuilder.Options))
+        {
+            await migrationContext.Database.MigrateAsync();
+        }
+
+        // Act — create and dispose multiple contexts rapidly (simulates IDbContextFactory pattern)
+        for (var i = 0; i < 10; i++)
+        {
+            await using var context = new AppDbContext(optionsBuilder.Options);
+            await context.Configs.CountAsync();
+        }
+
+        // Assert — if we got here without exceptions, connection pooling through PgBouncer works
+        Assert.Pass("10 rapid context create/dispose cycles completed through PgBouncer");
+    }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs
@@ -11,7 +11,7 @@ namespace TelegramGroupsAdmin.IntegrationTests.PgBouncer;
 [Category("PgBouncer")]
 public class PgBouncerMigrationTests
 {
-    private PgBouncerFixture _fixture = null!;
+    private PgBouncerFixture? _fixture;
 
     [OneTimeSetUp]
     public async Task FixtureSetup()
@@ -21,16 +21,17 @@ public class PgBouncerMigrationTests
     }
 
     [OneTimeTearDown]
-    public void FixtureTeardown()
+    public async Task FixtureTeardown()
     {
-        _fixture.Dispose();
+        if (_fixture is not null)
+            await _fixture.DisposeAsync();
     }
 
     [Test]
     public async Task MigrateAsync_ThroughPgBouncer_AppliesAllMigrations()
     {
         // Arrange — create a fresh database accessible through PgBouncer
-        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+        var (_, pgBouncerConnStr) = await _fixture!.CreateUniqueDatabaseAsync();
 
         var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
         optionsBuilder.UseNpgsql(pgBouncerConnStr);
@@ -50,7 +51,7 @@ public class PgBouncerMigrationTests
     public async Task EfCoreCrud_ThroughPgBouncer_WorksCorrectly()
     {
         // Arrange — create and migrate a fresh database
-        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+        var (_, pgBouncerConnStr) = await _fixture!.CreateUniqueDatabaseAsync();
 
         var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
         optionsBuilder.UseNpgsql(pgBouncerConnStr);
@@ -61,7 +62,7 @@ public class PgBouncerMigrationTests
         // Act — perform a basic CRUD operation through PgBouncer
         await using var crudContext = new AppDbContext(optionsBuilder.Options);
 
-        // Insert a config record (configs table is always available after migration)
+        // Query configs table (always available after migration)
         var configCount = await crudContext.Configs.CountAsync();
 
         // Assert — query succeeded through PgBouncer without errors
@@ -73,7 +74,7 @@ public class PgBouncerMigrationTests
     public async Task MultipleContexts_ThroughPgBouncer_ConnectionPoolingWorks()
     {
         // Arrange — validates IDbContextFactory pattern works through PgBouncer
-        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+        var (_, pgBouncerConnStr) = await _fixture!.CreateUniqueDatabaseAsync();
 
         var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
         optionsBuilder.UseNpgsql(pgBouncerConnStr);
@@ -85,13 +86,11 @@ public class PgBouncerMigrationTests
         }
 
         // Act — create and dispose multiple contexts rapidly (simulates IDbContextFactory pattern)
+        // If connection pooling through PgBouncer breaks, this will throw
         for (var i = 0; i < 10; i++)
         {
             await using var context = new AppDbContext(optionsBuilder.Options);
             await context.Configs.CountAsync();
         }
-
-        // Assert — if we got here without exceptions, connection pooling through PgBouncer works
-        Assert.Pass("10 rapid context create/dispose cycles completed through PgBouncer");
     }
 }

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/pgbouncer.ini
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/pgbouncer.ini
@@ -11,7 +11,9 @@ auth_user = pgbouncer_auth
 auth_query = SELECT usename, passwd FROM pg_shadow WHERE usename=$1
 ignore_startup_parameters = extra_float_digits,options
 
-; Prepared statement support (PgBouncer 1.21+, required for Quartz.NET)
+; Disable PgBouncer prepared statement passthrough — Npgsql manages prepared
+; statements internally. Setting 0 avoids conflicts between PgBouncer's
+; statement cache and Npgsql's own cache.
 max_prepared_statements = 0
 
 ; Connection limits
@@ -29,5 +31,6 @@ server_connect_timeout = 15
 ; Connection lifetime
 server_lifetime = 3600
 
-; Transaction mode safety
+; PgBouncer resets the server connection; Npgsql's NoResetOnClose=true
+; prevents a duplicate DISCARD ALL from the client side.
 server_reset_query = DISCARD ALL

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/pgbouncer.ini
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/pgbouncer.ini
@@ -1,0 +1,33 @@
+[databases]
+* = host=postgres port=5432
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 5432
+pool_mode = transaction
+auth_type = scram-sha-256
+auth_file = /etc/pgbouncer/userlist.txt
+auth_user = pgbouncer_auth
+auth_query = SELECT usename, passwd FROM pg_shadow WHERE usename=$1
+ignore_startup_parameters = extra_float_digits,options
+
+; Prepared statement support (PgBouncer 1.21+, required for Quartz.NET)
+max_prepared_statements = 0
+
+; Connection limits
+max_client_conn = 200
+default_pool_size = 20
+min_pool_size = 2
+max_db_connections = 50
+
+; Timeouts - match production
+query_timeout = 0
+server_idle_timeout = 600
+client_idle_timeout = 0
+server_connect_timeout = 15
+
+; Connection lifetime
+server_lifetime = 3600
+
+; Transaction mode safety
+server_reset_query = DISCARD ALL

--- a/TelegramGroupsAdmin.IntegrationTests/PgBouncer/userlist.txt
+++ b/TelegramGroupsAdmin.IntegrationTests/PgBouncer/userlist.txt
@@ -1,0 +1,1 @@
+"pgbouncer_auth" "pgbouncer_auth_password"

--- a/TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj
+++ b/TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj
@@ -27,6 +27,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Testcontainers" />
     <PackageReference Include="Testcontainers.PostgreSql" />
     <PackageReference Include="WireMock.Net" />
   </ItemGroup>
@@ -48,6 +49,11 @@
     <EmbeddedResource Include="TestData\SQL\*.sql" />
     <!-- Legacy (to be removed after migration) -->
     <EmbeddedResource Include="TestData\MLTrainingData.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="PgBouncer\pgbouncer.ini" />
+    <EmbeddedResource Include="PgBouncer\userlist.txt" />
   </ItemGroup>
 
 </Project>

--- a/TelegramGroupsAdmin.UnitTests/Data/PgBouncerConnectionStringTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Data/PgBouncerConnectionStringTests.cs
@@ -1,5 +1,5 @@
 using Npgsql;
-using TelegramGroupsAdmin.Data.Extensions;
+using static TelegramGroupsAdmin.Data.Extensions.ServiceCollectionExtensions;
 
 namespace TelegramGroupsAdmin.UnitTests.Data;
 
@@ -11,7 +11,7 @@ public class PgBouncerConnectionStringTests
     {
         var connectionString = "Host=localhost;Database=testdb;Username=user;Password=pass";
 
-        var result = TelegramGroupsAdmin.Data.Extensions.ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+        var result = ApplyPgBouncerSettings(connectionString);
 
         var builder = new NpgsqlConnectionStringBuilder(result);
         Assert.That(builder.NoResetOnClose, Is.True);
@@ -22,7 +22,7 @@ public class PgBouncerConnectionStringTests
     {
         var connectionString = "Host=myhost;Port=6432;Database=testdb;Username=user;Password=pass;Timeout=30";
 
-        var result = TelegramGroupsAdmin.Data.Extensions.ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+        var result = ApplyPgBouncerSettings(connectionString);
 
         var builder = new NpgsqlConnectionStringBuilder(result);
         Assert.That(builder.Host, Is.EqualTo("myhost"));
@@ -37,7 +37,7 @@ public class PgBouncerConnectionStringTests
     {
         var connectionString = "Host=localhost;Database=testdb;No Reset On Close=false";
 
-        var result = TelegramGroupsAdmin.Data.Extensions.ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+        var result = ApplyPgBouncerSettings(connectionString);
 
         var builder = new NpgsqlConnectionStringBuilder(result);
         Assert.That(builder.NoResetOnClose, Is.True);

--- a/TelegramGroupsAdmin.UnitTests/Data/PgBouncerConnectionStringTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Data/PgBouncerConnectionStringTests.cs
@@ -1,0 +1,45 @@
+using Npgsql;
+using TelegramGroupsAdmin.Data.Extensions;
+
+namespace TelegramGroupsAdmin.UnitTests.Data;
+
+[TestFixture]
+public class PgBouncerConnectionStringTests
+{
+    [Test]
+    public void ApplyPgBouncerSettings_WhenCalled_SetsNoResetOnClose()
+    {
+        var connectionString = "Host=localhost;Database=testdb;Username=user;Password=pass";
+
+        var result = TelegramGroupsAdmin.Data.Extensions.ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+
+        var builder = new NpgsqlConnectionStringBuilder(result);
+        Assert.That(builder.NoResetOnClose, Is.True);
+    }
+
+    [Test]
+    public void ApplyPgBouncerSettings_PreservesExistingSettings()
+    {
+        var connectionString = "Host=myhost;Port=6432;Database=testdb;Username=user;Password=pass;Timeout=30";
+
+        var result = TelegramGroupsAdmin.Data.Extensions.ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+
+        var builder = new NpgsqlConnectionStringBuilder(result);
+        Assert.That(builder.Host, Is.EqualTo("myhost"));
+        Assert.That(builder.Port, Is.EqualTo(6432));
+        Assert.That(builder.Database, Is.EqualTo("testdb"));
+        Assert.That(builder.Timeout, Is.EqualTo(30));
+        Assert.That(builder.NoResetOnClose, Is.True);
+    }
+
+    [Test]
+    public void ApplyPgBouncerSettings_OverridesExplicitFalse()
+    {
+        var connectionString = "Host=localhost;Database=testdb;No Reset On Close=false";
+
+        var result = TelegramGroupsAdmin.Data.Extensions.ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+
+        var builder = new NpgsqlConnectionStringBuilder(result);
+        Assert.That(builder.NoResetOnClose, Is.True);
+    }
+}

--- a/TelegramGroupsAdmin/WebApplicationExtensions.cs
+++ b/TelegramGroupsAdmin/WebApplicationExtensions.cs
@@ -97,6 +97,11 @@ public static class WebApplicationExtensions
         {
             app.Logger.LogInformation("Running PostgreSQL database migrations (EF Core)");
 
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PGBOUNCER_MODE")))
+            {
+                app.Logger.LogInformation("PgBouncer mode active — connection string configured for transaction mode compatibility");
+            }
+
             using var scope = app.Services.CreateScope();
 
             // Pre-migration: Check if history compaction is needed

--- a/docs/superpowers/plans/2026-03-21-pgbouncer-compatibility.md
+++ b/docs/superpowers/plans/2026-03-21-pgbouncer-compatibility.md
@@ -1,0 +1,568 @@
+# PgBouncer Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make TGA fully compatible with PgBouncer in transaction mode, controlled by a `PGBOUNCER_MODE` environment variable.
+
+**Architecture:** When `PGBOUNCER_MODE` is set, the connection string is modified to include `No Reset On Close=true` (prevents Npgsql from sending `DISCARD ALL` which conflicts with PgBouncer). Migrations work out-of-the-box with Npgsql 10.0's transaction-scoped table locks. An integration test with a real PgBouncer container validates the full stack.
+
+**Tech Stack:** .NET 10, EF Core 10.0, Npgsql 10.0, NUnit, Testcontainers 4.10.0, PgBouncer 1.25.1 (`ghcr.io/icoretech/pgbouncer-docker:1.25.1`)
+
+**Spec:** `docs/superpowers/specs/2026-03-21-pgbouncer-compatibility-design.md`
+
+**Branch:** `feature/pgbouncer-compatibility`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs` | Modify | Add PgBouncer connection string modification |
+| `TelegramGroupsAdmin/WebApplicationExtensions.cs` | Modify | Add PgBouncer mode startup log |
+| `TelegramGroupsAdmin.UnitTests/Data/PgBouncerConnectionStringTests.cs` | Create | Unit tests for connection string modification |
+| `TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs` | Create | Testcontainers fixture for PostgreSQL + PgBouncer |
+| `TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs` | Create | Integration tests: migrations + CRUD through PgBouncer |
+| `TelegramGroupsAdmin.IntegrationTests/PgBouncer/pgbouncer.ini` | Create | PgBouncer config file matching production settings |
+| `Directory.Packages.props` | Modify | Add base `Testcontainers` package for generic container support |
+| `TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj` | Modify | Add `Testcontainers` package reference + embedded resource |
+| `TelegramGroupsAdmin.Data/TelegramGroupsAdmin.Data.csproj` | Modify | Add `InternalsVisibleTo` for unit test access |
+
+---
+
+## Task 1: Unit Tests for Connection String Modification
+
+**Files:**
+- Create: `TelegramGroupsAdmin.UnitTests/Data/PgBouncerConnectionStringTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Npgsql;
+using TelegramGroupsAdmin.Data.Extensions;
+
+namespace TelegramGroupsAdmin.UnitTests.Data;
+
+[TestFixture]
+public class PgBouncerConnectionStringTests
+{
+    [Test]
+    public void ApplyPgBouncerSettings_WhenCalled_SetsNoResetOnClose()
+    {
+        var connectionString = "Host=localhost;Database=testdb;Username=user;Password=pass";
+
+        var result = ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+
+        var builder = new NpgsqlConnectionStringBuilder(result);
+        Assert.That(builder.NoResetOnClose, Is.True);
+    }
+
+    [Test]
+    public void ApplyPgBouncerSettings_PreservesExistingSettings()
+    {
+        var connectionString = "Host=myhost;Port=6432;Database=testdb;Username=user;Password=pass;Timeout=30";
+
+        var result = ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+
+        var builder = new NpgsqlConnectionStringBuilder(result);
+        Assert.That(builder.Host, Is.EqualTo("myhost"));
+        Assert.That(builder.Port, Is.EqualTo(6432));
+        Assert.That(builder.Database, Is.EqualTo("testdb"));
+        Assert.That(builder.Timeout, Is.EqualTo(30));
+        Assert.That(builder.NoResetOnClose, Is.True);
+    }
+
+    [Test]
+    public void ApplyPgBouncerSettings_OverridesExplicitFalse()
+    {
+        var connectionString = "Host=localhost;Database=testdb;No Reset On Close=false";
+
+        var result = ServiceCollectionExtensions.ApplyPgBouncerSettings(connectionString);
+
+        var builder = new NpgsqlConnectionStringBuilder(result);
+        Assert.That(builder.NoResetOnClose, Is.True);
+    }
+}
+```
+
+Note: The test references `ServiceCollectionExtensions.ApplyPgBouncerSettings` — a static `internal` method we'll extract in Task 2 so it's independently testable. Requires `InternalsVisibleTo` on the Data project (added in Task 2).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~PgBouncerConnectionStringTests" --no-build`
+Expected: Build failure — `ApplyPgBouncerSettings` does not exist yet.
+
+---
+
+## Task 2: Implement Connection String Modification
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs:14-19`
+- Modify: `TelegramGroupsAdmin.Data/TelegramGroupsAdmin.Data.csproj` — add `InternalsVisibleTo`
+
+- [ ] **Step 3: Add `InternalsVisibleTo` to the Data project**
+
+In `TelegramGroupsAdmin.Data/TelegramGroupsAdmin.Data.csproj`, add inside the existing `<PropertyGroup>` or as a new `<ItemGroup>`:
+
+```xml
+<ItemGroup>
+    <InternalsVisibleTo Include="TelegramGroupsAdmin.UnitTests" />
+</ItemGroup>
+```
+
+- [ ] **Step 4: Add the `ApplyPgBouncerSettings` method and wire it into `AddDataServices`**
+
+Add a `static internal` method for testability, and call it conditionally in `AddDataServices`:
+
+```csharp
+public static IServiceCollection AddDataServices(this IServiceCollection services, string connectionString)
+{
+    // When behind PgBouncer, prevent Npgsql from sending DISCARD ALL on connection return.
+    // PgBouncer handles connection state reset via its own server_reset_query.
+    if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PGBOUNCER_MODE")))
+    {
+        connectionString = ApplyPgBouncerSettings(connectionString);
+    }
+
+    // Single NpgsqlDataSource — the ONE connection pool for all app database access.
+    // ... rest of method unchanged ...
+}
+
+/// <summary>
+/// Modifies a connection string for PgBouncer transaction mode compatibility.
+/// Sets No Reset On Close = true to prevent Npgsql from sending DISCARD ALL
+/// when returning connections to its internal pool.
+/// </summary>
+internal static string ApplyPgBouncerSettings(string connectionString)
+{
+    var builder = new NpgsqlConnectionStringBuilder(connectionString)
+    {
+        NoResetOnClose = true
+    };
+    return builder.ConnectionString;
+}
+```
+
+- [ ] **Step 5: Build the solution**
+
+Run: `dotnet build TelegramGroupsAdmin.Data`
+Expected: Build succeeds.
+
+- [ ] **Step 6: Run unit tests to verify they pass**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~PgBouncerConnectionStringTests"`
+Expected: All 3 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin.UnitTests/Data/PgBouncerConnectionStringTests.cs TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs TelegramGroupsAdmin.Data/TelegramGroupsAdmin.Data.csproj
+git commit -m "feat: add PgBouncer connection string modification (#pgbouncer)"
+```
+
+---
+
+## Task 3: Add Startup Logging
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/WebApplicationExtensions.cs:96-98`
+
+- [ ] **Step 8: Add PgBouncer mode log line**
+
+In `RunDatabaseMigrationsAsync()`, add a log line after the existing opening log:
+
+```csharp
+public async Task RunDatabaseMigrationsAsync()
+{
+    app.Logger.LogInformation("Running PostgreSQL database migrations (EF Core)");
+
+    if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PGBOUNCER_MODE")))
+    {
+        app.Logger.LogInformation("PgBouncer mode active — connection string configured for transaction mode compatibility");
+    }
+
+    // ... rest of method unchanged ...
+}
+```
+
+- [ ] **Step 9: Build the solution**
+
+Run: `dotnet build TelegramGroupsAdmin`
+Expected: Build succeeds.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add TelegramGroupsAdmin/WebApplicationExtensions.cs
+git commit -m "feat: log PgBouncer mode status at startup (#pgbouncer)"
+```
+
+---
+
+## Task 4: Set Up PgBouncer Integration Test Infrastructure
+
+**Files:**
+- Modify: `Directory.Packages.props` — add `Testcontainers` base package (version `4.10.0` to match existing `Testcontainers.PostgreSql`)
+- Modify: `TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj` — add `Testcontainers` package reference
+- Create: `TelegramGroupsAdmin.IntegrationTests/PgBouncer/pgbouncer.ini` — test PgBouncer config (embedded resource)
+- Create: `TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs` — Testcontainers fixture
+
+- [ ] **Step 11: Add the base `Testcontainers` package to `Directory.Packages.props`**
+
+Add alongside the existing `Testcontainers.PostgreSql` entry:
+
+```xml
+<PackageVersion Include="Testcontainers" Version="4.10.0" />
+```
+
+- [ ] **Step 12: Add `Testcontainers` package reference to the integration test project**
+
+In `TelegramGroupsAdmin.IntegrationTests.csproj`, add alongside the existing `Testcontainers.PostgreSql` reference:
+
+```xml
+<PackageReference Include="Testcontainers" />
+```
+
+- [ ] **Step 13: Create the PgBouncer config file**
+
+Create `TelegramGroupsAdmin.IntegrationTests/PgBouncer/pgbouncer.ini`:
+
+```ini
+[databases]
+* = host=postgres port=5432
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 5432
+pool_mode = transaction
+auth_type = trust
+ignore_startup_parameters = extra_float_digits,options
+
+; Prepared statement support (PgBouncer 1.21+, required for Quartz.NET)
+max_prepared_statements = 0
+
+; Connection limits
+max_client_conn = 200
+default_pool_size = 20
+min_pool_size = 2
+max_db_connections = 50
+
+; Timeouts - match production
+query_timeout = 0
+server_idle_timeout = 600
+client_idle_timeout = 0
+server_connect_timeout = 15
+
+; Connection lifetime
+server_lifetime = 3600
+
+; Transaction mode safety
+server_reset_query = DISCARD ALL
+```
+
+Add as embedded resource in the `.csproj`:
+
+```xml
+<ItemGroup>
+    <EmbeddedResource Include="PgBouncer\pgbouncer.ini" />
+</ItemGroup>
+```
+
+- [ ] **Step 14: Create the PgBouncer test fixture**
+
+Create `TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerFixture.cs`:
+
+```csharp
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace TelegramGroupsAdmin.IntegrationTests.PgBouncer;
+
+/// <summary>
+/// Starts a PostgreSQL 18 container and a PgBouncer 1.25.1 container in transaction mode.
+/// PgBouncer sits between tests and PostgreSQL, matching production deployment topology.
+/// </summary>
+public class PgBouncerFixture : IDisposable
+{
+    private INetwork? _network;
+    private PostgreSqlContainer? _postgresContainer;
+    private IContainer? _pgBouncerContainer;
+    private bool _disposed;
+
+    /// <summary>
+    /// Connection string pointing through PgBouncer (with No Reset On Close=true).
+    /// </summary>
+    public string PgBouncerConnectionString { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Direct connection string to PostgreSQL (bypasses PgBouncer).
+    /// Used for admin operations like CREATE DATABASE.
+    /// </summary>
+    public string DirectConnectionString { get; private set; } = string.Empty;
+
+    public async Task StartAsync()
+    {
+        // 1. Create shared Docker network
+        _network = new NetworkBuilder().Build();
+        await _network.CreateAsync();
+
+        // 2. Start PostgreSQL on the shared network
+        _postgresContainer = new PostgreSqlBuilder("postgres:18")
+            .WithNetwork(_network)
+            .WithNetworkAliases("postgres")
+            .WithCleanUp(true)
+            .Build();
+
+        await _postgresContainer.StartAsync();
+        DirectConnectionString = _postgresContainer.GetConnectionString();
+
+        // 3. Extract PgBouncer config from embedded resource
+        var assembly = typeof(PgBouncerFixture).Assembly;
+        var configResourceName = assembly.GetManifestResourceNames()
+            .First(n => n.EndsWith("pgbouncer.ini"));
+
+        var tempConfigPath = Path.Combine(Path.GetTempPath(), $"pgbouncer_{Guid.NewGuid():N}.ini");
+        await using (var stream = assembly.GetManifestResourceStream(configResourceName)!)
+        await using (var fileStream = File.Create(tempConfigPath))
+        {
+            await stream.CopyToAsync(fileStream);
+        }
+
+        // 4. Start PgBouncer on the same network (random host port to avoid conflicts)
+        _pgBouncerContainer = new ContainerBuilder("ghcr.io/icoretech/pgbouncer-docker:1.25.1")
+            .WithNetwork(_network)
+            .WithPortBinding(5432, assignRandomHostPort: true)
+            .WithResourceMapping(tempConfigPath, "/etc/pgbouncer/pgbouncer.ini")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(5432))
+            .WithCleanUp(true)
+            .Build();
+
+        await _pgBouncerContainer.StartAsync();
+
+        // 5. Build connection string through PgBouncer
+        var pgBouncerPort = _pgBouncerContainer.GetMappedPublicPort(5432);
+        var directBuilder = new NpgsqlConnectionStringBuilder(DirectConnectionString);
+
+        var pgBouncerBuilder = new NpgsqlConnectionStringBuilder
+        {
+            Host = "localhost",
+            Port = pgBouncerPort,
+            Database = directBuilder.Database,
+            Username = directBuilder.Username,
+            Password = directBuilder.Password,
+            NoResetOnClose = true
+        };
+        PgBouncerConnectionString = pgBouncerBuilder.ConnectionString;
+
+        // Clean up temp file
+        File.Delete(tempConfigPath);
+    }
+
+    /// <summary>
+    /// Creates a unique database accessible through both direct and PgBouncer connections.
+    /// </summary>
+    public async Task<(string directConnStr, string pgBouncerConnStr)> CreateUniqueDatabaseAsync()
+    {
+        var dbName = $"test_db_{Guid.NewGuid():N}";
+
+        // Create database via direct connection
+        var adminBuilder = new NpgsqlConnectionStringBuilder(DirectConnectionString)
+        {
+            Database = "postgres"
+        };
+
+        await using (var connection = new NpgsqlConnection(adminBuilder.ConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var cmd = new NpgsqlCommand($"CREATE DATABASE \"{dbName}\"", connection);
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Return both connection strings for the new database
+        var directBuilder = new NpgsqlConnectionStringBuilder(DirectConnectionString) { Database = dbName };
+        var pgBouncerBuilder = new NpgsqlConnectionStringBuilder(PgBouncerConnectionString) { Database = dbName };
+
+        return (directBuilder.ConnectionString, pgBouncerBuilder.ConnectionString);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _pgBouncerContainer?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _postgresContainer?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _network?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+        _disposed = true;
+    }
+}
+```
+
+- [ ] **Step 15: Build to verify infrastructure compiles**
+
+Run: `dotnet build TelegramGroupsAdmin.IntegrationTests`
+Expected: Build succeeds.
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add Directory.Packages.props TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj TelegramGroupsAdmin.IntegrationTests/PgBouncer/
+git commit -m "test: add PgBouncer integration test infrastructure (#pgbouncer)"
+```
+
+---
+
+## Task 5: PgBouncer Integration Tests
+
+**Files:**
+- Create: `TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs`
+
+- [ ] **Step 17: Write the integration tests**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using TelegramGroupsAdmin.Data;
+
+namespace TelegramGroupsAdmin.IntegrationTests.PgBouncer;
+
+/// <summary>
+/// Validates that TGA works correctly through PgBouncer in transaction mode.
+/// These tests use real PostgreSQL + PgBouncer containers matching production config.
+/// </summary>
+[TestFixture]
+[Category("PgBouncer")]
+public class PgBouncerMigrationTests
+{
+    private PgBouncerFixture _fixture = null!;
+
+    [OneTimeSetUp]
+    public async Task FixtureSetup()
+    {
+        _fixture = new PgBouncerFixture();
+        await _fixture.StartAsync();
+    }
+
+    [OneTimeTearDown]
+    public void FixtureTeardown()
+    {
+        _fixture.Dispose();
+    }
+
+    [Test]
+    public async Task MigrateAsync_ThroughPgBouncer_AppliesAllMigrations()
+    {
+        // Arrange — create a fresh database accessible through PgBouncer
+        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseNpgsql(pgBouncerConnStr);
+
+        // Act — run all EF Core migrations through PgBouncer
+        await using var context = new AppDbContext(optionsBuilder.Options);
+        await context.Database.MigrateAsync();
+
+        // Assert — verify migrations applied by checking a known table exists
+        var appliedMigrations = await context.Database
+            .GetAppliedMigrationsAsync();
+        Assert.That(appliedMigrations, Is.Not.Empty,
+            "Expected at least one migration to be applied through PgBouncer");
+    }
+
+    [Test]
+    public async Task EfCoreCrud_ThroughPgBouncer_WorksCorrectly()
+    {
+        // Arrange — create and migrate a fresh database
+        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseNpgsql(pgBouncerConnStr);
+
+        await using var migrationContext = new AppDbContext(optionsBuilder.Options);
+        await migrationContext.Database.MigrateAsync();
+
+        // Act — perform a basic CRUD operation through PgBouncer
+        await using var crudContext = new AppDbContext(optionsBuilder.Options);
+
+        // Insert a config record (configs table is always available after migration)
+        var configCount = await crudContext.Configs.CountAsync();
+
+        // Assert — query succeeded through PgBouncer without errors
+        Assert.That(configCount, Is.GreaterThanOrEqualTo(0),
+            "Expected to query configs table through PgBouncer without errors");
+    }
+
+    [Test]
+    public async Task MultipleContexts_ThroughPgBouncer_ConnectionPoolingWorks()
+    {
+        // Arrange — validates IDbContextFactory pattern works through PgBouncer
+        var (_, pgBouncerConnStr) = await _fixture.CreateUniqueDatabaseAsync();
+
+        var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
+        optionsBuilder.UseNpgsql(pgBouncerConnStr);
+
+        // Migrate first
+        await using (var migrationContext = new AppDbContext(optionsBuilder.Options))
+        {
+            await migrationContext.Database.MigrateAsync();
+        }
+
+        // Act — create and dispose multiple contexts rapidly (simulates IDbContextFactory pattern)
+        for (var i = 0; i < 10; i++)
+        {
+            await using var context = new AppDbContext(optionsBuilder.Options);
+            await context.Configs.CountAsync();
+        }
+
+        // Assert — if we got here without exceptions, connection pooling through PgBouncer works
+        Assert.Pass("10 rapid context create/dispose cycles completed through PgBouncer");
+    }
+}
+```
+
+- [ ] **Step 18: Build to verify tests compile**
+
+Run: `dotnet build TelegramGroupsAdmin.IntegrationTests`
+Expected: Build succeeds.
+
+- [ ] **Step 19: Run the PgBouncer integration tests**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "Category=PgBouncer" --verbosity normal > /tmp/pgbouncer-test-output.log 2>&1`
+
+This runs in background since integration tests are slow. Check results:
+
+Run: `grep -E "(Passed|Failed|Error)" /tmp/pgbouncer-test-output.log`
+Expected: All 3 tests pass.
+
+- [ ] **Step 20: Commit**
+
+```bash
+git add TelegramGroupsAdmin.IntegrationTests/PgBouncer/PgBouncerMigrationTests.cs
+git commit -m "test: add PgBouncer migration and CRUD integration tests (#pgbouncer)"
+```
+
+---
+
+## Task 6: Final Verification
+
+- [ ] **Step 21: Run full unit test suite**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests`
+Expected: All tests pass (no regressions from connection string change).
+
+- [ ] **Step 22: Run `--migrate-only` to verify startup path**
+
+Run: `dotnet run --project TelegramGroupsAdmin -- --migrate-only`
+Expected: Migrations complete successfully. No PgBouncer log line (env var not set).
+
+- [ ] **Step 23: Run `--migrate-only` with PGBOUNCER_MODE set to verify logging**
+
+Run: `PGBOUNCER_MODE=true dotnet run --project TelegramGroupsAdmin -- --migrate-only`
+Expected: Migrations complete successfully. Log line shows "PgBouncer mode active".
+
+- [ ] **Step 24: Final commit if any cleanup needed, then verify branch state**
+
+Run: `git log --oneline feature/pgbouncer-compatibility ^develop`
+Expected: 5-6 commits (spec + implementation commits).

--- a/docs/superpowers/specs/2026-03-21-pgbouncer-compatibility-design.md
+++ b/docs/superpowers/specs/2026-03-21-pgbouncer-compatibility-design.md
@@ -1,0 +1,102 @@
+# PgBouncer Compatibility for TGA Hosting Platform
+
+## Context
+
+TGA is being deployed on a hosting platform where multiple tenant instances share a single PostgreSQL server through PgBouncer in **transaction mode**. Each tenant gets their own database. PgBouncer (v1.25.1, `ghcr.io/icoretech/pgbouncer-docker:1.25.1`) pools connections across all tenant databases to reduce total PostgreSQL connections.
+
+### Problem
+
+Npgsql sends `DISCARD ALL` when returning connections to its internal pool, which conflicts with PgBouncer's own connection state management in transaction mode. The app needs `No Reset On Close=true` in the connection string to prevent this.
+
+### Migration Locking — Not a Problem
+
+Earlier versions of Npgsql used session-level advisory locks (`pg_try_advisory_lock`) for migration concurrency, which broke in PgBouncer transaction mode. **Npgsql 10.0 uses `LOCK TABLE "__EFMigrationsHistory" IN ACCESS EXCLUSIVE MODE`** — a transaction-scoped table lock with `LockReleaseBehavior.Transaction`. Since PgBouncer transaction mode holds the same server connection for the duration of a transaction, this lock is fully compatible. No migration lock override is needed.
+
+### Non-Problems
+
+These components work through PgBouncer transaction mode without app changes:
+
+- **EF Core migrations** — Npgsql 10.0 uses transaction-scoped table locks, not session-scoped advisory locks. Compatible with PgBouncer transaction mode.
+- **MigrationHistoryCompactionService** — runs before `MigrateAsync()` using `OpenConnectionAsync()` with explicit `BeginTransactionAsync()`. PgBouncer holds the connection for the transaction duration.
+- **IDbContextFactory pattern** — short-lived contexts with transaction-scoped connections; ideal for transaction mode
+- **Quartz.NET** — has its own connection pool; PgBouncer 1.25.1 supports protocol-level prepared statements in transaction mode. Npgsql manages its own prepared statement lifecycle; PgBouncer's default `max_prepared_statements = 0` means it does not interfere with Npgsql's internal management.
+- **DatabaseMaintenanceJob** — `VACUUM`/`ANALYZE` run as single statements outside transactions; PgBouncer holds the connection for the command duration. Operator must configure `query_timeout = 0` (no query timeout) to accommodate the 600s command timeout — the app manages its own timeout via `NpgsqlCommand.CommandTimeout`.
+- **Backup/Restore** — long-running operations via `OpenConnectionAsync()`; operator configures `query_timeout = 0`
+- **Health checks** — readiness probe validates the full PgBouncer → PostgreSQL path
+
+## Design
+
+### Control Mechanism
+
+Environment variable `PGBOUNCER_MODE=true` — consistent with existing env var pattern (`ENABLE_METRICS`, `SEQ_URL`). When not set, behavior is unchanged (backwards-compatible for homelab/direct connections).
+
+### Change 1: Connection String Modification
+
+**Modified file:** `TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs`
+
+When `PGBOUNCER_MODE` is set, modify the connection string before registering `NpgsqlDataSource`:
+
+- Set `No Reset On Close=true` — prevents Npgsql from sending `DISCARD ALL` when returning connections to its internal pool. PgBouncer handles connection state reset via its own `server_reset_query = DISCARD ALL`.
+
+Use `NpgsqlConnectionStringBuilder` for clean modification rather than string concatenation.
+
+### Change 2: Startup Logging
+
+**Modified file:** `TelegramGroupsAdmin/WebApplicationExtensions.cs`
+
+Log at Information level in `RunDatabaseMigrationsAsync()` whether PgBouncer mode is active. Operators can verify configuration in logs.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `TelegramGroupsAdmin.Data/Extensions/ServiceCollectionExtensions.cs` | Connection string modification when `PGBOUNCER_MODE` is set |
+| `TelegramGroupsAdmin/WebApplicationExtensions.cs` | Startup log line |
+
+## What Does NOT Change
+
+- EF Core migration locking — Npgsql 10.0 table locks are PgBouncer-compatible
+- MigrationHistoryCompactionService — transaction-scoped, works through PgBouncer
+- Quartz.NET configuration — works through PgBouncer 1.25.1
+- DatabaseMaintenanceJob — operator configures PgBouncer timeouts
+- Backup/Restore services — operator configures PgBouncer timeouts
+- Health checks — validates full PgBouncer → PostgreSQL path
+- IDbContextFactory pattern — already PgBouncer-friendly
+- EF Core retry policy — 6 retries with 30s max delay, works with PgBouncer transient disconnects
+
+## Testing
+
+### Unit Tests
+
+- Connection string modification: verify `No Reset On Close=true` is appended when `PGBOUNCER_MODE` is set
+- Connection string unmodified: verify no changes when `PGBOUNCER_MODE` is not set
+
+### Integration Test (Testcontainers + PgBouncer)
+
+This is the most important deliverable — proves TGA works end-to-end through PgBouncer and catches future regressions.
+
+1. Start PostgreSQL 18 container (existing Testcontainers infrastructure)
+2. Start PgBouncer container (`ghcr.io/icoretech/pgbouncer-docker:1.25.1`) in transaction mode pointing at the PostgreSQL container
+3. Build `NpgsqlDataSource` with PgBouncer connection string + `No Reset On Close=true`
+4. Create `AppDbContext` and run `MigrateAsync()` through PgBouncer
+5. Verify schema was created (query a known table)
+6. Verify basic EF Core CRUD operations work through PgBouncer
+
+This test catches:
+- Migration table lock compatibility with PgBouncer transaction mode
+- Npgsql connection string settings behaving correctly
+- Any EF Core/Npgsql protocol issues through PgBouncer
+- Regressions if future EF Core/Npgsql upgrades change migration locking behavior
+
+## Operator-Side PgBouncer Configuration
+
+Not part of this implementation — provided as a reference for the hosting platform:
+
+```ini
+pool_mode = transaction
+max_prepared_statements = 0
+query_timeout = 0
+server_idle_timeout = 600
+client_idle_timeout = 0
+server_reset_query = DISCARD ALL
+```

--- a/docs/superpowers/specs/2026-03-21-pgbouncer-compatibility-design.md
+++ b/docs/superpowers/specs/2026-03-21-pgbouncer-compatibility-design.md
@@ -75,8 +75,45 @@ Log at Information level in `RunDatabaseMigrationsAsync()` whether PgBouncer mod
 
 This is the most important deliverable — proves TGA works end-to-end through PgBouncer and catches future regressions.
 
+**PgBouncer test config** — mirrors production-meaningful settings, skips Kubernetes-specific auth/networking:
+
+```ini
+[databases]
+* = host=postgres port=5432
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 5432
+pool_mode = transaction
+auth_type = trust
+ignore_startup_parameters = extra_float_digits,options
+
+; Prepared statement support (PgBouncer 1.21+, required for Quartz.NET)
+max_prepared_statements = 0
+
+; Connection limits
+max_client_conn = 200
+default_pool_size = 20
+min_pool_size = 2
+max_db_connections = 50
+
+; Timeouts - match production
+query_timeout = 0
+server_idle_timeout = 600
+client_idle_timeout = 0
+server_connect_timeout = 15
+
+; Connection lifetime
+server_lifetime = 3600
+
+; Transaction mode safety
+server_reset_query = DISCARD ALL
+```
+
+**Test steps:**
+
 1. Start PostgreSQL 18 container (existing Testcontainers infrastructure)
-2. Start PgBouncer container (`ghcr.io/icoretech/pgbouncer-docker:1.25.1`) in transaction mode pointing at the PostgreSQL container
+2. Start PgBouncer container (`ghcr.io/icoretech/pgbouncer-docker:1.25.1`) with the config above, pointing at the PostgreSQL container
 3. Build `NpgsqlDataSource` with PgBouncer connection string + `No Reset On Close=true`
 4. Create `AppDbContext` and run `MigrateAsync()` through PgBouncer
 5. Verify schema was created (query a known table)
@@ -85,18 +122,11 @@ This is the most important deliverable — proves TGA works end-to-end through P
 This test catches:
 - Migration table lock compatibility with PgBouncer transaction mode
 - Npgsql connection string settings behaving correctly
+- `ignore_startup_parameters` covering Npgsql's startup parameters
+- `server_reset_query = DISCARD ALL` interacting correctly with `No Reset On Close=true`
 - Any EF Core/Npgsql protocol issues through PgBouncer
 - Regressions if future EF Core/Npgsql upgrades change migration locking behavior
 
 ## Operator-Side PgBouncer Configuration
 
-Not part of this implementation — provided as a reference for the hosting platform:
-
-```ini
-pool_mode = transaction
-max_prepared_statements = 0
-query_timeout = 0
-server_idle_timeout = 600
-client_idle_timeout = 0
-server_reset_query = DISCARD ALL
-```
+Not part of this implementation — the full production config is maintained by the hosting platform. The integration test config above mirrors the production-meaningful settings for validation.


### PR DESCRIPTION
## Summary

- Adds `PGBOUNCER_MODE` env var that configures the connection string with `No Reset On Close=true`, preventing Npgsql from sending `DISCARD ALL` which conflicts with PgBouncer transaction mode
- Logs PgBouncer mode status at startup for operator visibility
- Adds integration tests with real PgBouncer 1.25.1 + PostgreSQL 18 containers matching production auth chain (`scram-sha-256` + `auth_query` + `pgbouncer_auth` SUPERUSER)

## Context

TGA is being deployed on a hosting platform where multiple tenant instances share a single PostgreSQL server through PgBouncer in transaction mode. Each tenant gets their own database. PgBouncer pools connections across all tenant databases to reduce total PostgreSQL connections.

Key finding during design: Npgsql 10.0 uses transaction-scoped table locks (`LOCK TABLE "__EFMigrationsHistory"`) for migration concurrency — NOT session-scoped advisory locks. This means EF Core migrations work through PgBouncer transaction mode out of the box. No migration lock override needed.

## Changes

| File | Change |
|------|--------|
| `ServiceCollectionExtensions.cs` | `ApplyPgBouncerSettings()` adds `NoResetOnClose=true` when `PGBOUNCER_MODE` is set |
| `WebApplicationExtensions.cs` | Startup log line confirming PgBouncer mode |
| `PgBouncerFixture.cs` | Testcontainers fixture: PostgreSQL + PgBouncer with production auth chain |
| `PgBouncerMigrationTests.cs` | 3 integration tests: migrations, CRUD, connection pooling through PgBouncer |
| `pgbouncer.ini` + `userlist.txt` | Test PgBouncer config matching production settings |

## What does NOT change

- EF Core migration locking (already PgBouncer-compatible in Npgsql 10.0)
- Quartz.NET (works with PgBouncer 1.25.1 prepared statement support)
- DatabaseMaintenanceJob (operator configures PgBouncer timeouts)
- Behavior when `PGBOUNCER_MODE` is not set (fully backwards-compatible)

## Test plan

- [x] 1829 unit tests pass (includes 3 new PgBouncer connection string tests)
- [x] 3 PgBouncer integration tests pass (migrations, CRUD, connection pooling through real PgBouncer container)
- [ ] Deploy with `PGBOUNCER_MODE=true` on hosting platform and verify startup log
- [ ] Verify tenant instances connect and operate normally through PgBouncer


🤖 Generated with [Claude Code](https://claude.com/claude-code)