### PR TITLE
fix: quick wins #398, #399, #405

### DIFF
--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
@@ -6,6 +6,7 @@ using Quartz;
 using TelegramGroupsAdmin.Configuration;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
 using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
+using TelegramGroupsAdmin.ContentDetection.Repositories;
 using TelegramGroupsAdmin.Core.Repositories;
 using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Core.Utilities;
@@ -80,6 +81,7 @@ public class DataCleanupJob : IJob
         var reportRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.ReportRetention, DataCleanupSettings.DefaultReportRetention);
         var contextRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.CallbackContextRetention, DataCleanupSettings.DefaultShortRetention);
         var notificationRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.WebNotificationRetention, DataCleanupSettings.DefaultShortRetention);
+        var fileScanRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.FileScanResultRetention, DataCleanupSettings.DefaultFileScanResultRetention);
 
         _logger.LogInformation("Data cleanup job started");
 
@@ -94,6 +96,9 @@ public class DataCleanupJob : IJob
 
         // 4. Clean up old read web notifications
         await CleanupNotificationsAsync(sp, notificationRetention, cancellationToken);
+
+        // 5. Clean up expired file scan results
+        await CleanupFileScanResultsAsync(sp, fileScanRetention, cancellationToken);
 
         _logger.LogInformation("Data cleanup job completed");
     }
@@ -197,6 +202,20 @@ public class DataCleanupJob : IJob
             _logger.LogInformation(
                 "Notification cleanup: {Count} old read notifications deleted (retention: {Retention})",
                 notificationsDeleted,
+                TimeSpanUtilities.FormatDuration(retention));
+        }
+    }
+
+    private async Task CleanupFileScanResultsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken ct)
+    {
+        var fileScanRepo = sp.GetRequiredService<IFileScanResultRepository>();
+        var deleted = await fileScanRepo.CleanupExpiredResultsAsync(retention, cancellationToken: ct);
+
+        if (deleted > 0)
+        {
+            _logger.LogInformation(
+                "File scan result cleanup: {Count} expired results deleted (retention: {Retention})",
+                deleted,
                 TimeSpanUtilities.FormatDuration(retention));
         }
     }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
@@ -103,10 +103,10 @@ public class DataCleanupJob : IJob
         _logger.LogInformation("Data cleanup job completed");
     }
 
-    private async Task CleanupMessagesAsync(IServiceProvider sp, TimeSpan retention, CancellationToken ct)
+    private async Task CleanupMessagesAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var repository = sp.GetRequiredService<IMessageHistoryRepository>();
-        var result = await repository.CleanupExpiredAsync(retention, ct);
+        var result = await repository.CleanupExpiredAsync(retention, cancellationToken);
 
         // Delete image files from disk (photo thumbnails)
         var imageDeletedCount = 0;
@@ -162,11 +162,11 @@ public class DataCleanupJob : IJob
                 : "none");
     }
 
-    private async Task CleanupReportsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken ct)
+    private async Task CleanupReportsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var reportsRepo = sp.GetRequiredService<IReportsRepository>();
         var reportsCutoff = DateTimeOffset.UtcNow - retention;
-        var reportsDeleted = await reportsRepo.DeleteOldReportsAsync(reportsCutoff, type: null, ct);
+        var reportsDeleted = await reportsRepo.DeleteOldReportsAsync(reportsCutoff, type: null, cancellationToken);
 
         if (reportsDeleted > 0)
         {
@@ -177,10 +177,10 @@ public class DataCleanupJob : IJob
         }
     }
 
-    private async Task CleanupCallbackContextsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken ct)
+    private async Task CleanupCallbackContextsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var callbackContextRepo = sp.GetRequiredService<IReportCallbackContextRepository>();
-        var contextsDeleted = await callbackContextRepo.DeleteExpiredAsync(retention, ct);
+        var contextsDeleted = await callbackContextRepo.DeleteExpiredAsync(retention, cancellationToken);
 
         if (contextsDeleted > 0)
         {
@@ -191,11 +191,11 @@ public class DataCleanupJob : IJob
         }
     }
 
-    private async Task CleanupNotificationsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken ct)
+    private async Task CleanupNotificationsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         // Use repository directly - it's the domain expert for notification data
         var notificationRepo = sp.GetRequiredService<IWebNotificationRepository>();
-        var notificationsDeleted = await notificationRepo.DeleteOldReadNotificationsAsync(retention, ct);
+        var notificationsDeleted = await notificationRepo.DeleteOldReadNotificationsAsync(retention, cancellationToken);
 
         if (notificationsDeleted > 0)
         {
@@ -206,10 +206,10 @@ public class DataCleanupJob : IJob
         }
     }
 
-    private async Task CleanupFileScanResultsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken ct)
+    private async Task CleanupFileScanResultsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var fileScanRepo = sp.GetRequiredService<IFileScanResultRepository>();
-        var deleted = await fileScanRepo.CleanupExpiredResultsAsync(retention, cancellationToken: ct);
+        var deleted = await fileScanRepo.CleanupExpiredResultsAsync(retention, cancellationToken);
 
         if (deleted > 0)
         {

--- a/TelegramGroupsAdmin.ComponentTests/Components/MessageBubbleTelegramTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/MessageBubbleTelegramTests.cs
@@ -458,7 +458,10 @@ public class MessageBubbleTelegramTests : MudBlazorTestContext
     [Test]
     public void DisplaysTimestamp()
     {
-        // Arrange
+        // Arrange — cascade TimeZoneInfo so LocalTimestamp renders the formatted time
+        RenderTree.TryAdd<Microsoft.AspNetCore.Components.CascadingValue<TimeZoneInfo?>>(p =>
+            p.Add(cv => cv.Value, TimeZoneInfo.Utc));
+
         var timestamp = new DateTimeOffset(2025, 6, 15, 14, 30, 0, TimeSpan.Zero);
         var message = new MessageRecord(
             MessageId: 123,
@@ -494,13 +497,14 @@ public class MessageBubbleTelegramTests : MudBlazorTestContext
         var cut = Render<MessageBubbleTelegram>(p => p
             .Add(x => x.Message, message));
 
-        // Assert — the timestamp element is rendered with the UTC value in data-utc attribute
+        // Assert — timestamp is rendered inside tg-timestamp wrapper via LocalTimestamp
         var timestampEl = cut.Find(".tg-timestamp");
-        Assert.That(timestampEl.GetAttribute("data-utc"), Is.EqualTo(timestamp.ToString("o")));
+        var displayTime = TimeZoneInfo.ConvertTime(timestamp, TimeZoneInfo.Utc);
+        Assert.That(timestampEl.TextContent.Trim(), Is.EqualTo(displayTime.ToString("MMM d, yyyy h:mm tt")));
     }
 
     [Test]
-    public void TimestampElement_HasLocalTimestampClass()
+    public void TimestampElement_HasTgTimestampClass()
     {
         // Arrange
         var message = CreateMessage();
@@ -509,8 +513,8 @@ public class MessageBubbleTelegramTests : MudBlazorTestContext
         var cut = Render<MessageBubbleTelegram>(p => p
             .Add(x => x.Message, message));
 
-        // Assert — client-side JS will localise times; verify the CSS hook class is present
-        var timestampEl = cut.Find(".tg-timestamp.local-timestamp");
+        // Assert — tg-timestamp wrapper exists around the LocalTimestamp component
+        var timestampEl = cut.Find(".tg-timestamp");
         Assert.That(timestampEl, Is.Not.Null);
     }
 

--- a/TelegramGroupsAdmin.ContentDetection/Repositories/FileScanResultRepository.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Repositories/FileScanResultRepository.cs
@@ -81,7 +81,7 @@ public class FileScanResultRepository : IFileScanResultRepository
         context.FileScanResults.RemoveRange(expiredResults);
         await context.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation("Cleaned up {Count} expired scan results (retention: {Retention})",
+        _logger.LogDebug("Cleaned up {Count} expired scan results (retention: {Retention})",
             expiredResults.Count, retention);
 
         return expiredResults.Count;

--- a/TelegramGroupsAdmin.ContentDetection/Repositories/FileScanResultRepository.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Repositories/FileScanResultRepository.cs
@@ -61,11 +61,11 @@ public class FileScanResultRepository : IFileScanResultRepository
         return dto.ToModel();
     }
 
-    public async Task<int> CleanupExpiredResultsAsync(CancellationToken cancellationToken = default)
+    public async Task<int> CleanupExpiredResultsAsync(TimeSpan retention, CancellationToken cancellationToken = default)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
-        var cutoffTime = DateTimeOffset.UtcNow - CacheTtl;
+        var cutoffTime = DateTimeOffset.UtcNow - retention;
 
         var expiredResults = await context.FileScanResults
             .Where(fsr => fsr.ScannedAt < cutoffTime)
@@ -81,8 +81,8 @@ public class FileScanResultRepository : IFileScanResultRepository
         context.FileScanResults.RemoveRange(expiredResults);
         await context.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation("Cleaned up {Count} expired scan results (older than {TTL})",
-            expiredResults.Count, CacheTtl);
+        _logger.LogInformation("Cleaned up {Count} expired scan results (retention: {Retention})",
+            expiredResults.Count, retention);
 
         return expiredResults.Count;
     }

--- a/TelegramGroupsAdmin.ContentDetection/Repositories/IFileScanResultRepository.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Repositories/IFileScanResultRepository.cs
@@ -3,14 +3,15 @@ using TelegramGroupsAdmin.ContentDetection.Models;
 namespace TelegramGroupsAdmin.ContentDetection.Repositories;
 
 /// <summary>
-/// Repository for managing file scan result caching
-/// Provides hash-based lookups with 24-hour TTL
+/// Repository for managing file scan result caching.
+/// Read path uses a hardcoded 24-hour TTL for cache freshness.
+/// Cleanup retention is configurable via DataCleanupSettings (default: 24 hours).
 /// </summary>
 public interface IFileScanResultRepository
 {
     /// <summary>
-    /// Get cached scan results for a file hash (24-hour TTL)
-    /// Returns all scanner results for the hash that are still fresh
+    /// Get cached scan results for a file hash (hardcoded 24-hour read TTL).
+    /// Returns all scanner results for the hash that are still fresh.
     /// </summary>
     /// <param name="fileHash">SHA256 hash of the file (64 hex chars)</param>
     /// <param name="cancellationToken">Cancellation token</param>

--- a/TelegramGroupsAdmin.ContentDetection/Repositories/IFileScanResultRepository.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Repositories/IFileScanResultRepository.cs
@@ -31,12 +31,13 @@ public interface IFileScanResultRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Cleanup expired scan results (older than 24 hours)
-    /// Should be called periodically via Quartz.NET background job
+    /// Cleanup expired scan results older than the specified retention period.
+    /// Should be called periodically via Quartz.NET background job.
     /// </summary>
+    /// <param name="retention">How long to keep scan results before cleanup</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Number of records deleted</returns>
-    Task<int> CleanupExpiredResultsAsync(CancellationToken cancellationToken = default);
+    Task<int> CleanupExpiredResultsAsync(TimeSpan retention, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Clear ALL cached scan results (for testing purposes)

--- a/TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs
+++ b/TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs
@@ -27,6 +27,16 @@ public record DataCleanupSettings
     public static readonly TimeSpan DefaultShortRetention = TimeSpan.FromDays(7);
 
     /// <summary>
+    /// Default file scan result retention period string (24 hours).
+    /// </summary>
+    public const string DefaultFileScanResultRetentionString = "24h";
+
+    /// <summary>
+    /// Fallback retention for file scan results if parsing fails (24 hours).
+    /// </summary>
+    public static readonly TimeSpan DefaultFileScanResultRetention = TimeSpan.FromHours(24);
+
+    /// <summary>
     /// Retention period for message history (default: 2 years).
     /// Messages with detection results (training data) are kept permanently.
     /// </summary>
@@ -47,4 +57,10 @@ public record DataCleanupSettings
     /// Retention period for read web notifications (default: 7 days).
     /// </summary>
     public string WebNotificationRetention { get; init; } = "7d";
+
+    /// <summary>
+    /// Retention period for file scan results (default: 24 hours).
+    /// Scan results are cached to avoid re-scanning the same file.
+    /// </summary>
+    public string FileScanResultRetention { get; init; } = DefaultFileScanResultRetentionString;
 }

--- a/TelegramGroupsAdmin.Data/AppDbContext.cs
+++ b/TelegramGroupsAdmin.Data/AppDbContext.cs
@@ -678,7 +678,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .HasIndex(bs => bs.BlockMode)
             .HasFilter("block_mode > 0");
         modelBuilder.Entity<BlocklistSubscriptionDto>()
-            .HasIndex(bs => bs.Url);  // For duplicate detection
+            .HasIndex(bs => new { bs.Url, bs.ChatId })
+            .IsUnique();
 
         // DomainFilters indexes
         modelBuilder.Entity<DomainFilterDto>()

--- a/TelegramGroupsAdmin.Data/Migrations/20260322214015_AddBlocklistSubscriptionUniqueUrlChatId.Designer.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260322214015_AddBlocklistSubscriptionUniqueUrlChatId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TelegramGroupsAdmin.Data;
@@ -11,9 +12,11 @@ using TelegramGroupsAdmin.Data;
 namespace TelegramGroupsAdmin.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260322214015_AddBlocklistSubscriptionUniqueUrlChatId")]
+    partial class AddBlocklistSubscriptionUniqueUrlChatId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TelegramGroupsAdmin.Data/Migrations/20260322214015_AddBlocklistSubscriptionUniqueUrlChatId.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260322214015_AddBlocklistSubscriptionUniqueUrlChatId.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelegramGroupsAdmin.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBlocklistSubscriptionUniqueUrlChatId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Remove any existing duplicate (url, chat_id) rows before creating the unique index
+            migrationBuilder.Sql("""
+                DELETE FROM blocklist_subscriptions
+                WHERE id NOT IN (
+                    SELECT MAX(id) FROM blocklist_subscriptions GROUP BY url, chat_id
+                );
+                """);
+
+            migrationBuilder.DropIndex(
+                name: "IX_blocklist_subscriptions_url",
+                table: "blocklist_subscriptions");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_blocklist_subscriptions_url_chat_id",
+                table: "blocklist_subscriptions",
+                columns: new[] { "url", "chat_id" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_blocklist_subscriptions_url_chat_id",
+                table: "blocklist_subscriptions");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_blocklist_subscriptions_url",
+                table: "blocklist_subscriptions",
+                column: "url");
+        }
+    }
+}

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/Settings/WebAdminAccountsPage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/Settings/WebAdminAccountsPage.cs
@@ -81,8 +81,8 @@ public class WebAdminAccountsPage
             Timeout = timeoutMs
         });
 
-        // Wait for loading indicator to disappear
-        var loadingIndicator = _page.Locator(LoadingIndicator);
+        // Wait for loading indicator to disappear (use .First to avoid strict mode when multiple progress bars exist)
+        var loadingIndicator = _page.Locator(LoadingIndicator).First;
         try
         {
             await loadingIndicator.WaitForAsync(new LocatorWaitForOptions

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs
@@ -1,0 +1,135 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Jobs;
+using TelegramGroupsAdmin.BackgroundJobs.Services;
+using TelegramGroupsAdmin.Configuration;
+using TelegramGroupsAdmin.ContentDetection.Repositories;
+using TelegramGroupsAdmin.Core.BackgroundJobs;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
+using TelegramGroupsAdmin.Core.Repositories;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+
+namespace TelegramGroupsAdmin.UnitTests.BackgroundJobs.Jobs;
+
+[TestFixture]
+public class DataCleanupJobTests
+{
+    private IServiceScopeFactory _scopeFactory = null!;
+    private IServiceScope _scope = null!;
+    private IServiceProvider _serviceProvider = null!;
+    private IBackgroundJobConfigService _configService = null!;
+    private IMessageHistoryRepository _messageHistoryRepo = null!;
+    private IReportsRepository _reportsRepo = null!;
+    private IReportCallbackContextRepository _callbackContextRepo = null!;
+    private IWebNotificationRepository _notificationRepo = null!;
+    private IFileScanResultRepository _fileScanResultRepo = null!;
+    private IJobExecutionContext _jobContext = null!;
+    private DataCleanupJob _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _scopeFactory = Substitute.For<IServiceScopeFactory>();
+        _serviceProvider = Substitute.For<IServiceProvider>();
+        _configService = Substitute.For<IBackgroundJobConfigService>();
+        _messageHistoryRepo = Substitute.For<IMessageHistoryRepository>();
+        _reportsRepo = Substitute.For<IReportsRepository>();
+        _callbackContextRepo = Substitute.For<IReportCallbackContextRepository>();
+        _notificationRepo = Substitute.For<IWebNotificationRepository>();
+        _fileScanResultRepo = Substitute.For<IFileScanResultRepository>();
+
+        _scope = Substitute.For<IServiceScope>();
+        _scopeFactory.CreateScope().Returns(_scope);
+        _scope.ServiceProvider.Returns(_serviceProvider);
+
+        _serviceProvider.GetService(typeof(IBackgroundJobConfigService)).Returns(_configService);
+        _serviceProvider.GetService(typeof(IMessageHistoryRepository)).Returns(_messageHistoryRepo);
+        _serviceProvider.GetService(typeof(IReportsRepository)).Returns(_reportsRepo);
+        _serviceProvider.GetService(typeof(IReportCallbackContextRepository)).Returns(_callbackContextRepo);
+        _serviceProvider.GetService(typeof(IWebNotificationRepository)).Returns(_notificationRepo);
+        _serviceProvider.GetService(typeof(IFileScanResultRepository)).Returns(_fileScanResultRepo);
+
+        // Default: return empty config (use defaults)
+        _configService.GetJobConfigAsync(BackgroundJobNames.DataCleanup)
+            .Returns(Task.FromResult<BackgroundJobConfig?>(null));
+
+        // Default: message cleanup returns empty result
+        _messageHistoryRepo.CleanupExpiredAsync(Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(new MessageCleanupResult(0, [], [], 0, 0, 0, null));
+
+        var appOptions = Options.Create(new AppOptions { DataPath = "/data" });
+        var logger = Substitute.For<ILogger<DataCleanupJob>>();
+
+        _jobContext = Substitute.For<IJobExecutionContext>();
+        _jobContext.CancellationToken.Returns(CancellationToken.None);
+
+        _sut = new DataCleanupJob(_scopeFactory, appOptions, logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _scope.Dispose();
+    }
+
+    [Test]
+    public async Task Execute_CallsFileScanResultCleanup_WithDefaultRetention()
+    {
+        // Act
+        await _sut.Execute(_jobContext);
+
+        // Assert — file scan result cleanup is called with 24h default retention
+        await _fileScanResultRepo.Received(1).CleanupExpiredResultsAsync(
+            TimeSpan.FromHours(24),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Execute_CallsFileScanResultCleanup_WithConfiguredRetention()
+    {
+        // Arrange — configure 48h retention
+        var settings = new DataCleanupSettings { FileScanResultRetention = "48h" };
+        var config = new BackgroundJobConfig
+        {
+            JobName = BackgroundJobNames.DataCleanup,
+            DisplayName = "Data Cleanup",
+            Description = "Test",
+            Schedule = "1d",
+            DataCleanup = settings
+        };
+        _configService.GetJobConfigAsync(BackgroundJobNames.DataCleanup)
+            .Returns(Task.FromResult<BackgroundJobConfig?>(config));
+
+        // Act
+        await _sut.Execute(_jobContext);
+
+        // Assert — uses the configured 48h retention
+        await _fileScanResultRepo.Received(1).CleanupExpiredResultsAsync(
+            TimeSpan.FromHours(48),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Execute_CallsAllFiveCleanupSteps()
+    {
+        // Act
+        await _sut.Execute(_jobContext);
+
+        // Assert — all 5 cleanup steps are called
+        await _messageHistoryRepo.Received(1).CleanupExpiredAsync(
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await _reportsRepo.Received(1).DeleteOldReportsAsync(
+            Arg.Any<DateTimeOffset>(), type: null, Arg.Any<CancellationToken>());
+        await _callbackContextRepo.Received(1).DeleteExpiredAsync(
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await _notificationRepo.Received(1).DeleteOldReadNotificationsAsync(
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await _fileScanResultRepo.Received(1).CleanupExpiredResultsAsync(
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/TelegramGroupsAdmin/Components/Pages/Users.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Users.razor
@@ -250,14 +250,14 @@
                      Hover="true" Breakpoint="Breakpoint.Sm" Dense="true">
                 <HeaderContent>
                     <MudTh><MudTableSortLabel T="TelegramUserListItem" SortLabel="User">User</MudTableSortLabel></MudTh>
-                    <MudTh><MudTableSortLabel T="TelegramUserListItem" SortLabel="LastSeen">Joined</MudTableSortLabel></MudTh>
+                    <MudTh><MudTableSortLabel T="TelegramUserListItem" SortLabel="LastSeen">Last Seen</MudTableSortLabel></MudTh>
                     <MudTh>Actions</MudTh>
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="User">
                         <UserInfoCell User="context" ShowBadges="false" />
                     </MudTd>
-                    <MudTd DataLabel="Joined">
+                    <MudTd DataLabel="Last Seen">
                         <LocalTimestamp Value="@context.LastSeenAt" />
                     </MudTd>
                     <MudTd DataLabel="Actions">

--- a/TelegramGroupsAdmin/Components/Reports/ExamReviewCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ExamReviewCard.razor
@@ -27,7 +27,7 @@
                     <MudChip T="string" Size="Size.Small" Color="Color.Warning">Pending</MudChip>
                 }
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    <span class="local-timestamp" data-utc="@ExamFailure.FailedAt.ToString("o")">@ExamFailure.FailedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                    <LocalTimestamp Value="@ExamFailure.FailedAt" />
                 </MudText>
             </MudStack>
         </CardHeaderContent>
@@ -228,7 +228,7 @@
             {
                 <MudAlert Severity="Severity.Info" Dense="true">
                     <b>Reviewed:</b> @ExamFailure.ActionTaken by @(ExamFailure.ReviewedBy ?? "Unknown")
-                    on <span class="local-timestamp" data-utc="@ExamFailure.ReviewedAt.Value.ToString("o")">@ExamFailure.ReviewedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                    on <LocalTimestamp Value="@ExamFailure.ReviewedAt.Value" />
                     @if (ExamFailure.AdminNotes != null)
                     {
                         <br /><b>Notes:</b> @ExamFailure.AdminNotes

--- a/TelegramGroupsAdmin/Components/Reports/ImpersonationAlertCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ImpersonationAlertCard.razor
@@ -20,7 +20,7 @@
                     @Alert.RiskLevel.ToString()
                 </MudChip>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    <span class="local-timestamp" data-utc="@Alert.DetectedAt.ToString("o")">@Alert.DetectedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                    <LocalTimestamp Value="@Alert.DetectedAt" />
                 </MudText>
             </MudStack>
         </CardHeaderContent>
@@ -203,7 +203,7 @@
             {
                 <MudAlert Severity="Severity.Info" Dense="true">
                     <b>Reviewed:</b> @Alert.Verdict by @(Alert.ReviewedByEmail ?? Alert.ReviewedByUserId ?? "Unknown")
-                    on <span class="local-timestamp" data-utc="@Alert.ReviewedAt.Value.ToString("o")">@Alert.ReviewedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                    on <LocalTimestamp Value="@Alert.ReviewedAt.Value" />
                 </MudAlert>
             }
         </MudStack>

--- a/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
@@ -18,7 +18,7 @@
                     @Report.Status.ToString()
                 </MudChip>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    <span class="local-timestamp" data-utc="@Report.ReportedAt.ToString("o")">@Report.ReportedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                    <LocalTimestamp Value="@Report.ReportedAt" />
                 </MudText>
             </MudStack>
         </CardHeaderContent>
@@ -59,7 +59,7 @@
                 @if (_message.DeletedAt.HasValue)
                 {
                     <MudChip T="string" Size="Size.Small" Color="Color.Error">
-                        Deleted <span class="local-timestamp" data-utc="@_message.DeletedAt.Value.ToString("o")">@_message.DeletedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                        Deleted <LocalTimestamp Value="@_message.DeletedAt.Value" />
                     </MudChip>
                 }
 

--- a/TelegramGroupsAdmin/Components/Reports/ProfileScanAlertCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ProfileScanAlertCard.razor
@@ -18,7 +18,7 @@
                     @Alert.Outcome.ToString()
                 </MudChip>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    <span class="local-timestamp" data-utc="@Alert.DetectedAt.ToString("o")">@Alert.DetectedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                    <LocalTimestamp Value="@Alert.DetectedAt" />
                 </MudText>
             </MudStack>
         </CardHeaderContent>
@@ -171,7 +171,7 @@
             {
                 <MudAlert Severity="Severity.Info" Dense="true">
                     <b>Reviewed:</b> @(Alert.ActionTaken ?? "Unknown action") by @(Alert.ReviewedByEmail ?? Alert.ReviewedByUserId ?? "Unknown")
-                    on <span class="local-timestamp" data-utc="@Alert.ReviewedAt.Value.ToString("o")">@Alert.ReviewedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                    on <LocalTimestamp Value="@Alert.ReviewedAt.Value" />
                 </MudAlert>
             }
         </MudStack>

--- a/TelegramGroupsAdmin/Components/Shared/BackupBrowser.razor
+++ b/TelegramGroupsAdmin/Components/Shared/BackupBrowser.razor
@@ -276,7 +276,7 @@
                         </tr>
                         <tr>
                             <td><strong>Created At:</strong></td>
-                            <td><span class="local-timestamp" data-utc="@_viewingMetadata.CreatedAt.ToString("o")">@_viewingMetadata.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span></td>
+                            <td><LocalTimestamp Value="@_viewingMetadata.CreatedAt" Format="yyyy-MM-dd HH:mm:ss" /></td>
                         </tr>
                         <tr>
                             <td><strong>App Version:</strong></td>

--- a/TelegramGroupsAdmin/Components/Shared/BackupRestore.razor
+++ b/TelegramGroupsAdmin/Components/Shared/BackupRestore.razor
@@ -109,7 +109,7 @@ else
                 {
                     <MudPaper Class="pa-3 mb-3" Elevation="0" Outlined="true">
                         <MudText Typo="Typo.subtitle2" Class="mb-2">Backup Info</MudText>
-                        <MudText Typo="Typo.body2"><strong>Created:</strong> <span class="local-timestamp" data-utc="@_uploadMetadata.CreatedAt.ToString("o")">@_uploadMetadata.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</span></MudText>
+                        <MudText Typo="Typo.body2"><strong>Created:</strong> <LocalTimestamp Value="@_uploadMetadata.CreatedAt" Format="yyyy-MM-dd HH:mm" /></MudText>
                         <MudText Typo="Typo.body2"><strong>Version:</strong> @_uploadMetadata.Version | <strong>Tables:</strong> @_uploadMetadata.TableCount</MudText>
                         <MudText Typo="Typo.body2"><strong>Size:</strong> @FormatBytes(_selectedFile?.Size ?? 0)</MudText>
                         @if (_uploadIsEncrypted)

--- a/TelegramGroupsAdmin/Components/Shared/ChatManagement/ChatConfigModal.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ChatManagement/ChatConfigModal.razor
@@ -324,7 +324,7 @@
                 {
                     <MudStack Spacing="2">
                         <MudText Typo="Typo.body1">
-                            This chat has <strong>@_admins.Count admin(s)</strong> cached. Last refresh: <span class="local-timestamp" data-utc="@((ChatInfo.Record.LastSeenAt ?? DateTimeOffset.MinValue).ToString("o"))">@(ChatInfo.Record.LastSeenAt ?? DateTimeOffset.MinValue).ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                            This chat has <strong>@_admins.Count admin(s)</strong> cached. Last refresh: <LocalTimestamp Value="@(ChatInfo.Record.LastSeenAt ?? DateTimeOffset.MinValue)" />
                         </MudText>
 
                         <MudTable Items="@_admins" Dense="true" Hover="true">

--- a/TelegramGroupsAdmin/Components/Shared/ContentDetection/UrlFiltersConfig.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ContentDetection/UrlFiltersConfig.razor
@@ -470,6 +470,7 @@
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Select(u => u.Trim())
             .Where(u => !string.IsNullOrWhiteSpace(u))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         // Remove old custom hard block subscriptions
@@ -479,9 +480,17 @@
             await BlocklistRepo.DeleteAsync(old.Id);
         }
 
-        // Add new custom subscriptions
+        // Add new custom subscriptions (skip duplicates from other block modes or built-ins)
+        var skippedDuplicates = new List<string>();
         foreach (var url in urls)
         {
+            var existing = await BlocklistRepo.FindByUrlAsync(url, ChatId);
+            if (existing.Count > 0)
+            {
+                skippedDuplicates.Add(url);
+                continue;
+            }
+
             var subscription = new BlocklistSubscription(
                 Id: 0,
                 ChatId: ChatId,
@@ -501,6 +510,11 @@
             await BlocklistRepo.InsertAsync(subscription);
         }
 
+        if (skippedDuplicates.Count > 0)
+        {
+            Snackbar.Add($"Skipped {skippedDuplicates.Count} duplicate URL(s): {string.Join(", ", skippedDuplicates)}", Severity.Warning);
+        }
+
         // Save manual domains
         await SaveManualDomainsAsync(_hardBlockManualDomains, DomainFilterType.Blacklist, BlockMode.Hard, actor);
     }
@@ -512,6 +526,7 @@
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Select(u => u.Trim())
             .Where(u => !string.IsNullOrWhiteSpace(u))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         // Remove old custom soft block subscriptions
@@ -521,9 +536,17 @@
             await BlocklistRepo.DeleteAsync(old.Id);
         }
 
-        // Add new custom subscriptions
+        // Add new custom subscriptions (skip duplicates from other block modes or built-ins)
+        var skippedDuplicates = new List<string>();
         foreach (var url in urls)
         {
+            var existing = await BlocklistRepo.FindByUrlAsync(url, ChatId);
+            if (existing.Count > 0)
+            {
+                skippedDuplicates.Add(url);
+                continue;
+            }
+
             var subscription = new BlocklistSubscription(
                 Id: 0,
                 ChatId: ChatId,
@@ -541,6 +564,11 @@
                 Notes: "Custom soft block URL"
             );
             await BlocklistRepo.InsertAsync(subscription);
+        }
+
+        if (skippedDuplicates.Count > 0)
+        {
+            Snackbar.Add($"Skipped {skippedDuplicates.Count} duplicate URL(s): {string.Join(", ", skippedDuplicates)}", Severity.Warning);
         }
 
         // Save manual domains

--- a/TelegramGroupsAdmin/Components/Shared/ContentDetection/UrlFiltersConfig.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ContentDetection/UrlFiltersConfig.razor
@@ -463,19 +463,24 @@
         }
     }
 
-    private async Task SaveHardBlockConfigurationAsync(Actor actor)
+    private Task SaveHardBlockConfigurationAsync(Actor actor) =>
+        SaveCustomBlockSubscriptionsAsync(_hardBlockCustomUrls, BlockMode.Hard, _hardBlockManualDomains, actor);
+
+    private Task SaveSoftBlockConfigurationAsync(Actor actor) =>
+        SaveCustomBlockSubscriptionsAsync(_softBlockCustomUrls, BlockMode.Soft, _softBlockManualDomains, actor);
+
+    private async Task SaveCustomBlockSubscriptionsAsync(string urlsText, BlockMode mode, string manualDomains, Actor actor)
     {
-        // Save custom URLs
-        var urls = _hardBlockCustomUrls
+        var urls = urlsText
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Select(u => u.Trim())
             .Where(u => !string.IsNullOrWhiteSpace(u))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        // Remove old custom hard block subscriptions
-        var oldCustomHard = _customSubscriptions.Where(s => s.BlockMode == BlockMode.Hard).ToList();
-        foreach (var old in oldCustomHard)
+        // Remove old custom subscriptions for this block mode
+        var oldCustomSubs = _customSubscriptions.Where(s => s.BlockMode == mode).ToList();
+        foreach (var old in oldCustomSubs)
         {
             await BlocklistRepo.DeleteAsync(old.Id);
         }
@@ -497,7 +502,7 @@
                 Name: $"Custom: {url}",
                 Url: url,
                 Format: BlocklistFormat.NewlineDomains,
-                BlockMode: BlockMode.Hard,
+                BlockMode: mode,
                 IsBuiltIn: false,
                 Enabled: true,
                 LastFetched: null,
@@ -505,7 +510,7 @@
                 RefreshIntervalHours: 24,
                 AddedBy: actor,
                 AddedDate: DateTimeOffset.UtcNow,
-                Notes: "Custom hard block URL"
+                Notes: $"Custom {mode.ToString().ToLowerInvariant()} block URL"
             );
             await BlocklistRepo.InsertAsync(subscription);
         }
@@ -516,63 +521,7 @@
         }
 
         // Save manual domains
-        await SaveManualDomainsAsync(_hardBlockManualDomains, DomainFilterType.Blacklist, BlockMode.Hard, actor);
-    }
-
-    private async Task SaveSoftBlockConfigurationAsync(Actor actor)
-    {
-        // Save custom URLs
-        var urls = _softBlockCustomUrls
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
-            .Select(u => u.Trim())
-            .Where(u => !string.IsNullOrWhiteSpace(u))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        // Remove old custom soft block subscriptions
-        var oldCustomSoft = _customSubscriptions.Where(s => s.BlockMode == BlockMode.Soft).ToList();
-        foreach (var old in oldCustomSoft)
-        {
-            await BlocklistRepo.DeleteAsync(old.Id);
-        }
-
-        // Add new custom subscriptions (skip duplicates from other block modes or built-ins)
-        var skippedDuplicates = new List<string>();
-        foreach (var url in urls)
-        {
-            var existing = await BlocklistRepo.FindByUrlAsync(url, ChatId);
-            if (existing.Count > 0)
-            {
-                skippedDuplicates.Add(url);
-                continue;
-            }
-
-            var subscription = new BlocklistSubscription(
-                Id: 0,
-                ChatId: ChatId,
-                Name: $"Custom: {url}",
-                Url: url,
-                Format: BlocklistFormat.NewlineDomains,
-                BlockMode: BlockMode.Soft,
-                IsBuiltIn: false,
-                Enabled: true,
-                LastFetched: null,
-                EntryCount: null,
-                RefreshIntervalHours: 24,
-                AddedBy: actor,
-                AddedDate: DateTimeOffset.UtcNow,
-                Notes: "Custom soft block URL"
-            );
-            await BlocklistRepo.InsertAsync(subscription);
-        }
-
-        if (skippedDuplicates.Count > 0)
-        {
-            Snackbar.Add($"Skipped {skippedDuplicates.Count} duplicate URL(s): {string.Join(", ", skippedDuplicates)}", Severity.Warning);
-        }
-
-        // Save manual domains
-        await SaveManualDomainsAsync(_softBlockManualDomains, DomainFilterType.Blacklist, BlockMode.Soft, actor);
+        await SaveManualDomainsAsync(manualDomains, DomainFilterType.Blacklist, mode, actor);
     }
 
     private async Task SaveWhitelist()

--- a/TelegramGroupsAdmin/Components/Shared/DetectionHistoryDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/DetectionHistoryDialog.razor
@@ -32,7 +32,7 @@
                     <MudTimelineItem Color="@(result.IsSpam ? Color.Error : Color.Success)" Size="Size.Small">
                         <ItemOpposite>
                             <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                <span class="local-timestamp" data-utc="@result.DetectedAt.ToString("o")">@result.DetectedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                                <LocalTimestamp Value="@result.DetectedAt" />
                             </MudText>
                         </ItemOpposite>
                         <ItemContent>

--- a/TelegramGroupsAdmin/Components/Shared/EditHistoryDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/EditHistoryDialog.razor
@@ -43,7 +43,7 @@
                         <MudStack Spacing="2">
                             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                    <b>Edited:</b> <span class="local-timestamp" data-utc="@edit.EditDate.ToString("o")">@edit.EditDate.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                                    <b>Edited:</b> <LocalTimestamp Value="@edit.EditDate" />
                                 </MudText>
                                 <MudStack Row="true" Spacing="1">
                                     @* Phase 4.20: Translation badge *@

--- a/TelegramGroupsAdmin/Components/Shared/ImageViewerDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ImageViewerDialog.razor
@@ -12,7 +12,7 @@
                             @(Message.User.DisplayName)
                         </MudText>
                         <MudText Typo="Typo.caption" Color="Color.Secondary">
-                            <span class="local-timestamp" data-utc="@Message.Timestamp.ToString("o")">@Message.Timestamp.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                            <LocalTimestamp Value="@Message.Timestamp" />
                         </MudText>
                     </MudStack>
                 </MudStack>

--- a/TelegramGroupsAdmin/Components/Shared/MessageBubbleTelegram.razor
+++ b/TelegramGroupsAdmin/Components/Shared/MessageBubbleTelegram.razor
@@ -32,9 +32,7 @@
                 <span class="tg-user-name" @onclick="() => OnViewUserDetail.InvokeAsync(Message.User.Id)" @onclick:stopPropagation="true" title="View user details">
                     @GetUserDisplayName()
                 </span>
-                <span class="tg-timestamp local-timestamp" data-utc="@Message.Timestamp.ToString("o")">
-                    @Message.Timestamp.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
-                </span>
+                <span class="tg-timestamp"><LocalTimestamp Value="@Message.Timestamp" /></span>
 
                 @* User Tags (Phase 4.12) *@
                 @if (UserTags != null && UserTags.Any())
@@ -64,7 +62,7 @@
                 @if (Message.DeletedAt.HasValue)
                 {
                     <span class="tg-badge tg-badge-deleted" title="@($"Deleted: {Message.DeletionSource ?? "unknown"}")">
-                        🗑️ DELETED <span class="local-timestamp" data-utc="@Message.DeletedAt.Value.ToString("o")">@Message.DeletedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                        🗑️ DELETED <LocalTimestamp Value="@Message.DeletedAt.Value" />
                     </span>
                 }
                 @if (Message.EditDate.HasValue)

--- a/TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor
@@ -23,7 +23,7 @@
                     <MudTimelineItem Color="@ProfileScanDisplayHelpers.GetOutcomeColor(result.Outcome)" Size="Size.Small">
                         <ItemOpposite>
                             <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                <span class="local-timestamp" data-utc="@result.ScannedAt.ToString("o")">@result.ScannedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                                <LocalTimestamp Value="@result.ScannedAt" />
                             </MudText>
                         </ItemOpposite>
                         <ItemContent>

--- a/TelegramGroupsAdmin/Components/Shared/RestoreBackupModal.razor
+++ b/TelegramGroupsAdmin/Components/Shared/RestoreBackupModal.razor
@@ -19,7 +19,7 @@
         {
             <MudPaper Class="pa-3 mb-3" Elevation="0" Outlined="true">
                 <MudText Typo="Typo.subtitle2" Class="mb-2">Backup Information</MudText>
-                <MudText Typo="Typo.body2"><strong>Created:</strong> <span class="local-timestamp" data-utc="@_metadata.CreatedAt.ToString("o")">@_metadata.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span></MudText>
+                <MudText Typo="Typo.body2"><strong>Created:</strong> <LocalTimestamp Value="@_metadata.CreatedAt" Format="yyyy-MM-dd HH:mm:ss" /></MudText>
                 <MudText Typo="Typo.body2"><strong>Version:</strong> @_metadata.Version | <strong>Tables:</strong> @_metadata.TableCount</MudText>
                 <MudText Typo="Typo.body2"><strong>App Version:</strong> @_metadata.AppVersion</MudText>
             </MudPaper>

--- a/TelegramGroupsAdmin/Components/Shared/Settings/BackgroundJobs.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/BackgroundJobs.razor
@@ -184,6 +184,13 @@
                                  HelperText="e.g., 7d, 2w"
                                  Error="@(!ValidateRetention(_editNotificationRetention))"
                                  ErrorText="Invalid format" />
+
+                    <MudTextField @bind-Value="_editFileScanResultRetention"
+                                 Label="File Scan Results"
+                                 Variant="Variant.Outlined"
+                                 HelperText="e.g., 24h, 7d"
+                                 Error="@(!ValidateRetention(_editFileScanResultRetention))"
+                                 ErrorText="Invalid format" />
                 }
                 else if (_editingJob.JobName == BackgroundJobNames.DatabaseMaintenance)
                 {
@@ -251,6 +258,7 @@
     private string _editReportRetention = "30d";
     private string _editContextRetention = "7d";
     private string _editNotificationRetention = "7d";
+    private string _editFileScanResultRetention = "24h";
 
     [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
 
@@ -362,6 +370,7 @@
             _editReportRetention = settings.ReportRetention;
             _editContextRetention = settings.CallbackContextRetention;
             _editNotificationRetention = settings.WebNotificationRetention;
+            _editFileScanResultRetention = settings.FileScanResultRetention;
         }
         else if (job.JobName == BackgroundJobNames.ProfileRescan)
         {
@@ -416,7 +425,8 @@
                 if (!ValidateRetention(_editMessageRetention) ||
                     !ValidateRetention(_editReportRetention) ||
                     !ValidateRetention(_editContextRetention) ||
-                    !ValidateRetention(_editNotificationRetention))
+                    !ValidateRetention(_editNotificationRetention) ||
+                    !ValidateRetention(_editFileScanResultRetention))
                 {
                     Snackbar.Add("Invalid retention format. Use formats like: 7d, 2w, 1M, 1y", Severity.Error);
                     return;
@@ -427,7 +437,8 @@
                     MessageRetention = _editMessageRetention,
                     ReportRetention = _editReportRetention,
                     CallbackContextRetention = _editContextRetention,
-                    WebNotificationRetention = _editNotificationRetention
+                    WebNotificationRetention = _editNotificationRetention,
+                    FileScanResultRetention = _editFileScanResultRetention
                 };
             }
             else if (_editingJob.JobName == BackgroundJobNames.ProfileRescan)

--- a/TelegramGroupsAdmin/Components/Shared/UserNotesDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/UserNotesDialog.razor
@@ -28,12 +28,12 @@
                                         By @note.CreatedBy.GetDisplayText()
                                     </MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        <span class="local-timestamp" data-utc="@note.CreatedAt.ToString("o")">@note.CreatedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+                                        <LocalTimestamp Value="@note.CreatedAt" />
                                     </MudText>
                                     @if (note.UpdatedAt.HasValue)
                                     {
                                         <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                            (edited <span class="local-timestamp" data-utc="@note.UpdatedAt.Value.ToString("o")">@note.UpdatedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>)
+                                            (edited <LocalTimestamp Value="@note.UpdatedAt.Value" />)
                                         </MudText>
                                     }
                                 </MudStack>

--- a/docs/superpowers/plans/2026-03-21-quick-wins-398-399-405.md
+++ b/docs/superpowers/plans/2026-03-21-quick-wins-398-399-405.md
@@ -1,0 +1,860 @@
+# Quick Wins #398, #399, #405 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver three independent bug fixes as separate commits in a single PR: wire file scan result cleanup into the data cleanup job (#398), prevent duplicate blocklist subscription URLs (#399), and migrate 14 components from broken inline `data-utc` timestamps to `<LocalTimestamp>` (#405).
+
+**Architecture:** Each fix is self-contained. #398 adds a 5th cleanup step to `DataCleanupJob` using the existing retention-setting pattern. #399 adds a unique DB constraint on `(Url, ChatId)` plus UI-side deduplication. #405 is a mechanical find-and-replace across 14 Razor components plus 2 test updates.
+
+**Tech Stack:** C# / .NET 10, EF Core 10, Blazor Server, MudBlazor 9, NUnit, NSubstitute
+
+---
+
+## Task 1: Add FileScanResultRetention setting (#398)
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs:7-50`
+
+- [ ] **Step 1: Add the new retention property to DataCleanupSettings**
+
+Add a default constant and property following the existing pattern (MessageRetention, ReportRetention, etc.):
+
+```csharp
+// Add after line 27 (DefaultShortRetention):
+
+/// <summary>
+/// Default file scan result retention period string (24 hours).
+/// </summary>
+public const string DefaultFileScanResultRetentionString = "24h";
+
+/// <summary>
+/// Fallback retention for file scan results if parsing fails (24 hours).
+/// </summary>
+public static readonly TimeSpan DefaultFileScanResultRetention = TimeSpan.FromHours(24);
+```
+
+```csharp
+// Add after line 49 (WebNotificationRetention property):
+
+/// <summary>
+/// Retention period for file scan results (default: 24 hours).
+/// Scan results are cached to avoid re-scanning the same file.
+/// </summary>
+public string FileScanResultRetention { get; init; } = DefaultFileScanResultRetentionString;
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin.Core`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs
+git commit -m "feat(#398): add FileScanResultRetention setting to DataCleanupSettings"
+```
+
+---
+
+## Task 2: Add retention parameter to CleanupExpiredResultsAsync (#398)
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.ContentDetection/Repositories/IFileScanResultRepository.cs:33-39`
+- Modify: `TelegramGroupsAdmin.ContentDetection/Repositories/FileScanResultRepository.cs:64-88`
+
+- [ ] **Step 1: Update the interface signature**
+
+In `IFileScanResultRepository.cs`, replace the `CleanupExpiredResultsAsync` declaration (lines 33-39):
+
+```csharp
+/// <summary>
+/// Cleanup expired scan results older than the specified retention period.
+/// Should be called periodically via Quartz.NET background job.
+/// </summary>
+/// <param name="retention">How long to keep scan results before cleanup</param>
+/// <param name="cancellationToken">Cancellation token</param>
+/// <returns>Number of records deleted</returns>
+Task<int> CleanupExpiredResultsAsync(TimeSpan retention, CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 2: Update the implementation**
+
+In `FileScanResultRepository.cs`, update the method (lines 64-88) to accept and use the `retention` parameter instead of `CacheTtl`:
+
+```csharp
+public async Task<int> CleanupExpiredResultsAsync(TimeSpan retention, CancellationToken cancellationToken = default)
+{
+    await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+    var cutoffTime = DateTimeOffset.UtcNow - retention;
+
+    var expiredResults = await context.FileScanResults
+        .Where(fsr => fsr.ScannedAt < cutoffTime)
+        .ToListAsync(cancellationToken)
+        ;
+
+    if (!expiredResults.Any())
+    {
+        _logger.LogDebug("No expired scan results to clean up");
+        return 0;
+    }
+
+    context.FileScanResults.RemoveRange(expiredResults);
+    await context.SaveChangesAsync(cancellationToken);
+
+    _logger.LogInformation("Cleaned up {Count} expired scan results (retention: {Retention})",
+        expiredResults.Count, retention);
+
+    return expiredResults.Count;
+}
+```
+
+Note: Keep the `CacheTtl` field on line 16 — it's still used by `GetCachedResultsByHashAsync` (line 32) for cache freshness.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin.ContentDetection`
+Expected: Build succeeded
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin.ContentDetection/Repositories/IFileScanResultRepository.cs \
+       TelegramGroupsAdmin.ContentDetection/Repositories/FileScanResultRepository.cs
+git commit -m "refactor(#398): add retention parameter to CleanupExpiredResultsAsync"
+```
+
+---
+
+## Task 3: Wire cleanup into DataCleanupJob and add unit test (#398)
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs:69-99,189-203`
+- Create: `TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs`.
+
+Follow the existing test pattern from `ScheduledBackupJobTests.cs` — use `IServiceScopeFactory` + NSubstitute mocks:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Jobs;
+using TelegramGroupsAdmin.BackgroundJobs.Services;
+using TelegramGroupsAdmin.Configuration;
+using TelegramGroupsAdmin.ContentDetection.Repositories;
+using TelegramGroupsAdmin.Core.BackgroundJobs;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
+using TelegramGroupsAdmin.Core.Repositories;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+
+namespace TelegramGroupsAdmin.UnitTests.BackgroundJobs.Jobs;
+
+[TestFixture]
+public class DataCleanupJobTests
+{
+    private IServiceScopeFactory _scopeFactory = null!;
+    private IServiceScope _scope = null!;
+    private IServiceProvider _serviceProvider = null!;
+    private IBackgroundJobConfigService _configService = null!;
+    private IMessageHistoryRepository _messageHistoryRepo = null!;
+    private IReportsRepository _reportsRepo = null!;
+    private IReportCallbackContextRepository _callbackContextRepo = null!;
+    private IWebNotificationRepository _notificationRepo = null!;
+    private IFileScanResultRepository _fileScanResultRepo = null!;
+    private IJobExecutionContext _jobContext = null!;
+    private DataCleanupJob _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _scopeFactory = Substitute.For<IServiceScopeFactory>();
+        _serviceProvider = Substitute.For<IServiceProvider>();
+        _configService = Substitute.For<IBackgroundJobConfigService>();
+        _messageHistoryRepo = Substitute.For<IMessageHistoryRepository>();
+        _reportsRepo = Substitute.For<IReportsRepository>();
+        _callbackContextRepo = Substitute.For<IReportCallbackContextRepository>();
+        _notificationRepo = Substitute.For<IWebNotificationRepository>();
+        _fileScanResultRepo = Substitute.For<IFileScanResultRepository>();
+
+        _scope = Substitute.For<IServiceScope>();
+        _scopeFactory.CreateScope().Returns(_scope);
+        _scope.ServiceProvider.Returns(_serviceProvider);
+
+        _serviceProvider.GetService(typeof(IBackgroundJobConfigService)).Returns(_configService);
+        _serviceProvider.GetService(typeof(IMessageHistoryRepository)).Returns(_messageHistoryRepo);
+        _serviceProvider.GetService(typeof(IReportsRepository)).Returns(_reportsRepo);
+        _serviceProvider.GetService(typeof(IReportCallbackContextRepository)).Returns(_callbackContextRepo);
+        _serviceProvider.GetService(typeof(IWebNotificationRepository)).Returns(_notificationRepo);
+        _serviceProvider.GetService(typeof(IFileScanResultRepository)).Returns(_fileScanResultRepo);
+
+        // Default: return empty config (use defaults)
+        _configService.GetJobConfigAsync(BackgroundJobNames.DataCleanup)
+            .Returns(Task.FromResult<BackgroundJobConfig?>(null));
+
+        // Default: message cleanup returns empty result
+        _messageHistoryRepo.CleanupExpiredAsync(Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(new MessageCleanupResult(0, [], [], 0, 0, 0, null));
+
+        var appOptions = Options.Create(new AppOptions { DataPath = "/data" });
+        var logger = Substitute.For<ILogger<DataCleanupJob>>();
+
+        _jobContext = Substitute.For<IJobExecutionContext>();
+        _jobContext.CancellationToken.Returns(CancellationToken.None);
+
+        _sut = new DataCleanupJob(_scopeFactory, appOptions, logger);
+    }
+
+    [Test]
+    public async Task Execute_CallsFileScanResultCleanup_WithDefaultRetention()
+    {
+        // Act
+        await _sut.Execute(_jobContext);
+
+        // Assert — file scan result cleanup is called with 24h default retention
+        await _fileScanResultRepo.Received(1).CleanupExpiredResultsAsync(
+            TimeSpan.FromHours(24),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Execute_CallsFileScanResultCleanup_WithConfiguredRetention()
+    {
+        // Arrange — configure 48h retention
+        var settings = new DataCleanupSettings { FileScanResultRetention = "48h" };
+        var config = new BackgroundJobConfig { DataCleanup = settings };
+        _configService.GetJobConfigAsync(BackgroundJobNames.DataCleanup)
+            .Returns(Task.FromResult<BackgroundJobConfig?>(config));
+
+        // Act
+        await _sut.Execute(_jobContext);
+
+        // Assert — uses the configured 48h retention
+        await _fileScanResultRepo.Received(1).CleanupExpiredResultsAsync(
+            TimeSpan.FromHours(48),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Execute_CallsAllFiveCleanupSteps()
+    {
+        // Act
+        await _sut.Execute(_jobContext);
+
+        // Assert — all 5 cleanup steps are called
+        await _messageHistoryRepo.Received(1).CleanupExpiredAsync(
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await _reportsRepo.Received(1).DeleteOldReportsAsync(
+            Arg.Any<DateTimeOffset>(), type: null, Arg.Any<CancellationToken>());
+        await _callbackContextRepo.Received(1).DeleteExpiredAsync(
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await _notificationRepo.Received(1).DeleteOldReadNotificationsAsync(
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await _fileScanResultRepo.Received(1).CleanupExpiredResultsAsync(
+            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~DataCleanupJobTests" --no-restore`
+Expected: FAIL — `CleanupExpiredResultsAsync` signature mismatch (no `TimeSpan` overload) and no call to file scan result repo
+
+- [ ] **Step 3: Add the 5th cleanup step to DataCleanupJob**
+
+In `DataCleanupJob.cs`, add a `using` for the ContentDetection repository at the top:
+
+```csharp
+// Add after line 9 (using TelegramGroupsAdmin.Core.Repositories;):
+using TelegramGroupsAdmin.ContentDetection.Repositories;
+```
+
+In `ExecuteCleanupAsync`, add the 5th retention parse (after line 82):
+
+```csharp
+var fileScanRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.FileScanResultRetention, DataCleanupSettings.DefaultFileScanResultRetention);
+```
+
+Add the 5th cleanup call (after the notifications cleanup on line 96, before the "completed" log on line 98):
+
+```csharp
+// 5. Clean up expired file scan results
+await CleanupFileScanResultsAsync(sp, fileScanRetention, cancellationToken);
+```
+
+Add the private method after `CleanupNotificationsAsync` (after line 202):
+
+```csharp
+private async Task CleanupFileScanResultsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken ct)
+{
+    var fileScanRepo = sp.GetRequiredService<IFileScanResultRepository>();
+    var deleted = await fileScanRepo.CleanupExpiredResultsAsync(retention, cancellationToken: ct);
+
+    if (deleted > 0)
+    {
+        _logger.LogInformation(
+            "File scan result cleanup: {Count} expired results deleted (retention: {Retention})",
+            deleted,
+            TimeSpanUtilities.FormatDuration(retention));
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~DataCleanupJobTests" --no-restore`
+Expected: 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs \
+       TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs
+git commit -m "feat(#398): wire file scan result cleanup into DataCleanupJob"
+```
+
+---
+
+## Task 4: Add unique index migration for blocklist subscriptions (#399)
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Data/AppDbContext.cs:680-681`
+- Create: EF Core migration (auto-generated)
+
+- [ ] **Step 1: Replace the non-unique URL index with a composite unique index**
+
+In `AppDbContext.cs`, replace the index at line 680-681:
+
+```csharp
+// Old (line 680-681):
+modelBuilder.Entity<BlocklistSubscriptionDto>()
+    .HasIndex(bs => bs.Url);  // For duplicate detection
+
+// New:
+modelBuilder.Entity<BlocklistSubscriptionDto>()
+    .HasIndex(bs => new { bs.Url, bs.ChatId })
+    .IsUnique();
+```
+
+- [ ] **Step 2: Generate the EF Core migration**
+
+Run:
+```bash
+dotnet ef migrations add AddBlocklistSubscriptionUniqueUrlChatId \
+  -p TelegramGroupsAdmin.Data \
+  -s TelegramGroupsAdmin
+```
+
+- [ ] **Step 3: Add deduplication SQL to the migration's Up method**
+
+Open the generated migration file. Add deduplication SQL **before** the `CreateIndex` call:
+
+```csharp
+// Add at the start of Up(), before the DropIndex/CreateIndex:
+migrationBuilder.Sql("""
+    DELETE FROM blocklist_subscriptions
+    WHERE id NOT IN (
+        SELECT MAX(id) FROM blocklist_subscriptions GROUP BY url, chat_id
+    );
+    """);
+```
+
+Review the migration to ensure EF Core generated a `DropIndex` for the old `IX_blocklist_subscriptions_url` and a `CreateIndex` for the new unique composite index.
+
+- [ ] **Step 4: Verify migration compiles and applies**
+
+Run:
+```bash
+dotnet run --project TelegramGroupsAdmin -- --migrate-only
+```
+Expected: Migration applied, exit code 0
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Data/AppDbContext.cs \
+       TelegramGroupsAdmin.Data/Migrations/
+git commit -m "feat(#399): add unique index on (Url, ChatId) for blocklist subscriptions"
+```
+
+---
+
+## Task 5: Add duplicate check to UrlFiltersConfig save flows (#399)
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Shared/ContentDetection/UrlFiltersConfig.razor:466-548`
+
+- [ ] **Step 1: Update SaveHardBlockConfigurationAsync with dedup logic**
+
+Replace the method at lines 466-506:
+
+```csharp
+private async Task SaveHardBlockConfigurationAsync(Actor actor)
+{
+    // Save custom URLs
+    var urls = _hardBlockCustomUrls
+        .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+        .Select(u => u.Trim())
+        .Where(u => !string.IsNullOrWhiteSpace(u))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    // Remove old custom hard block subscriptions
+    var oldCustomHard = _customSubscriptions.Where(s => s.BlockMode == BlockMode.Hard).ToList();
+    foreach (var old in oldCustomHard)
+    {
+        await BlocklistRepo.DeleteAsync(old.Id);
+    }
+
+    // Add new custom subscriptions (skip duplicates from other block modes or built-ins)
+    var skippedDuplicates = new List<string>();
+    foreach (var url in urls)
+    {
+        var existing = await BlocklistRepo.FindByUrlAsync(url, ChatId);
+        if (existing.Count > 0)
+        {
+            skippedDuplicates.Add(url);
+            continue;
+        }
+
+        var subscription = new BlocklistSubscription(
+            Id: 0,
+            ChatId: ChatId,
+            Name: $"Custom: {url}",
+            Url: url,
+            Format: BlocklistFormat.NewlineDomains,
+            BlockMode: BlockMode.Hard,
+            IsBuiltIn: false,
+            Enabled: true,
+            LastFetched: null,
+            EntryCount: null,
+            RefreshIntervalHours: 24,
+            AddedBy: actor,
+            AddedDate: DateTimeOffset.UtcNow,
+            Notes: "Custom hard block URL"
+        );
+        await BlocklistRepo.InsertAsync(subscription);
+    }
+
+    if (skippedDuplicates.Count > 0)
+    {
+        Snackbar.Add($"Skipped {skippedDuplicates.Count} duplicate URL(s): {string.Join(", ", skippedDuplicates)}", Severity.Warning);
+    }
+
+    // Save manual domains
+    await SaveManualDomainsAsync(_hardBlockManualDomains, DomainFilterType.Blacklist, BlockMode.Hard, actor);
+}
+```
+
+- [ ] **Step 2: Update SaveSoftBlockConfigurationAsync with the same dedup logic**
+
+Replace the method at lines 508-548:
+
+```csharp
+private async Task SaveSoftBlockConfigurationAsync(Actor actor)
+{
+    // Save custom URLs
+    var urls = _softBlockCustomUrls
+        .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+        .Select(u => u.Trim())
+        .Where(u => !string.IsNullOrWhiteSpace(u))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    // Remove old custom soft block subscriptions
+    var oldCustomSoft = _customSubscriptions.Where(s => s.BlockMode == BlockMode.Soft).ToList();
+    foreach (var old in oldCustomSoft)
+    {
+        await BlocklistRepo.DeleteAsync(old.Id);
+    }
+
+    // Add new custom subscriptions (skip duplicates from other block modes or built-ins)
+    var skippedDuplicates = new List<string>();
+    foreach (var url in urls)
+    {
+        var existing = await BlocklistRepo.FindByUrlAsync(url, ChatId);
+        if (existing.Count > 0)
+        {
+            skippedDuplicates.Add(url);
+            continue;
+        }
+
+        var subscription = new BlocklistSubscription(
+            Id: 0,
+            ChatId: ChatId,
+            Name: $"Custom: {url}",
+            Url: url,
+            Format: BlocklistFormat.NewlineDomains,
+            BlockMode: BlockMode.Soft,
+            IsBuiltIn: false,
+            Enabled: true,
+            LastFetched: null,
+            EntryCount: null,
+            RefreshIntervalHours: 24,
+            AddedBy: actor,
+            AddedDate: DateTimeOffset.UtcNow,
+            Notes: "Custom soft block URL"
+        );
+        await BlocklistRepo.InsertAsync(subscription);
+    }
+
+    if (skippedDuplicates.Count > 0)
+    {
+        Snackbar.Add($"Skipped {skippedDuplicates.Count} duplicate URL(s): {string.Join(", ", skippedDuplicates)}", Severity.Warning);
+    }
+
+    // Save manual domains
+    await SaveManualDomainsAsync(_softBlockManualDomains, DomainFilterType.Blacklist, BlockMode.Soft, actor);
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin`
+Expected: Build succeeded
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Shared/ContentDetection/UrlFiltersConfig.razor
+git commit -m "feat(#399): add duplicate URL check to blocklist save flow"
+```
+
+---
+
+## Task 6: Migrate 11 simple-format components to LocalTimestamp (#405)
+
+These 11 components all use the default format (`"MMM d, yyyy h:mm tt"`). Mechanical replacement — each `<span class="local-timestamp" data-utc="@expr.ToString("o")">@expr.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>` becomes `<LocalTimestamp Value="@expr" />`.
+
+**Files (11):**
+- Modify: `TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor:21,62`
+- Modify: `TelegramGroupsAdmin/Components/Reports/ImpersonationAlertCard.razor:23,206`
+- Modify: `TelegramGroupsAdmin/Components/Reports/ProfileScanAlertCard.razor:21,174`
+- Modify: `TelegramGroupsAdmin/Components/Reports/ExamReviewCard.razor:30,231`
+- Modify: `TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor:26`
+- Modify: `TelegramGroupsAdmin/Components/Shared/ImageViewerDialog.razor:15`
+- Modify: `TelegramGroupsAdmin/Components/Shared/DetectionHistoryDialog.razor:35`
+- Modify: `TelegramGroupsAdmin/Components/Shared/EditHistoryDialog.razor:46`
+- Modify: `TelegramGroupsAdmin/Components/Shared/UserNotesDialog.razor:31,36`
+- Modify: `TelegramGroupsAdmin/Components/Shared/ChatManagement/ChatConfigModal.razor:327`
+
+- [ ] **Step 1: Replace all default-format timestamps**
+
+For each file, find every occurrence of the pattern and replace with `<LocalTimestamp Value="@expr" />`. The exact old/new for each:
+
+**ModerationReportCard.razor line 21:**
+```
+Old: <span class="local-timestamp" data-utc="@Report.ReportedAt.ToString("o")">@Report.ReportedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@Report.ReportedAt" />
+```
+
+**ModerationReportCard.razor line 62:**
+```
+Old: <span class="local-timestamp" data-utc="@_message.DeletedAt.Value.ToString("o")">@_message.DeletedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@_message.DeletedAt.Value" />
+```
+
+**ImpersonationAlertCard.razor line 23:**
+```
+Old: <span class="local-timestamp" data-utc="@Alert.DetectedAt.ToString("o")">@Alert.DetectedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@Alert.DetectedAt" />
+```
+
+**ImpersonationAlertCard.razor line 206:**
+```
+Old: <span class="local-timestamp" data-utc="@Alert.ReviewedAt.Value.ToString("o")">@Alert.ReviewedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@Alert.ReviewedAt.Value" />
+```
+
+**ProfileScanAlertCard.razor line 21:**
+```
+Old: <span class="local-timestamp" data-utc="@Alert.DetectedAt.ToString("o")">@Alert.DetectedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@Alert.DetectedAt" />
+```
+
+**ProfileScanAlertCard.razor line 174:**
+```
+Old: <span class="local-timestamp" data-utc="@Alert.ReviewedAt.Value.ToString("o")">@Alert.ReviewedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@Alert.ReviewedAt.Value" />
+```
+
+**ExamReviewCard.razor line 30:**
+```
+Old: <span class="local-timestamp" data-utc="@ExamFailure.FailedAt.ToString("o")">@ExamFailure.FailedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@ExamFailure.FailedAt" />
+```
+
+**ExamReviewCard.razor line 231:**
+```
+Old: <span class="local-timestamp" data-utc="@ExamFailure.ReviewedAt.Value.ToString("o")">@ExamFailure.ReviewedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@ExamFailure.ReviewedAt.Value" />
+```
+
+**ProfileScanHistoryDialog.razor line 26:**
+```
+Old: <span class="local-timestamp" data-utc="@result.ScannedAt.ToString("o")">@result.ScannedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@result.ScannedAt" />
+```
+
+**ImageViewerDialog.razor line 15:**
+```
+Old: <span class="local-timestamp" data-utc="@Message.Timestamp.ToString("o")">@Message.Timestamp.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@Message.Timestamp" />
+```
+
+**DetectionHistoryDialog.razor line 35:**
+```
+Old: <span class="local-timestamp" data-utc="@result.DetectedAt.ToString("o")">@result.DetectedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@result.DetectedAt" />
+```
+
+**EditHistoryDialog.razor line 46:**
+```
+Old: <span class="local-timestamp" data-utc="@edit.EditDate.ToString("o")">@edit.EditDate.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@edit.EditDate" />
+```
+
+**UserNotesDialog.razor line 31:**
+```
+Old: <span class="local-timestamp" data-utc="@note.CreatedAt.ToString("o")">@note.CreatedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@note.CreatedAt" />
+```
+
+**UserNotesDialog.razor line 36:**
+```
+Old: <span class="local-timestamp" data-utc="@note.UpdatedAt.Value.ToString("o")">@note.UpdatedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+New: <LocalTimestamp Value="@note.UpdatedAt.Value" />
+```
+
+**ChatConfigModal.razor line 327:**
+The entire inline expression `<span class="local-timestamp" data-utc="@((ChatInfo.Record.LastSeenAt ?? DateTimeOffset.MinValue).ToString("o"))">@(ChatInfo.Record.LastSeenAt ?? DateTimeOffset.MinValue).ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>` becomes:
+```
+<LocalTimestamp Value="@(ChatInfo.Record.LastSeenAt ?? DateTimeOffset.MinValue)" />
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor \
+       TelegramGroupsAdmin/Components/Reports/ImpersonationAlertCard.razor \
+       TelegramGroupsAdmin/Components/Reports/ProfileScanAlertCard.razor \
+       TelegramGroupsAdmin/Components/Reports/ExamReviewCard.razor \
+       TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor \
+       TelegramGroupsAdmin/Components/Shared/ImageViewerDialog.razor \
+       TelegramGroupsAdmin/Components/Shared/DetectionHistoryDialog.razor \
+       TelegramGroupsAdmin/Components/Shared/EditHistoryDialog.razor \
+       TelegramGroupsAdmin/Components/Shared/UserNotesDialog.razor \
+       TelegramGroupsAdmin/Components/Shared/ChatManagement/ChatConfigModal.razor
+git commit -m "fix(#405): migrate 11 components from data-utc to LocalTimestamp"
+```
+
+---
+
+## Task 7: Migrate 3 custom-format + special-case components to LocalTimestamp (#405)
+
+**Files (3 + 1 special):**
+- Modify: `TelegramGroupsAdmin/Components/Shared/BackupRestore.razor:112`
+- Modify: `TelegramGroupsAdmin/Components/Shared/RestoreBackupModal.razor:22`
+- Modify: `TelegramGroupsAdmin/Components/Shared/BackupBrowser.razor:279`
+- Modify: `TelegramGroupsAdmin/Components/Shared/MessageBubbleTelegram.razor:35-37,67`
+
+- [ ] **Step 1: Replace custom-format timestamps**
+
+**BackupRestore.razor line 112** (format: `yyyy-MM-dd HH:mm`):
+```
+Old: <span class="local-timestamp" data-utc="@_uploadMetadata.CreatedAt.ToString("o")">@_uploadMetadata.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</span>
+New: <LocalTimestamp Value="@_uploadMetadata.CreatedAt" Format="yyyy-MM-dd HH:mm" />
+```
+
+**RestoreBackupModal.razor line 22** (format: `yyyy-MM-dd HH:mm:ss`):
+```
+Old: <span class="local-timestamp" data-utc="@_metadata.CreatedAt.ToString("o")">@_metadata.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span>
+New: <LocalTimestamp Value="@_metadata.CreatedAt" Format="yyyy-MM-dd HH:mm:ss" />
+```
+
+**BackupBrowser.razor line 279** (format: `yyyy-MM-dd HH:mm:ss`):
+```
+Old: <span class="local-timestamp" data-utc="@_viewingMetadata.CreatedAt.ToString("o")">@_viewingMetadata.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span>
+New: <LocalTimestamp Value="@_viewingMetadata.CreatedAt" Format="yyyy-MM-dd HH:mm:ss" />
+```
+
+- [ ] **Step 2: Replace MessageBubbleTelegram.razor special cases**
+
+**Line 35-37** (has extra `tg-timestamp` CSS class — wrap in span):
+
+Old:
+```razor
+<span class="tg-timestamp local-timestamp" data-utc="@Message.Timestamp.ToString("o")">
+    @Message.Timestamp.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
+</span>
+```
+
+New:
+```razor
+<span class="tg-timestamp"><LocalTimestamp Value="@Message.Timestamp" /></span>
+```
+
+**Line 67** (DeletedAt inside the badge span):
+
+Old:
+```razor
+🗑️ DELETED <span class="local-timestamp" data-utc="@Message.DeletedAt.Value.ToString("o")">@Message.DeletedAt.Value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
+```
+
+New:
+```razor
+🗑️ DELETED <LocalTimestamp Value="@Message.DeletedAt.Value" />
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin`
+Expected: Build succeeded
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Shared/BackupRestore.razor \
+       TelegramGroupsAdmin/Components/Shared/RestoreBackupModal.razor \
+       TelegramGroupsAdmin/Components/Shared/BackupBrowser.razor \
+       TelegramGroupsAdmin/Components/Shared/MessageBubbleTelegram.razor
+git commit -m "fix(#405): migrate 3 custom-format + MessageBubbleTelegram to LocalTimestamp"
+```
+
+---
+
+## Task 8: Update MessageBubbleTelegram tests (#405)
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.ComponentTests/Components/MessageBubbleTelegramTests.cs:456-515`
+
+- [ ] **Step 1: Update DisplaysTimestamp test**
+
+The test at lines 458-500 currently creates a full `MessageRecord` manually and asserts on `data-utc` attribute. Update to assert on the `<LocalTimestamp>` rendered output.
+
+Since `LocalTimestamp` uses a cascading `TimeZoneInfo?` parameter, we must cascade it via `RenderTree.TryAdd` before rendering — the same pattern used in `MessageTrendsOverviewCardTests.cs` (lines 57-59). The `CreateMessage` helper doesn't accept a `timestamp` parameter, so continue constructing the `MessageRecord` manually as the existing test does.
+
+Replace the full test method (lines 458-500):
+
+```csharp
+[Test]
+public void DisplaysTimestamp()
+{
+    // Arrange — cascade TimeZoneInfo so LocalTimestamp renders the formatted time
+    RenderTree.TryAdd<Microsoft.AspNetCore.Components.CascadingValue<TimeZoneInfo?>>(p =>
+        p.Add(cv => cv.Value, TimeZoneInfo.Utc));
+
+    var timestamp = new DateTimeOffset(2025, 6, 15, 14, 30, 0, TimeSpan.Zero);
+    var message = new MessageRecord(
+        MessageId: 123,
+        User: new UserIdentity(456, "John", null, null),
+        Chat: new ChatIdentity(789, "Test Chat"),
+        Timestamp: timestamp,
+        MessageText: "Hello",
+        PhotoFileId: null,
+        PhotoFileSize: null,
+        Urls: null,
+        EditDate: null,
+        ContentHash: null,
+        PhotoLocalPath: null,
+        PhotoThumbnailPath: null,
+        ChatIconPath: null,
+        UserPhotoPath: null,
+        DeletedAt: null,
+        DeletionSource: null,
+        ReplyToMessageId: null,
+        ReplyToUser: null,
+        ReplyToText: null,
+        MediaType: null,
+        MediaFileId: null,
+        MediaFileSize: null,
+        MediaFileName: null,
+        MediaMimeType: null,
+        MediaLocalPath: null,
+        MediaDuration: null,
+        Translation: null,
+        ContentCheckSkipReason: ContentCheckSkipReason.NotSkipped);
+
+    // Act
+    var cut = Render<MessageBubbleTelegram>(p => p
+        .Add(x => x.Message, message));
+
+    // Assert — timestamp is rendered inside tg-timestamp wrapper via LocalTimestamp
+    var timestampEl = cut.Find(".tg-timestamp");
+    var displayTime = TimeZoneInfo.ConvertTime(timestamp, TimeZoneInfo.Utc);
+    Assert.That(timestampEl.TextContent.Trim(), Is.EqualTo(displayTime.ToString("MMM d, yyyy h:mm tt")));
+}
+```
+
+Note: `RenderTree.TryAdd` is available on `BunitContext` (the base of `MudBlazorTestContext`). It registers the cascading value for this test's render tree. The `TryAdd` call is safe to make per-test — it only affects the current test's render.
+
+- [ ] **Step 2: Update TimestampElement_HasLocalTimestampClass test**
+
+The test at lines 502-515 asserts on `.tg-timestamp.local-timestamp` selector. Since `local-timestamp` class no longer exists (the `<LocalTimestamp>` component renders a plain `<span>`), update to assert on just `.tg-timestamp`:
+
+```csharp
+[Test]
+public void TimestampElement_HasTgTimestampClass()
+{
+    // Arrange
+    var message = CreateMessage();
+
+    // Act
+    var cut = Render<MessageBubbleTelegram>(p => p
+        .Add(x => x.Message, message));
+
+    // Assert — tg-timestamp wrapper exists around the LocalTimestamp component
+    var timestampEl = cut.Find(".tg-timestamp");
+    Assert.That(timestampEl, Is.Not.Null);
+}
+```
+
+- [ ] **Step 3: Run the updated tests**
+
+Run: `dotnet test TelegramGroupsAdmin.ComponentTests --filter "FullyQualifiedName~MessageBubbleTelegramTests" --no-restore`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin.ComponentTests/Components/MessageBubbleTelegramTests.cs
+git commit -m "test(#405): update MessageBubbleTelegram tests for LocalTimestamp migration"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1: Full solution build**
+
+Run: `dotnet build`
+Expected: Build succeeded, 0 errors, 0 warnings
+
+- [ ] **Step 2: Run all unit + component tests**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --no-build && dotnet test TelegramGroupsAdmin.ComponentTests --no-build`
+Expected: All tests PASS
+
+- [ ] **Step 3: Verify no remaining data-utc usage**
+
+Run: `grep -r "data-utc" TelegramGroupsAdmin/Components/`
+Expected: No matches (all 14 components migrated)
+
+- [ ] **Step 4: Verify migration applies cleanly**
+
+Run: `dotnet run --project TelegramGroupsAdmin -- --migrate-only`
+Expected: Exit code 0

--- a/docs/superpowers/specs/2026-03-21-quick-wins-398-399-405-design.md
+++ b/docs/superpowers/specs/2026-03-21-quick-wins-398-399-405-design.md
@@ -1,0 +1,170 @@
+# Quick Wins: Issues #398, #399, #405
+
+Three independent fixes delivered as separate commits in a single PR to `develop`.
+
+---
+
+## Issue #398: Wire FileScanResult Cleanup into DataCleanupJob
+
+### Problem
+
+`IFileScanResultRepository.CleanupExpiredResultsAsync()` exists and works, but `DataCleanupJob` never calls it. File scan results accumulate in the database without cleanup.
+
+### Design
+
+**1. Add retention setting to `DataCleanupSettings`**
+
+Follow the existing pattern (same as `MessageRetention`, `ReportRetention`, etc.):
+
+```csharp
+public const string DefaultFileScanResultRetentionString = "24h";
+public static readonly TimeSpan DefaultFileScanResultRetention = TimeSpan.FromHours(24);
+public string FileScanResultRetention { get; init; } = DefaultFileScanResultRetentionString;
+```
+
+**2. Update `CleanupExpiredResultsAsync` to accept configurable retention**
+
+Change the method signature on both `IFileScanResultRepository` and `FileScanResultRepository`:
+
+```csharp
+Task<int> CleanupExpiredResultsAsync(TimeSpan retention, CancellationToken cancellationToken = default);
+```
+
+Replace the hardcoded `CacheTtl` usage in `CleanupExpiredResultsAsync` with the passed `retention` parameter. Keep the `CacheTtl` constant — it is also used by `GetCachedResultsByHashAsync` for cache freshness filtering (separate concern from cleanup retention).
+
+**3. Add 5th cleanup step to `DataCleanupJob`**
+
+- Parse `FileScanResultRetention` in `ExecuteCleanupAsync` alongside the other 4 settings
+- Add a `CleanupFileScanResultsAsync` private method following the existing pattern
+- Call it from `ExecuteCleanupAsync` after the notifications cleanup step
+
+### Files Modified
+
+- `TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs`
+- `TelegramGroupsAdmin.ContentDetection/Repositories/IFileScanResultRepository.cs`
+- `TelegramGroupsAdmin.ContentDetection/Repositories/FileScanResultRepository.cs`
+- `TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs`
+
+### Testing
+
+- Unit test for `DataCleanupJob` verifying the new cleanup step calls the repository with the correct retention value
+- Update any existing tests that call `CleanupExpiredResultsAsync` to pass the new `TimeSpan` parameter
+
+---
+
+## Issue #399: Prevent Duplicate Blocklist Subscription URLs
+
+### Problem
+
+`FindByUrlAsync()` exists on `IBlocklistSubscriptionsRepository` but the UI never calls it. Users can add the same blocklist URL multiple times, causing duplicate downloads during sync. No unique constraint exists at the database level.
+
+### Design
+
+**1. Add unique index via EF Core migration**
+
+Add a unique index on `(Url, ChatId)` in `AppDbContext`:
+
+```csharp
+modelBuilder.Entity<BlocklistSubscriptionDto>()
+    .HasIndex(bs => new { bs.Url, bs.ChatId })
+    .IsUnique();
+```
+
+Remove the existing non-unique index on `Url` alone (superseded by the composite unique index — leading-column lookups on `Url` are still supported).
+
+**Migration safety:** The `Up()` method must deduplicate existing rows before creating the unique index. Delete duplicate `(Url, ChatId)` rows keeping the most recent (by `Id`) before the `CREATE UNIQUE INDEX`:
+
+```csharp
+migrationBuilder.Sql("""
+    DELETE FROM blocklist_subscriptions
+    WHERE id NOT IN (
+        SELECT MAX(id) FROM blocklist_subscriptions GROUP BY url, chat_id
+    );
+    """);
+```
+
+Generate an EF Core migration for this schema change.
+
+**2. Add duplicate check and deduplication in UI save flow**
+
+The save flow uses a delete-then-reinsert pattern (deletes all custom subscriptions of that block mode, then reinserts from the text area). This means `FindByUrlAsync` protects against duplicating a *built-in* subscription or a subscription from the *other* block mode — not against same-mode custom entries (which were just deleted).
+
+In `UrlFiltersConfig.razor`, in both `SaveHardBlockConfigurationAsync` and `SaveSoftBlockConfigurationAsync`:
+
+- Apply `.Distinct()` to the parsed URL list to prevent duplicate entries within the same save batch
+- Before `InsertAsync`, call `FindByUrlAsync(url, ChatId)` to check for existing subscriptions (built-in or other block mode)
+- If duplicate found, skip insertion and collect the URL
+- After the save loop, show a snackbar listing any skipped duplicates
+
+### Files Modified
+
+- `TelegramGroupsAdmin.Data/AppDbContext.cs` (unique index)
+- `TelegramGroupsAdmin.Data/Migrations/` (new migration)
+- `TelegramGroupsAdmin/Components/Shared/ContentDetection/UrlFiltersConfig.razor` (duplicate check)
+
+### Testing
+
+- Integration test with Testcontainers: verify `FindByUrlAsync` correctly detects duplicates
+- Integration test: verify unique constraint rejects duplicate `(Url, ChatId)` at the database level
+
+---
+
+## Issue #405: Migrate 14 Components from Inline data-utc to LocalTimestamp
+
+### Problem
+
+The JS that hydrated `data-utc` spans was removed during the Phase 8 timezone cascade fix (#203). 14 components still use the old inline pattern and now display raw server time instead of browser-local time.
+
+### Design
+
+Mechanical replacement in all 14 components. Replace:
+
+```razor
+<span class="local-timestamp" data-utc="@value.ToString("o")">
+    @value.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
+</span>
+```
+
+With:
+
+```razor
+<LocalTimestamp Value="@value" />
+```
+
+For the 3 backup components using non-default formats (`"yyyy-MM-dd HH:mm:ss"` or `"yyyy-MM-dd HH:mm"`), pass the `Format` parameter:
+
+```razor
+<LocalTimestamp Value="@value" Format="yyyy-MM-dd HH:mm:ss" />
+```
+
+**Special case: `MessageBubbleTelegram.razor`** — This component uses `<span class="tg-timestamp local-timestamp" ...>` with an additional `tg-timestamp` CSS class for styling. Wrap the `<LocalTimestamp>` in a `<span class="tg-timestamp">` to preserve the CSS styling:
+
+```razor
+<span class="tg-timestamp"><LocalTimestamp Value="@Message.Timestamp" /></span>
+```
+
+No other changes needed — `LocalTimestamp` is globally imported and all components already receive the cascading `TimeZoneInfo` from `MainLayout`.
+
+### Files Modified (14 total, ~20 replacements)
+
+| Component | Timestamps | Format |
+|-----------|-----------|--------|
+| `Components/Reports/ModerationReportCard.razor` | 2 | default |
+| `Components/Reports/ImpersonationAlertCard.razor` | 2 | default |
+| `Components/Reports/ProfileScanAlertCard.razor` | 2 | default |
+| `Components/Reports/ExamReviewCard.razor` | 2 | default |
+| `Components/Shared/BackupRestore.razor` | 1 | `yyyy-MM-dd HH:mm` |
+| `Components/Shared/RestoreBackupModal.razor` | 1 | `yyyy-MM-dd HH:mm:ss` |
+| `Components/Shared/ProfileScanHistoryDialog.razor` | 1 | default |
+| `Components/Shared/ImageViewerDialog.razor` | 1 | default |
+| `Components/Shared/MessageBubbleTelegram.razor` | 2 | default |
+| `Components/Shared/DetectionHistoryDialog.razor` | 1 | default |
+| `Components/Shared/EditHistoryDialog.razor` | 1 | default |
+| `Components/Shared/UserNotesDialog.razor` | 2 | default |
+| `Components/Shared/BackupBrowser.razor` | 1 | `yyyy-MM-dd HH:mm:ss` |
+| `Components/Shared/ChatManagement/ChatConfigModal.razor` | 1 | default |
+
+### Testing
+
+- **Update existing tests:** `MessageBubbleTelegramTests.cs` has two tests that assert on the old `data-utc` / `.local-timestamp` markup (`DisplaysTimestamp` and `TimestampElement_HasLocalTimestampClass`). These must be updated to assert on the new `<LocalTimestamp>` rendering (wrapped in `<span class="tg-timestamp">`).
+- Build verification confirms markup compiles across all 14 files.


### PR DESCRIPTION
Closes #398, Closes #399, Closes #405

## Summary

Three independent quick-win fixes delivered as separate commits:

- **#398** — Wire `FileScanResultRepository.CleanupExpiredResultsAsync()` into `DataCleanupJob` as its 5th cleanup step with configurable `FileScanResultRetention` setting (default 24h). Includes 3 unit tests.
- **#399** — Add unique composite index on `(Url, ChatId)` for blocklist subscriptions with migration-safe deduplication of existing rows. UI-side `FindByUrlAsync` check + `Distinct()` prevents duplicates with snackbar feedback. Defense-in-depth: UI for UX, DB constraint for correctness.
- **#405** — Migrate all 14 components from broken inline `data-utc` timestamp spans to the `<LocalTimestamp>` component (~20 replacements). Three components use custom date formats, `MessageBubbleTelegram` preserves its `tg-timestamp` CSS wrapper. Two component tests updated.

**Additional fixes from code review:**
- Rename `ct` → `cancellationToken` in all 5 `DataCleanupJob` private methods
- Extract shared `SaveCustomBlockSubscriptionsAsync` to DRY the hard/soft block save methods
- Update `IFileScanResultRepository` doc comments to clarify read TTL vs cleanup retention
- Fix "Joined" column label → "Last Seen" in `Users.razor` (pre-existing bug, data was `LastSeenAt`)
- Fix flaky E2E test: `.First` on progress bar locator to avoid Playwright strict mode violation

## Test plan
- [x] Full solution build: 0 errors, 0 warnings
- [x] Unit tests: 1832 passed
- [x] Component tests: 1042 passed
- [x] Integration tests: 575 passed
- [x] Migration applies cleanly (`--migrate-only`)
- [x] Zero `data-utc` remnants in Components/
- [x] 4-agent code review: approved (no blocking findings)
- [ ] Manual verification of timestamp rendering in browser
- [ ] Manual verification of blocklist duplicate snackbar warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)