### PR TITLE
feat: redesign profile scanner detection model

### DIFF
--- a/TelegramGroupsAdmin.Data/Migrations/20260323222538_DropProfileScanResultsAiConfidence.Designer.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260323222538_DropProfileScanResultsAiConfidence.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TelegramGroupsAdmin.Data;
@@ -11,9 +12,11 @@ using TelegramGroupsAdmin.Data;
 namespace TelegramGroupsAdmin.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260323222538_DropProfileScanResultsAiConfidence")]
+    partial class DropProfileScanResultsAiConfidence
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TelegramGroupsAdmin.Data/Migrations/20260323222538_DropProfileScanResultsAiConfidence.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260323222538_DropProfileScanResultsAiConfidence.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelegramGroupsAdmin.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropProfileScanResultsAiConfidence : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ai_confidence",
+                table: "profile_scan_results");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ai_confidence",
+                table: "profile_scan_results",
+                type: "integer",
+                nullable: true);
+        }
+    }
+}

--- a/TelegramGroupsAdmin.Data/Models/ProfileScanResultDto.cs
+++ b/TelegramGroupsAdmin.Data/Models/ProfileScanResultDto.cs
@@ -36,10 +36,6 @@ public class ProfileScanResultDto
     [Column("ai_score")]
     public decimal AiScore { get; set; }
 
-    /// <summary>AI confidence 0-100, null if AI was skipped</summary>
-    [Column("ai_confidence")]
-    public int? AiConfidence { get; set; }
-
     /// <summary>AI's explanation of its decision</summary>
     [Column("ai_reason")]
     public string? AiReason { get; set; }

--- a/TelegramGroupsAdmin.Telegram/Models/ProfileScanResultRecord.cs
+++ b/TelegramGroupsAdmin.Telegram/Models/ProfileScanResultRecord.cs
@@ -14,6 +14,5 @@ public record ProfileScanResultRecord(
     ProfileScanOutcome Outcome,
     decimal RuleScore,
     decimal AiScore,
-    int? AiConfidence,
     string? AiReason,
     string? AiSignals);

--- a/TelegramGroupsAdmin.Telegram/Repositories/IProfileScanResultsRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/IProfileScanResultsRepository.cs
@@ -10,15 +10,15 @@ public interface IProfileScanResultsRepository
     /// <summary>
     /// Insert a new scan result record.
     /// </summary>
-    Task<long> InsertAsync(ProfileScanResultRecord record, CancellationToken ct);
+    Task<long> InsertAsync(ProfileScanResultRecord record, CancellationToken cancellationToken);
 
     /// <summary>
     /// Get all scan results for a user, most recent first.
     /// </summary>
-    Task<List<ProfileScanResultRecord>> GetByUserIdAsync(long userId, CancellationToken ct);
+    Task<List<ProfileScanResultRecord>> GetByUserIdAsync(long userId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Get the most recent scan result for a user, or null if never scanned.
     /// </summary>
-    Task<ProfileScanResultRecord?> GetLatestByUserIdAsync(long userId, CancellationToken ct);
+    Task<ProfileScanResultRecord?> GetLatestByUserIdAsync(long userId, CancellationToken cancellationToken);
 }

--- a/TelegramGroupsAdmin.Telegram/Repositories/Mappings/ProfileScanResultMappings.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/Mappings/ProfileScanResultMappings.cs
@@ -19,7 +19,6 @@ public static class ProfileScanResultMappings
             Outcome: (ProfileScanOutcome)data.Outcome,
             RuleScore: data.RuleScore,
             AiScore: data.AiScore,
-            AiConfidence: data.AiConfidence,
             AiReason: data.AiReason,
             AiSignals: data.AiSignals);
     }
@@ -35,7 +34,6 @@ public static class ProfileScanResultMappings
             Outcome = (int)ui.Outcome,
             RuleScore = ui.RuleScore,
             AiScore = ui.AiScore,
-            AiConfidence = ui.AiConfidence,
             AiReason = ui.AiReason,
             AiSignals = ui.AiSignals
         };

--- a/TelegramGroupsAdmin.Telegram/Repositories/ProfileScanResultsRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/ProfileScanResultsRepository.cs
@@ -11,35 +11,35 @@ namespace TelegramGroupsAdmin.Telegram.Repositories;
 public class ProfileScanResultsRepository(IDbContextFactory<AppDbContext> contextFactory)
     : IProfileScanResultsRepository
 {
-    public async Task<long> InsertAsync(ProfileScanResultRecord record, CancellationToken ct)
+    public async Task<long> InsertAsync(ProfileScanResultRecord record, CancellationToken cancellationToken)
     {
-        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
         var dto = record.ToDto();
         context.ProfileScanResults.Add(dto);
-        await context.SaveChangesAsync(ct);
+        await context.SaveChangesAsync(cancellationToken);
         return dto.Id;
     }
 
-    public async Task<List<ProfileScanResultRecord>> GetByUserIdAsync(long userId, CancellationToken ct)
+    public async Task<List<ProfileScanResultRecord>> GetByUserIdAsync(long userId, CancellationToken cancellationToken)
     {
-        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
         var results = await context.ProfileScanResults
             .AsNoTracking()
             .Where(r => r.UserId == userId)
             .OrderByDescending(r => r.ScannedAt)
-            .ToListAsync(ct);
+            .ToListAsync(cancellationToken);
 
         return results.Select(r => r.ToModel()).ToList();
     }
 
-    public async Task<ProfileScanResultRecord?> GetLatestByUserIdAsync(long userId, CancellationToken ct)
+    public async Task<ProfileScanResultRecord?> GetLatestByUserIdAsync(long userId, CancellationToken cancellationToken)
     {
-        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
         var dto = await context.ProfileScanResults
             .AsNoTracking()
             .Where(r => r.UserId == userId)
             .OrderByDescending(r => r.ScannedAt)
-            .FirstOrDefaultAsync(ct);
+            .FirstOrDefaultAsync(cancellationToken);
 
         return dto?.ToModel();
     }

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/IProfileScoringEngine.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/IProfileScoringEngine.cs
@@ -15,5 +15,5 @@ public interface IProfileScoringEngine
         string? imageLabels,
         decimal banThreshold,
         decimal notifyThreshold,
-        CancellationToken ct);
+        CancellationToken cancellationToken);
 }

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs
@@ -1,4 +1,4 @@
-using System.Security;
+using System.Net;
 using System.Text.Json.Serialization;
 
 namespace TelegramGroupsAdmin.Telegram.Services.UserApi;
@@ -14,7 +14,7 @@ internal static class ProfileScanPrompts
     /// Escapes &lt;, &gt;, &amp;, &quot;, and &apos;.
     /// </summary>
     internal static string SanitizeForPrompt(string? text)
-        => string.IsNullOrEmpty(text) ? "" : SecurityElement.Escape(text);
+        => string.IsNullOrEmpty(text) ? "" : WebUtility.HtmlEncode(text);
 
     internal static string BuildSystemPrompt(string? customDetectionCriteria = null)
     {

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs
@@ -16,62 +16,168 @@ internal static class ProfileScanPrompts
     internal static string SanitizeForPrompt(string? text)
         => string.IsNullOrEmpty(text) ? "" : SecurityElement.Escape(text);
 
-    internal static string BuildSystemPrompt() =>
+    internal static string BuildSystemPrompt(string? customDetectionCriteria = null)
+    {
+        var technical = GetTechnicalContract();
+        var criteria = customDetectionCriteria ?? GetDefaultDetectionCriteria();
+        var guardrails = GetBehavioralGuardrails();
+        return $"{technical}\n\n{criteria}\n\n{guardrails}";
+    }
+
+    private static string GetTechnicalContract() =>
         """
-        You are a profile safety analyzer for Telegram group administration.
-        You will receive a user's complete profile including images and text.
-        Analyze ALL provided evidence to assess the risk level of this account.
+        You are a profile risk analyzer for Telegram group administration.
+        Your job is to determine whether a user's profile belongs to a genuine
+        community member. Most real people in community groups have profiles that
+        look like a real person — their name, photo, bio, and username form a
+        coherent personal identity.
 
-        You must respond with valid JSON in this exact format:
-        {"spam": true/false, "confidence": 0-100, "reason": "clear explanation", "signals_detected": ["signal1", "signal2"], "contains_nudity": true/false}
+        You will receive a user's complete profile including text fields and images.
+        Evaluate the COMPLETE picture — every field and image, and how they relate
+        to each other.
 
-        IMPORTANT: Set "spam" to true for ANY level of concern — not just definitive spam.
-        Use the "confidence" field to indicate severity:
-        - 80-100: Definitive spam/explicit — obvious porn bot, explicit photos, clear solicitation
-        - 40-79: Suspicious/suggestive — warrants admin review but not auto-ban
-        - 1-39: Minor signals present but likely harmless
-        Set "spam" to false ONLY when the profile appears genuinely clean with no concerning signals.
+        Respond with valid JSON in this exact format:
+        {"score": 0.0-5.0, "reason": "clear explanation", "signals_detected": ["signal1", "signal2"], "contains_nudity": true/false}
 
-        HIGH RISK indicators (confidence 80+):
-        - Explicit or pornographic profile photo or story images
-        - Bio text promoting adult services, escort services, or sexual solicitation
-        - Personal channel with adult branding (title or photo containing 18+, NSFW, adult, xxx, porn, escort, sexual terms, suggestive emojis like 🍑🔞💋, or sexualized imagery)
-        - Personal channel linking to adult/porn/scam content
-        - Story content containing explicit imagery or adult solicitation
-        - Bio or channel description containing known spam domains or URL shorteners
-        - Combination of adult-branded channel + suggestive profile photo (even without explicit bio — the channel branding confirms intent)
+        The score is a continuous risk assessment on a 0.0 to 5.0 scale:
+          4.0-5.0: Clearly not a genuine community member — obvious on inspection
+          2.0-3.9: Questionable — real signals present but could go either way
+          0.1-1.9: Minor oddities, likely a real person with an unusual profile
+          0.0:     Clean profile consistent with a genuine community member
+        """;
 
-        SUSPICIOUS indicators (confidence 40-79):
-        - Sexually suggestive profile photo (revealing clothing, provocative poses, thirst traps)
-        - Suggestive or sexually-themed display name or username
-        - Combination of suggestive name + suggestive photo (even without explicit bio)
-        - Minimal profile info combined with suggestive imagery
-        - Channel or stories with borderline adult content (but no explicit 18+/NSFW branding)
+    internal static string GetDefaultDetectionCriteria() =>
+        """
+        ══════════════════════════════════════
+         DETECTION CATEGORIES
+        ══════════════════════════════════════
 
-        CLEAN indicators (spam: false):
-        - Normal profile photo (selfie, pet, landscape, avatar, no photo)
-        - Bio about hobbies, work, education, or interests
-        - Personal channel about legitimate topics
-        - Stories showing normal life content
+        ADULT / EXPLICIT (score 4.0-5.0):
+        - Visible nudity in ANY image — bare breasts, genitalia, buttocks.
+          If you can see it, flag it. Do not rationalize away visible nudity
+          because the photo is cropped, the face is the focal point, or the
+          pose is "artistic." Nudity is nudity.
+        - Implied nudity — bare shoulders on a bed, sexual pose where the
+          person is obviously unclothed but the frame crops below the neck.
+          Strategic cropping does not make nudity disappear.
+        - Bio promoting adult services, escort services, sexual solicitation
+        - Personal channel with adult branding (18+, NSFW, xxx, porn, escort,
+          suggestive emojis, sexualized imagery)
+        - Story content with explicit imagery or adult solicitation
+        - Bio or channel linking to adult/pornographic content
 
-        URL METADATA ANALYSIS:
-        When a <url_metadata> section is provided, it contains scraped page titles and descriptions
-        from URLs found in the user's bio, channel description, or story captions. Use this to identify:
-        - Adult/pornographic site titles or descriptions (HIGH RISK, confidence 80+)
+        COMMERCIAL / SERVICE ACCOUNT (score 4.0-5.0):
+        - Display name is a business, brand, product, or service — not a
+          person's name (e.g., "VOIP DEVELOPMENT", "CRYPTO SIGNALS", "FOREX VIP")
+        - Profile photo shows products, inventory, storefronts, logos, QR codes,
+          or marketing material instead of a personal photo
+        - Bio reads like an advertisement: pricing, "DM for orders", "wholesale",
+          service descriptions, contact info for business inquiries
+        - Username is the business name compressed or abbreviated
+        - The profile exists to promote a commercial activity, not to
+          participate in community conversation
+
+        INCOHERENT / MANUFACTURED PROFILE (score 3.0-4.5):
+        - Name, bio, and photo tell completely unrelated stories
+          (e.g., tech company name + random personal name in bio + product photo)
+        - Bio is gibberish, random characters, or has no logical connection to
+          the name or photo
+        - Profile elements appear assembled from different identities
+        - The combination doesn't make sense for any real person
+
+        BOT / MASS-CREATED PATTERNS (score 3.0-4.5):
+        - Name follows a template: CATEGORY + KEYWORD format
+          (e.g., "CRYPTO TRADING", "FOREX SIGNALS", "SEO EXPERT")
+        - All-caps display name styled as a brand or service header
+        - Empty profile with only a commercial or promotional name
+        - Sequential or generated-looking username (dev1234, user_8837)
+
+        SCAM / SCHEME PROMOTION (score 4.0-5.0):
+        - Bio or channel containing known spam domains or URL shorteners
+        - Cryptocurrency/investment scheme promotion with guaranteed returns
+        - Phishing or impersonation indicators
+        - Gambling or casino promotion
+        - Get-rich-quick schemes or unrealistic profit promises
+        NOTE: Decentralized identity strings (Nostr npub keys, Lightning
+        addresses, ENS .eth names) are legitimate social identifiers, not
+        scam signals. Only flag cryptocurrency content when it promotes
+        schemes, guaranteed returns, or investment solicitation.
+
+        IMPERSONATION (score 3.5-5.0):
+        - Profile mimics a public figure, celebrity, or well-known person
+        - Name and photo combination designed to appear as someone famous
+        - Bio claims to be a notable individual
+        NOTE: Group admin impersonation is handled by a separate system.
+        This category covers public figure impersonation only.
+
+        ══════════════════════════════════════
+         WHAT A CLEAN PROFILE LOOKS LIKE
+        ══════════════════════════════════════
+
+        A clean profile (score near 0.0) has:
+        - A name that sounds like a real person's name, in any language or culture
+        - A photo that is personal: selfie, pet, landscape, avatar, anime,
+          artwork, group photo, or no photo at all
+        - A bio (if present) about personal interests, hobbies, work, education,
+          a quote, or simply empty
+        - Profile elements that don't contradict each other
+
+        An EMPTY profile (no bio, no photo, basic human name) is CLEAN.
+        Most real users have minimal profiles. Do not penalize absence of
+        information — penalize presence of wrong information.
+
+        ══════════════════════════════════════
+         SIGNAL CONVERGENCE
+        ══════════════════════════════════════
+
+        Multiple signals pointing in the same direction COMPOUND — do not
+        average them. Each additional aligned signal makes the case stronger.
+
+        Examples:
+        - Suggestive photo alone → 2.0-2.5
+        - Suggestive photo + suggestive name → 3.0-3.5
+        - Suggestive photo + suggestive name + suggestive username + empty
+          profile → 4.0-4.5 (four aligned signals = clearly not normal)
+
+        - Business name alone → 2.0-2.5 (some people use business names casually)
+        - Business name + product photo → 3.5-4.0
+        - Business name + product photo + incoherent bio → 4.0-4.5
+
+        The guiding question: "Could a reasonable person look at this entire
+        profile and believe it belongs to a genuine community member?"
+        If the answer is clearly no, score should be 4.0+.
+        """;
+
+    private static string GetBehavioralGuardrails() =>
+        """
+        ══════════════════════════════════════
+         URL METADATA ANALYSIS
+        ══════════════════════════════════════
+
+        When <url_metadata> is provided, it contains scraped page titles and
+        descriptions from URLs in the bio, channel, or stories. Use to identify:
+        - Adult/pornographic sites (score 4.0+)
         - Cryptocurrency/investment scam landing pages
         - Phishing or impersonation pages
-        - Gambling or casino promotion pages
-        - URL shortener landing pages that redirect to suspicious content
-        URL metadata revealing legitimate sites (social media, GitHub, personal blogs) is neutral.
+        - Gambling or casino promotion
+        - URL shortener redirects to suspicious content
+        Legitimate URLs (social media, GitHub, personal blogs) are neutral.
 
-        When multiple suggestive signals combine, increase confidence accordingly.
-        A suggestive photo alone might be 40-50, but suggestive photo + suggestive name = 55-70.
-        A personal channel with explicit adult branding (18+, NSFW, etc.) is a strong signal on its own (80+),
-        regardless of whether the profile photo is explicitly pornographic.
+        ══════════════════════════════════════
+         NUDITY FLAG
+        ══════════════════════════════════════
 
-        Set "contains_nudity" to true ONLY if any provided image contains nudity, pornography, or
-        explicit sexual imagery. This is specifically about visual content in images — suggestive text,
-        adult channel branding, or non-visual signals should NOT set this flag.
+        Set "contains_nudity" to true ONLY for visible nudity that would
+        violate public indecency laws:
+        - Bare breasts (not cleavage in clothing/lingerie)
+        - Exposed genitalia
+        - Exposed buttocks
+
+        Lingerie, swimwear, revealing clothing, suggestive poses, and
+        cleavage do NOT set this flag. Those are handled by the score,
+        not the nudity flag.
+
+        This flag triggers image censoring in admin review.
         """;
 
     internal static string BuildUserPrompt(
@@ -111,7 +217,7 @@ internal static class ProfileScanPrompts
         }
 
         return $$"""
-            Analyze this Telegram user profile for spam/adult content indicators.
+            Assess whether this Telegram user profile belongs to a genuine community member.
 
             <profile>
               <display_name>{{SanitizeForPrompt(firstName)}} {{SanitizeForPrompt(lastName)}}</display_name>
@@ -133,7 +239,7 @@ internal static class ProfileScanPrompts
               <image_labels>{{imageLabels ?? "none"}}</image_labels>
             </images>
             {{urlMetadataBlock}}
-            Respond with JSON: {"spam": true/false, "confidence": 0-100, "reason": "...", "signals_detected": [...], "contains_nudity": true/false}
+            Respond with JSON: {"score": 0.0-5.0, "reason": "...", "signals_detected": [...], "contains_nudity": true/false}
             """;
     }
 }

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs
@@ -142,8 +142,7 @@ internal static class ProfileScanPrompts
 /// Deserialization target for the AI profile scan response.
 /// </summary>
 internal record ProfileScanAIResponse(
-    [property: JsonPropertyName("spam")] bool Spam,
-    [property: JsonPropertyName("confidence")] int Confidence,
+    [property: JsonPropertyName("score")] decimal Score,
     [property: JsonPropertyName("reason")] string? Reason,
     [property: JsonPropertyName("signals_detected")] string[]? SignalsDetected,
     [property: JsonPropertyName("contains_nudity")] bool ContainsNudity);

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
@@ -333,7 +333,7 @@ public sealed class ProfileScanService(
         var scoringEngine = sp.GetRequiredService<IProfileScoringEngine>();
 
         var scoreResult = await scoringEngine.ScoreAsync(
-            profileData, imageResult.Images, imageResult.Labels, banThreshold, notifyThreshold, ct);
+            profileData, imageResult.Images, imageResult.Labels, banThreshold, notifyThreshold, cancellationToken: ct);
 
         // ── Step 7: Persist results ──
         await userRepo.UpdateProfileScanDataAsync(

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
@@ -355,10 +355,9 @@ public sealed class ProfileScanService(
             Outcome: scoreResult.Outcome,
             RuleScore: scoreResult.RuleScore,
             AiScore: scoreResult.AiScore,
-            AiConfidence: scoreResult.AiConfidence,
             AiReason: scoreResult.AiReason,
             AiSignals: scoreResult.AiSignals is { Length: > 0 }
-                ? string.Join(", ", scoreResult.AiSignals) : null), ct);
+                ? string.Join(", ", scoreResult.AiSignals) : null), cancellationToken: ct);
 
         var result = new ProfileScanResult(
             user.Id, bio, personalChannelId, channelTitle, channelAbout,

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs
@@ -25,12 +25,11 @@ public sealed class ProfileScoringEngine(
     /// <summary>Result from AI vision analysis (Layer 2).</summary>
     private record AiScoringResult(
         decimal Score,
-        int? Confidence,
         string? Reason,
         string[]? Signals,
         bool ContainsNudity = false)
     {
-        public static readonly AiScoringResult Empty = new(0.0m, null, null, null, false);
+        public static readonly AiScoringResult Empty = new(0.0m, null, null, false);
     }
 
     private const decimal MaxScore = 5.0m;
@@ -69,7 +68,6 @@ public sealed class ProfileScoringEngine(
                 Outcome: ProfileScanOutcome.Banned,
                 RuleScore: ruleScore,
                 AiScore: 0.0m,
-                AiConfidence: null,
                 AiReason: "Rule-based detection triggered ban threshold",
                 AiSignals: null,
                 ContainsNudity: false);
@@ -94,7 +92,6 @@ public sealed class ProfileScoringEngine(
             Outcome: outcome,
             RuleScore: ruleScore,
             AiScore: aiResult.Score,
-            AiConfidence: aiResult.Confidence,
             AiReason: aiResult.Reason,
             AiSignals: aiResult.Signals,
             ContainsNudity: aiResult.ContainsNudity);
@@ -242,18 +239,8 @@ public sealed class ProfileScoringEngine(
                 return AiScoringResult.Empty;
             }
 
-            if (!response.Spam)
-                return new AiScoringResult(0.0m, response.Confidence, response.Reason, response.SignalsDetected, response.ContainsNudity);
-
-            // Map confidence to points (aligned with prompt tiers)
-            var score = response.Confidence switch
-            {
-                >= 80 => 4.5m,  // Definitive spam/explicit → auto-ban
-                >= 40 => 2.5m,  // Suspicious/suggestive → admin review
-                _ => 0.0m       // Minor signals — treat as clean
-            };
-
-            return new AiScoringResult(score, response.Confidence, response.Reason, response.SignalsDetected, response.ContainsNudity);
+            var score = Math.Clamp(response.Score, 0.0m, MaxScore);
+            return new AiScoringResult(score, response.Reason, response.SignalsDetected, response.ContainsNudity);
         }
         catch (JsonException ex)
         {

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs
@@ -47,17 +47,17 @@ public sealed class ProfileScoringEngine(
     /// <param name="imageLabels">Labels describing each image (e.g. "Image 1: profile photo, Image 2: pinned story").</param>
     /// <param name="banThreshold">Score at or above which the user should be auto-banned.</param>
     /// <param name="notifyThreshold">Score at or above which admins should be notified.</param>
-    /// <param name="ct">Cancellation token.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public async Task<ScoringResult> ScoreAsync(
         ProfileData profile,
         IReadOnlyList<ImageInput> images,
         string? imageLabels,
         decimal banThreshold,
         decimal notifyThreshold,
-        CancellationToken ct)
+        CancellationToken cancellationToken)
     {
         // ── Layer 1: Rule-based pre-filters ──
-        var ruleScore = await RunRuleBasedScoringAsync(profile, ct);
+        var ruleScore = await RunRuleBasedScoringAsync(profile, cancellationToken);
 
         if (ruleScore >= banThreshold)
         {
@@ -74,7 +74,7 @@ public sealed class ProfileScoringEngine(
         }
 
         // ── Layer 2: AI vision analysis ──
-        var aiResult = await RunAiScoringAsync(profile, images, imageLabels, ct);
+        var aiResult = await RunAiScoringAsync(profile, images, imageLabels, cancellationToken);
         var totalScore = Cap(ruleScore + aiResult.Score);
 
         var outcome = totalScore >= banThreshold
@@ -101,7 +101,7 @@ public sealed class ProfileScoringEngine(
     // Layer 1: Rule-based pre-filters
     // ═══════════════════════════════════════════════════════════════════════════
 
-    private async Task<decimal> RunRuleBasedScoringAsync(ProfileData profile, CancellationToken ct)
+    private async Task<decimal> RunRuleBasedScoringAsync(ProfileData profile, CancellationToken cancellationToken)
     {
         var score = 0.0m;
 
@@ -119,7 +119,7 @@ public sealed class ProfileScoringEngine(
             return score;
 
         // Check for blocked URLs
-        var hardBlock = await urlPreFilter.CheckHardBlockAsync(allText, profile.Chat, ct);
+        var hardBlock = await urlPreFilter.CheckHardBlockAsync(allText, profile.Chat, cancellationToken);
         if (hardBlock.ShouldBlock)
         {
             logger.LogInformation("Profile scan for {User}: blocked URL detected ({Domain})",
@@ -128,7 +128,7 @@ public sealed class ProfileScoringEngine(
         }
 
         // Check for stop words
-        var stopWords = (await stopWordsRepository.GetEnabledStopWordsAsync(ct)).ToList();
+        var stopWords = (await stopWordsRepository.GetEnabledStopWordsAsync(cancellationToken)).ToList();
         if (stopWords.Count > 0)
         {
             var lowerText = allText.ToLowerInvariant();
@@ -162,9 +162,9 @@ public sealed class ProfileScoringEngine(
         ProfileData profile,
         IReadOnlyList<ImageInput> images,
         string? imageLabels,
-        CancellationToken ct)
+        CancellationToken cancellationToken)
     {
-        if (!await chatService.IsFeatureAvailableAsync(AIFeatureType.ProfileScan, ct))
+        if (!await chatService.IsFeatureAvailableAsync(AIFeatureType.ProfileScan, cancellationToken))
         {
             logger.LogWarning("ProfileScan AI feature not configured — only rule-based scoring active");
             return AiScoringResult.Empty;
@@ -177,7 +177,7 @@ public sealed class ProfileScoringEngine(
         {
             try
             {
-                urlMetadata = await urlContentScraping.ScrapeUrlMetadataAsync(allText, ct);
+                urlMetadata = await urlContentScraping.ScrapeUrlMetadataAsync(allText, cancellationToken);
                 if (urlMetadata != null)
                 {
                     logger.LogDebug("Profile scan for {User}: scraped URL metadata for AI context",
@@ -207,16 +207,16 @@ public sealed class ProfileScoringEngine(
             result = images.Count == 1
                 ? await chatService.GetVisionCompletionAsync(
                     AIFeatureType.ProfileScan, systemPrompt, userPrompt,
-                    images[0].Data, images[0].MimeType, options, ct)
+                    images[0].Data, images[0].MimeType, options, cancellationToken)
                 : await chatService.GetVisionCompletionAsync(
                     AIFeatureType.ProfileScan, systemPrompt, userPrompt,
-                    images, options, ct);
+                    images, options, cancellationToken);
         }
         else
         {
             // No images — text-only analysis
             result = await chatService.GetCompletionAsync(
-                AIFeatureType.ProfileScan, systemPrompt, userPrompt, options, ct);
+                AIFeatureType.ProfileScan, systemPrompt, userPrompt, options, cancellationToken);
         }
 
         if (result == null)

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ScoringResult.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ScoringResult.cs
@@ -8,7 +8,6 @@ public record ScoringResult(
     ProfileScanOutcome Outcome,
     decimal RuleScore,
     decimal AiScore,
-    int? AiConfidence,
     string? AiReason,
     string[]? AiSignals,
     bool ContainsNudity = false);

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/UserApi/ProfileScoringEngineTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/UserApi/ProfileScoringEngineTests.cs
@@ -434,11 +434,7 @@ public class ProfileScoringEngineTests
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
 
         // Assert
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AiScore, Is.EqualTo(0.0m));
-
-        }
+        Assert.That(result.AiScore, Is.EqualTo(0.0m));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -597,11 +593,7 @@ public class ProfileScoringEngineTests
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
 
         // Assert
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AiScore, Is.EqualTo(0.0m));
-
-        }
+        Assert.That(result.AiScore, Is.EqualTo(0.0m));
     }
 
     [Test]

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/UserApi/ProfileScoringEngineTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/UserApi/ProfileScoringEngineTests.cs
@@ -20,7 +20,7 @@ namespace TelegramGroupsAdmin.UnitTests.Telegram.Services.UserApi;
 /// - No real HTTP, database, or file system access.
 /// - Two scoring layers are exercised independently:
 ///     Layer 1 — rule-based: IsScam/IsFake flags, blocked URLs (+3.0), stop words (+1.5).
-///     Layer 2 — AI: confidence tiers (>=80 → 4.5, >=40 → 2.5, <40 → 0.0), malformed JSON fallback.
+///     Layer 2 — AI: direct 0.0-5.0 score passthrough with clamp, nudity flag, malformed JSON fallback.
 /// - Outcome thresholds use defaults: banThreshold=4.0, notifyThreshold=2.0.
 /// </summary>
 [TestFixture]
@@ -101,6 +101,18 @@ public class ProfileScoringEngineTests
 
     private static ChatCompletionResult AiResponse(string json) =>
         new() { Content = json };
+
+    private void EnableAiWithResponse(string json)
+    {
+        _chatService
+            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
+            .Returns(true);
+        _chatService
+            .GetCompletionAsync(
+                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(AiResponse(json));
+    }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Layer 1: Telegram-flagged accounts
@@ -390,7 +402,7 @@ public class ProfileScoringEngineTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.AiScore, Is.EqualTo(0.0m));
-            Assert.That(result.AiConfidence, Is.Null);
+
             Assert.That(result.AiReason, Is.Null);
         }
 
@@ -425,185 +437,142 @@ public class ProfileScoringEngineTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.AiScore, Is.EqualTo(0.0m));
-            Assert.That(result.AiConfidence, Is.Null);
+
         }
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // Layer 2: AI returns spam=false
+    // Layer 2: AI score passthrough (new 0-5 direct scoring)
     // ═══════════════════════════════════════════════════════════════════════════
 
     [Test]
-    public async Task ScoreAsync_AiReturnsSpamFalse_AiScoreIsZeroAndClean()
+    public async Task ScoreAsync_AiReturnsCleanScore_AiScoreIsZero()
     {
-        // Arrange
         var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": false, "confidence": 90, "reason": "clean profile"}"""));
+        EnableAiWithResponse("""{"score": 0.0, "reason": "genuine community member", "signals_detected": [], "contains_nudity": false}""");
 
-        // Act
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
 
-        // Assert
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.AiScore, Is.EqualTo(0.0m));
-            Assert.That(result.AiConfidence, Is.EqualTo(90));
-            Assert.That(result.AiReason, Is.EqualTo("clean profile"));
+            Assert.That(result.AiReason, Is.EqualTo("genuine community member"));
             Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Clean));
         }
     }
 
-    // ═══════════════════════════════════════════════════════════════════════════
-    // Layer 2: AI confidence tiers (spam=true)
-    // ═══════════════════════════════════════════════════════════════════════════
-
     [Test]
-    public async Task ScoreAsync_AiSpamTrueConfidence80_AiScoreIsFourPointFive()
+    public async Task ScoreAsync_AiReturnsSuspiciousScore_OutcomeIsHeldForReview()
     {
-        // Arrange — confidence >= 80 → 4.5 AI score → total >= banThreshold
         var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 80, "reason": "explicit spam", "signals_detected": ["promo_link"]}"""));
+        EnableAiWithResponse("""{"score": 2.8, "reason": "suggestive photo + name", "signals_detected": ["suggestive_photo", "suggestive_name"], "contains_nudity": false}""");
 
-        // Act
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
 
-        // Assert
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result.AiScore, Is.EqualTo(4.5m));
-            Assert.That(result.AiConfidence, Is.EqualTo(80));
-            Assert.That(result.AiReason, Is.EqualTo("explicit spam"));
-            Assert.That(result.AiSignals, Is.EquivalentTo(new[] { "promo_link" }));
-            Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Banned));
-        }
-    }
-
-    [Test]
-    public async Task ScoreAsync_AiSpamTrueConfidenceExactly80_AiScoreIsFourPointFive()
-    {
-        // Arrange — boundary test: confidence of exactly 80 must hit the >=80 tier
-        var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 80, "reason": "boundary"}"""));
-
-        // Act
-        var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
-
-        // Assert
-        Assert.That(result.AiScore, Is.EqualTo(4.5m));
-    }
-
-    [Test]
-    public async Task ScoreAsync_AiSpamTrueConfidence50_AiScoreIsTwoPointFive()
-    {
-        // Arrange — confidence >= 40 → 2.5 AI score → HeldForReview
-        var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 50, "reason": "suspicious"}"""));
-
-        // Act
-        var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
-
-        // Assert
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.AiScore, Is.EqualTo(2.5m));
-            Assert.That(result.AiConfidence, Is.EqualTo(50));
+            Assert.That(result.AiScore, Is.EqualTo(2.8m));
             Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.HeldForReview));
         }
     }
 
     [Test]
-    public async Task ScoreAsync_AiSpamTrueConfidenceExactly40_AiScoreIsTwoPointFive()
+    public async Task ScoreAsync_AiReturnsBanScore_OutcomeIsBanned()
     {
-        // Arrange — boundary test: confidence of exactly 40 must hit the >=40 tier
         var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 40, "reason": "boundary"}"""));
+        EnableAiWithResponse("""{"score": 4.5, "reason": "commercial account with product photos", "signals_detected": ["commercial_name", "product_photo"], "contains_nudity": false}""");
 
-        // Act
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
 
-        // Assert
-        Assert.That(result.AiScore, Is.EqualTo(2.5m));
-    }
-
-    [Test]
-    public async Task ScoreAsync_AiSpamTrueConfidence20_AiScoreIsZero()
-    {
-        // Arrange — confidence < 40 → 0 AI score (minor signals treated as clean)
-        var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 20, "reason": "minor signals"}"""));
-
-        // Act
-        var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
-
-        // Assert
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result.AiScore, Is.EqualTo(0.0m));
-            Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Clean));
+            Assert.That(result.AiScore, Is.EqualTo(4.5m));
+            Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Banned));
         }
     }
 
     [Test]
-    public async Task ScoreAsync_AiSpamTrueConfidenceExactly39_AiScoreIsZero()
+    public async Task ScoreAsync_AiScoreExceedsFive_ClampedToMaxScore()
     {
-        // Arrange — boundary: 39 is one below the >=40 tier, must produce 0
         var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 39, "reason": "below threshold"}"""));
+        EnableAiWithResponse("""{"score": 7.5, "reason": "extreme risk", "signals_detected": [], "contains_nudity": false}""");
 
-        // Act
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
 
-        // Assert
+        Assert.That(result.AiScore, Is.EqualTo(5.0m));
+    }
+
+    [Test]
+    public async Task ScoreAsync_AiScoreNegative_ClampedToZero()
+    {
+        var profile = BuildProfile(bio: "Some bio text");
+        EnableAiWithResponse("""{"score": -1.0, "reason": "invalid", "signals_detected": [], "contains_nudity": false}""");
+
+        var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
         Assert.That(result.AiScore, Is.EqualTo(0.0m));
+    }
+
+    [Test]
+    public async Task ScoreAsync_RuleScorePlusAiScore_Additive()
+    {
+        // Rule: stop word (+1.5) + AI score 3.0 = 4.5 → ban
+        var profile = BuildProfile(bio: "guaranteed profits from my service");
+        _stopWordsRepository
+            .GetEnabledStopWordsAsync(Arg.Any<CancellationToken>())
+            .Returns(["guaranteed profits"]);
+        EnableAiWithResponse("""{"score": 3.0, "reason": "scam promotion", "signals_detected": ["scam_language"], "contains_nudity": false}""");
+
+        var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.RuleScore, Is.EqualTo(1.5m));
+            Assert.That(result.AiScore, Is.EqualTo(3.0m));
+            Assert.That(result.Score, Is.EqualTo(4.5m));
+            Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Banned));
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Layer 2: Nudity flag passthrough
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task ScoreAsync_AiReturnsNudityTrue_ContainsNudityIsTrue()
+    {
+        var profile = BuildProfile(bio: "Some bio text");
+        EnableAiWithResponse("""{"score": 4.8, "reason": "visible nudity in profile photo", "signals_detected": ["nudity"], "contains_nudity": true}""");
+
+        var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+        Assert.That(result.ContainsNudity, Is.True);
+    }
+
+    [Test]
+    public async Task ScoreAsync_AiReturnsNudityFalse_ContainsNudityIsFalse()
+    {
+        var profile = BuildProfile(bio: "Some bio text");
+        EnableAiWithResponse("""{"score": 3.5, "reason": "suggestive but not nude", "signals_detected": ["suggestive_photo"], "contains_nudity": false}""");
+
+        var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+        Assert.That(result.ContainsNudity, Is.False);
+    }
+
+    [Test]
+    public async Task ScoreAsync_NudityFlagIndependentOfScore_LowScoreCanHaveNudity()
+    {
+        var profile = BuildProfile(bio: "Some bio text");
+        EnableAiWithResponse("""{"score": 1.5, "reason": "minimal risk but nudity present", "signals_detected": ["nudity"], "contains_nudity": true}""");
+
+        var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.ContainsNudity, Is.True);
+            Assert.That(result.AiScore, Is.EqualTo(1.5m));
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -631,14 +600,14 @@ public class ProfileScoringEngineTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.AiScore, Is.EqualTo(0.0m));
-            Assert.That(result.AiConfidence, Is.Null);
+
         }
     }
 
     [Test]
     public async Task ScoreAsync_AiReturnsEmptyJsonObject_AiScoreIsZero()
     {
-        // Arrange — valid JSON but missing fields; Spam defaults to false
+        // Arrange — valid JSON but missing fields; Score defaults to 0
         var profile = BuildProfile(bio: "Some bio text");
         _chatService
             .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
@@ -672,7 +641,7 @@ public class ProfileScoringEngineTests
             .GetCompletionAsync(
                 Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": false, "confidence": 10, "reason": "clean"}"""));
+            .Returns(AiResponse("""{"score": 0.0, "reason": "clean", "signals_detected": [], "contains_nudity": false}"""));
 
         // Act
         await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
@@ -708,7 +677,7 @@ public class ProfileScoringEngineTests
                 Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<byte[]>(), Arg.Any<string>(),
                 Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": false, "confidence": 5, "reason": "clean"}"""));
+            .Returns(AiResponse("""{"score": 0.0, "reason": "clean", "signals_detected": [], "contains_nudity": false}"""));
 
         // Act
         await _sut.ScoreAsync(profile, [singleImage], "Image 1: profile photo", BanThreshold, NotifyThreshold, CancellationToken.None);
@@ -739,7 +708,7 @@ public class ProfileScoringEngineTests
                 Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<IReadOnlyList<ImageInput>>(),
                 Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": false, "confidence": 5, "reason": "clean"}"""));
+            .Returns(AiResponse("""{"score": 0.0, "reason": "clean", "signals_detected": [], "contains_nudity": false}"""));
 
         // Act
         await _sut.ScoreAsync(profile, images, "Image 1: profile photo, Image 2: story", BanThreshold, NotifyThreshold, CancellationToken.None);
@@ -772,17 +741,9 @@ public class ProfileScoringEngineTests
     [Test]
     public async Task ScoreAsync_TotalScoreAtNotifyThreshold_OutcomeIsHeldForReview()
     {
-        // Arrange — stop word hit → rule score 1.5, AI adds 0.5 needed to reach exactly 2.0
-        // Easier: use AI confidence >=40 → AI score 2.5 alone → total 2.5, which is >= 2.0 < 4.0
+        // Arrange — AI returns score 2.5 directly → total 2.5, which is >= 2.0 < 4.0
         var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 50, "reason": "suspicious"}"""));
+        EnableAiWithResponse("""{"score": 2.5, "reason": "suspicious", "signals_detected": [], "contains_nudity": false}""");
 
         // Act
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
@@ -798,16 +759,9 @@ public class ProfileScoringEngineTests
     [Test]
     public async Task ScoreAsync_TotalScoreAtBanThreshold_OutcomeIsBanned()
     {
-        // Arrange — AI returns 4.5 score alone → >= banThreshold 4.0
+        // Arrange — AI returns score 4.5 directly → >= banThreshold 4.0
         var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 95, "reason": "definitive spam"}"""));
+        EnableAiWithResponse("""{"score": 4.5, "reason": "definitive spam", "signals_detected": [], "contains_nudity": false}""");
 
         // Act
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
@@ -841,20 +795,13 @@ public class ProfileScoringEngineTests
     [Test]
     public async Task ScoreAsync_CombinedRuleAndAiScoreExceedsFive_CappedAtFive()
     {
-        // Arrange — blocked URL (3.0) + AI spam confidence 95 (4.5) = 7.5 raw, capped at 5.0
+        // Arrange — blocked URL (3.0) + AI score 4.5 = 7.5 raw, capped at 5.0
         // Rule score 3.0 < banThreshold 4.0 so AI layer is reached.
         var profile = BuildProfile(bio: "spam site link");
         _urlPreFilter
             .CheckHardBlockAsync(Arg.Any<string>(), Arg.Any<ChatIdentity>(), Arg.Any<CancellationToken>())
             .Returns(new HardBlockResult(true, "Blocked", "spam.example"));
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 95, "reason": "definitive spam"}"""));
+        EnableAiWithResponse("""{"score": 4.5, "reason": "definitive spam", "signals_detected": [], "contains_nudity": false}""");
 
         // Note: rule score 3.0 < banThreshold 4.0 so AI layer is reached.
         // Total raw = 3.0 + 4.5 = 7.5, should be capped at 5.0.
@@ -875,14 +822,7 @@ public class ProfileScoringEngineTests
     {
         // Arrange — with a high ban threshold of 5.0, AI score 4.5 should become HeldForReview
         var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 95, "reason": "definitive spam"}"""));
+        EnableAiWithResponse("""{"score": 4.5, "reason": "definitive spam", "signals_detected": [], "contains_nudity": false}""");
 
         // Act — ban threshold raised so 4.5 does not trigger ban
         var result = await _sut.ScoreAsync(profile, [], null,
@@ -897,14 +837,7 @@ public class ProfileScoringEngineTests
     {
         // Arrange — notify threshold 0.5m means any positive score triggers HeldForReview
         var profile = BuildProfile(bio: "slightly suspicious bio");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": false, "confidence": 30, "reason": "minor flags"}"""));
+        EnableAiWithResponse("""{"score": 0.0, "reason": "minor flags", "signals_detected": [], "contains_nudity": false}""");
         _stopWordsRepository
             .GetEnabledStopWordsAsync(Arg.Any<CancellationToken>())
             .Returns(["suspicious"]);
@@ -965,7 +898,7 @@ public class ProfileScoringEngineTests
             Assert.That(result.Score, Is.EqualTo(0.0m));
             Assert.That(result.RuleScore, Is.EqualTo(0.0m));
             Assert.That(result.AiScore, Is.EqualTo(0.0m));
-            Assert.That(result.AiConfidence, Is.Null);
+
             Assert.That(result.AiReason, Is.Null);
             Assert.That(result.AiSignals, Is.Null);
             Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Clean));
@@ -977,14 +910,7 @@ public class ProfileScoringEngineTests
     {
         // Arrange
         var profile = BuildProfile(bio: "Some bio text");
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 85, "reason": "crypto scam", "signals_detected": ["promo_link", "explicit_content"]}"""));
+        EnableAiWithResponse("""{"score": 4.5, "reason": "crypto scam", "signals_detected": ["promo_link", "explicit_content"], "contains_nudity": false}""");
 
         // Act
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
@@ -1019,7 +945,7 @@ public class ProfileScoringEngineTests
                 Arg.Any<AIFeatureType>(), Arg.Any<string>(),
                 Arg.Is<string>(prompt => prompt.Contains("url_metadata")),
                 Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": true, "confidence": 90, "reason": "adult site URL", "signals_detected": ["adult_url_metadata"]}"""));
+            .Returns(AiResponse("""{"score": 4.5, "reason": "adult site URL", "signals_detected": ["adult_url_metadata"], "contains_nudity": false}"""));
 
         // Act
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
@@ -1041,14 +967,7 @@ public class ProfileScoringEngineTests
             .ScrapeUrlMetadataAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns<string?>(_ => throw new HttpRequestException("Connection refused"));
 
-        _chatService
-            .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
-            .Returns(true);
-        _chatService
-            .GetCompletionAsync(
-                Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": false, "confidence": 10, "reason": "clean"}"""));
+        EnableAiWithResponse("""{"score": 0.0, "reason": "clean", "signals_detected": [], "contains_nudity": false}""");
 
         // Act — must not throw
         var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
@@ -1100,7 +1019,7 @@ public class ProfileScoringEngineTests
                 Arg.Any<AIFeatureType>(), Arg.Any<string>(),
                 Arg.Is<string>(prompt => !prompt.Contains("url_metadata")),
                 Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
-            .Returns(AiResponse("""{"spam": false, "confidence": 5, "reason": "clean"}"""));
+            .Returns(AiResponse("""{"score": 0.0, "reason": "clean", "signals_detected": [], "contains_nudity": false}"""));
 
         // Act
         await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);

--- a/TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor
@@ -47,10 +47,6 @@
                                     <MudText Typo="Typo.body2">
                                         <strong>Rule:</strong> @result.RuleScore.ToString("F1")
                                         | <strong>AI:</strong> @result.AiScore.ToString("F1")
-                                        @if (result.AiConfidence.HasValue)
-                                        {
-                                            <text> (confidence: @result.AiConfidence%)</text>
-                                        }
                                     </MudText>
 
                                     @* AI Reason *@

--- a/TelegramGroupsAdmin/Docs/features/08-profile-scanning.md
+++ b/TelegramGroupsAdmin/Docs/features/08-profile-scanning.md
@@ -101,7 +101,7 @@ The scoring engine runs two layers. See [Scoring Engine](#scoring-engine) for th
 Two writes happen:
 
 1. **User record update** -- profile metadata, score, and Telegram IDs (photo ID, channel photo ID, pinned story IDs) are saved for future change detection
-2. **Scan history record** -- a `ProfileScanResultRecord` is inserted with the full scoring breakdown (rule score, AI score, confidence, reason, signals)
+2. **Scan history record** -- a `ProfileScanResultRecord` is inserted with the full scoring breakdown (rule score, AI score, reason, signals)
 
 If the user was previously excluded from scanning (Step 1 failure), the exclusion flag is cleared on a successful scan.
 
@@ -165,21 +165,22 @@ When Layer 1 does not trigger a ban, the AI layer runs OpenAI vision analysis on
 
 The AI returns a structured JSON response with:
 
-- **spam** (boolean) -- whether any concern exists
-- **confidence** (0-100) -- severity level
+- **score** (0.0-5.0) -- continuous risk assessment on the application's scoring scale
 - **reason** -- human-readable explanation
 - **signals_detected** -- array of identified risk signals
-- **contains_nudity** -- whether any image contains explicit content
+- **contains_nudity** -- whether any image contains visible nudity (triggers blur censoring)
 
-**Confidence-to-score mapping** (when `spam` is true):
+The AI returns the score directly on the 0.0-5.0 scale — no mapping needed. The score is clamped to the valid range via `Math.Clamp`.
 
-| Confidence | Score Added | Meaning |
-|---|---|---|
-| 80-100 | +4.5 | Definitive spam/explicit content -- auto-ban |
-| 40-79 | +2.5 | Suspicious/suggestive -- admin review |
-| 1-39 | +0.0 | Minor signals, treated as clean |
+**Detection categories** assessed by the AI:
+1. Adult / Explicit
+2. Commercial / Service Account
+3. Incoherent / Manufactured
+4. Bot / Mass-Created
+5. Scam / Scheme Promotion
+6. Impersonation
 
-When `spam` is false, the AI score is 0.0 regardless of confidence.
+Multiple aligned signals compound (not average). The AI evaluates whether the profile belongs to a genuine community member.
 
 ### Score Scale
 

--- a/docs/superpowers/plans/2026-03-23-profile-scanner-redesign.md
+++ b/docs/superpowers/plans/2026-03-23-profile-scanner-redesign.md
@@ -1,0 +1,761 @@
+# Profile Scanner Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the profile scanner from "flag known-bad" to "flag deviation from genuine community member" with a new AI prompt, simplified scoring, and 6 detection categories.
+
+**Architecture:** Three-part prompt sandwich (technical contract / detection criteria / guardrails) replaces the monolithic system prompt. AI returns a 0.0–5.0 score directly, eliminating the 3-bucket confidence mapping. `AiConfidence` removed from the entire stack.
+
+**Tech Stack:** .NET 10, EF Core 10, PostgreSQL 18, OpenAI API, NUnit + NSubstitute
+
+**Spec:** `docs/superpowers/specs/2026-03-23-profile-scanner-redesign-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs` | Modify | Three-part system prompt, updated user prompt, new `ProfileScanAIResponse` record |
+| `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs` | Modify | Score passthrough with clamp, drop `Confidence` from `AiScoringResult`, remove `Spam` gate |
+| `TelegramGroupsAdmin.Telegram/Services/UserApi/ScoringResult.cs` | Modify | Drop `AiConfidence` parameter |
+| `TelegramGroupsAdmin.Telegram/Models/ProfileScanResultRecord.cs` | Modify | Drop `AiConfidence` parameter |
+| `TelegramGroupsAdmin.Telegram/Repositories/Mappings/ProfileScanResultMappings.cs` | Modify | Remove `AiConfidence` from both mapping directions |
+| `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs` | Modify | Remove `AiConfidence` from `ScoringResult` construction and history insert |
+| `TelegramGroupsAdmin.Data/Models/ProfileScanResultDto.cs` | Modify | Drop `AiConfidence` property |
+| `TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor` | Modify | Remove confidence display |
+| `TelegramGroupsAdmin/Docs/features/08-profile-scanning.md` | Modify | Update AI response docs, remove confidence references, document new categories |
+| `TelegramGroupsAdmin.UnitTests/Telegram/Services/UserApi/ProfileScoringEngineTests.cs` | Modify | Replace AI-layer tests, update Layer 1 tests for record shape |
+| New EF Core migration | Create | Drop `ai_confidence` column from `profile_scan_results` |
+
+---
+
+### Task 1: Update AI Response Record and Scoring Engine Core
+
+This task changes the data contracts and scoring logic. Everything downstream breaks until the ripple is completed in Task 2.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs:141-149` (ProfileScanAIResponse record)
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs:26-34` (AiScoringResult record)
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs:234-264` (ParseAiResponse method)
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs:64-101` (ScoreAsync — ScoringResult construction)
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UserApi/ScoringResult.cs:6-14`
+
+- [ ] **Step 1: Update `ProfileScanAIResponse` record**
+
+In `ProfileScanPrompts.cs`, replace the record at lines 144-149:
+
+```csharp
+internal record ProfileScanAIResponse(
+    [property: JsonPropertyName("score")] decimal Score,
+    [property: JsonPropertyName("reason")] string? Reason,
+    [property: JsonPropertyName("signals_detected")] string[]? SignalsDetected,
+    [property: JsonPropertyName("contains_nudity")] bool ContainsNudity);
+```
+
+Remove the `using System.Security;` import only if `SanitizeForPrompt` no longer needs it — it still does, so keep it.
+
+- [ ] **Step 2: Update `AiScoringResult` internal record**
+
+In `ProfileScoringEngine.cs`, replace lines 26-34:
+
+```csharp
+private record AiScoringResult(
+    decimal Score,
+    string? Reason,
+    string[]? Signals,
+    bool ContainsNudity = false)
+{
+    public static readonly AiScoringResult Empty = new(0.0m, null, null, false);
+}
+```
+
+Note: `Confidence` parameter removed entirely.
+
+- [ ] **Step 3: Update `ScoringResult` record**
+
+In `ScoringResult.cs`, remove the `AiConfidence` parameter:
+
+```csharp
+public record ScoringResult(
+    decimal Score,
+    ProfileScanOutcome Outcome,
+    decimal RuleScore,
+    decimal AiScore,
+    string? AiReason,
+    string[]? AiSignals,
+    bool ContainsNudity = false);
+```
+
+- [ ] **Step 4: Rewrite `ParseAiResponse` method**
+
+In `ProfileScoringEngine.cs`, replace lines 234-264. The entire 3-bucket mapping and `Spam` gate logic is replaced with a score passthrough:
+
+```csharp
+private AiScoringResult ParseAiResponse(string content, UserIdentity user)
+{
+    try
+    {
+        var response = JsonSerializer.Deserialize<ProfileScanAIResponse>(content, JsonOptions);
+        if (response == null)
+        {
+            logger.LogWarning("Profile scan AI response deserialized to null for {User}", user.ToLogDebug());
+            return AiScoringResult.Empty;
+        }
+
+        var score = Math.Clamp(response.Score, 0.0m, MaxScore);
+        return new AiScoringResult(score, response.Reason, response.SignalsDetected, response.ContainsNudity);
+    }
+    catch (JsonException ex)
+    {
+        logger.LogWarning(ex, "Failed to parse profile scan AI response for {User}: {Content}",
+            user.ToLogDebug(), content[..Math.Min(content.Length, 200)]);
+        return AiScoringResult.Empty;
+    }
+}
+```
+
+- [ ] **Step 5: Update `ScoringResult` construction in `ScoreAsync`**
+
+In `ProfileScoringEngine.cs`, update the two places where `ScoringResult` is constructed to remove `AiConfidence`:
+
+Line ~67 (rule-based ban path):
+```csharp
+return new ScoringResult(
+    Score: Cap(ruleScore),
+    Outcome: ProfileScanOutcome.Banned,
+    RuleScore: ruleScore,
+    AiScore: 0.0m,
+    AiReason: "Rule-based detection triggered ban threshold",
+    AiSignals: null,
+    ContainsNudity: false);
+```
+
+Line ~88 (combined score path):
+```csharp
+return new ScoringResult(
+    Score: totalScore,
+    Outcome: outcome,
+    RuleScore: ruleScore,
+    AiScore: aiResult.Score,
+    AiReason: aiResult.Reason,
+    AiSignals: aiResult.Signals,
+    ContainsNudity: aiResult.ContainsNudity);
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs \
+       TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScoringEngine.cs \
+       TelegramGroupsAdmin.Telegram/Services/UserApi/ScoringResult.cs
+git commit -m "refactor: replace AI confidence mapping with direct 0-5 score passthrough"
+```
+
+---
+
+### Task 2: Ripple AiConfidence Removal Through Data Layer and UI
+
+This task propagates the `AiConfidence` removal to the data models, mappings, orchestrator, and UI.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Models/ProfileScanResultRecord.cs:17`
+- Modify: `TelegramGroupsAdmin.Telegram/Repositories/Mappings/ProfileScanResultMappings.cs:22,38`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs:358`
+- Modify: `TelegramGroupsAdmin.Data/Models/ProfileScanResultDto.cs:41`
+- Modify: `TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor:50-53`
+
+- [ ] **Step 1: Update `ProfileScanResultRecord`**
+
+In `ProfileScanResultRecord.cs`, remove the `AiConfidence` parameter. Read the file first to confirm exact current shape, then remove the `int? AiConfidence` line from the record.
+
+- [ ] **Step 2: Update `ProfileScanResultDto`**
+
+In `ProfileScanResultDto.cs`, remove the `AiConfidence` property:
+```csharp
+// Remove this line:
+public int? AiConfidence { get; set; }
+```
+
+- [ ] **Step 3: Update `ProfileScanResultMappings`**
+
+In `ProfileScanResultMappings.cs`, remove `AiConfidence` from both `ToModel()` (line ~22) and `ToDto()` (line ~38) extension methods. Read the file first to see exact mapping structure.
+
+- [ ] **Step 4: Update `ProfileScanService`**
+
+In `ProfileScanService.cs`, update the `ProfileScanResultRecord` construction at line ~358 to remove `AiConfidence: scoreResult.AiConfidence`.
+
+- [ ] **Step 5: Update `ProfileScanHistoryDialog.razor`**
+
+In the Razor file, remove lines 50-53 (the confidence display block):
+```razor
+@* Remove this block: *@
+@if (result.AiConfidence.HasValue)
+{
+    <text> (confidence: @result.AiConfidence%)</text>
+}
+```
+
+- [ ] **Step 6: Verify build compiles**
+
+Run: `dotnet build --no-restore`
+Expected: Build succeeds with no errors related to `AiConfidence`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Models/ProfileScanResultRecord.cs \
+       TelegramGroupsAdmin.Data/Models/ProfileScanResultDto.cs \
+       TelegramGroupsAdmin.Telegram/Repositories/Mappings/ProfileScanResultMappings.cs \
+       TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs \
+       TelegramGroupsAdmin/Components/Shared/ProfileScanHistoryDialog.razor
+git commit -m "refactor: remove AiConfidence from data layer, mappings, and UI"
+```
+
+---
+
+### Task 3: EF Core Migration — Drop ai_confidence Column
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Data/AppDbContext.cs` (only if `AiConfidence` has Fluent API config)
+- Create: New migration file
+
+- [ ] **Step 1: Check if AppDbContext has Fluent API config for AiConfidence**
+
+Search `AppDbContext.cs` for any `AiConfidence` or `ai_confidence` configuration in `OnModelCreating`. If found, remove it.
+
+- [ ] **Step 2: Generate migration**
+
+Run from repo root:
+```bash
+dotnet ef migrations add DropProfileScanResultsAiConfidence -p TelegramGroupsAdmin.Data -s TelegramGroupsAdmin
+```
+
+- [ ] **Step 3: Review generated migration**
+
+Read the generated migration file. It should contain only:
+```csharp
+migrationBuilder.DropColumn(
+    name: "ai_confidence",
+    table: "profile_scan_results");
+```
+
+If EF Core generates anything beyond dropping the column (e.g., table recreation), manually fix the migration.
+
+- [ ] **Step 4: Validate migration runs**
+
+Run: `dotnet run --project TelegramGroupsAdmin -- --migrate-only`
+Expected: Migration applies successfully, app exits cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Data/Migrations/
+git commit -m "migration: drop ai_confidence column from profile_scan_results"
+```
+
+---
+
+### Task 4: New Three-Part System Prompt
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs:10-75` (replace BuildSystemPrompt and add new methods)
+
+- [ ] **Step 1: Replace `BuildSystemPrompt` with three-part architecture**
+
+Replace the entire `BuildSystemPrompt()` method (lines 19-75) with:
+
+```csharp
+internal static string BuildSystemPrompt(string? customDetectionCriteria = null)
+{
+    var technical = GetTechnicalContract();
+    var criteria = customDetectionCriteria ?? GetDefaultDetectionCriteria();
+    var guardrails = GetBehavioralGuardrails();
+    return $"{technical}\n\n{criteria}\n\n{guardrails}";
+}
+```
+
+Note: The caller at `ProfileScoringEngine.cs:197` calls `ProfileScanPrompts.BuildSystemPrompt()` with no arguments. This still compiles because the new parameter has a default value of `null`. **Do not modify the call site.**
+
+- [ ] **Step 2: Add `GetTechnicalContract` method**
+
+```csharp
+private static string GetTechnicalContract() =>
+    """
+    You are a profile risk analyzer for Telegram group administration.
+    Your job is to determine whether a user's profile belongs to a genuine
+    community member. Most real people in community groups have profiles that
+    look like a real person — their name, photo, bio, and username form a
+    coherent personal identity.
+
+    You will receive a user's complete profile including text fields and images.
+    Evaluate the COMPLETE picture — every field and image, and how they relate
+    to each other.
+
+    Respond with valid JSON in this exact format:
+    {"score": 0.0-5.0, "reason": "clear explanation", "signals_detected": ["signal1", "signal2"], "contains_nudity": true/false}
+
+    The score is a continuous risk assessment on a 0.0 to 5.0 scale:
+      4.0-5.0: Clearly not a genuine community member — obvious on inspection
+      2.0-3.9: Questionable — real signals present but could go either way
+      0.1-1.9: Minor oddities, likely a real person with an unusual profile
+      0.0:     Clean profile consistent with a genuine community member
+    """;
+```
+
+- [ ] **Step 3: Add `GetDefaultDetectionCriteria` method**
+
+```csharp
+internal static string GetDefaultDetectionCriteria() =>
+    """
+    ══════════════════════════════════════
+     DETECTION CATEGORIES
+    ══════════════════════════════════════
+
+    ADULT / EXPLICIT (score 4.0-5.0):
+    - Visible nudity in ANY image — bare breasts, genitalia, buttocks.
+      If you can see it, flag it. Do not rationalize away visible nudity
+      because the photo is cropped, the face is the focal point, or the
+      pose is "artistic." Nudity is nudity.
+    - Implied nudity — bare shoulders on a bed, sexual pose where the
+      person is obviously unclothed but the frame crops below the neck.
+      Strategic cropping does not make nudity disappear.
+    - Bio promoting adult services, escort services, sexual solicitation
+    - Personal channel with adult branding (18+, NSFW, xxx, porn, escort,
+      suggestive emojis, sexualized imagery)
+    - Story content with explicit imagery or adult solicitation
+    - Bio or channel linking to adult/pornographic content
+
+    COMMERCIAL / SERVICE ACCOUNT (score 4.0-5.0):
+    - Display name is a business, brand, product, or service — not a
+      person's name (e.g., "VOIP DEVELOPMENT", "CRYPTO SIGNALS", "FOREX VIP")
+    - Profile photo shows products, inventory, storefronts, logos, QR codes,
+      or marketing material instead of a personal photo
+    - Bio reads like an advertisement: pricing, "DM for orders", "wholesale",
+      service descriptions, contact info for business inquiries
+    - Username is the business name compressed or abbreviated
+    - The profile exists to promote a commercial activity, not to
+      participate in community conversation
+
+    INCOHERENT / MANUFACTURED PROFILE (score 3.0-4.5):
+    - Name, bio, and photo tell completely unrelated stories
+      (e.g., tech company name + random personal name in bio + product photo)
+    - Bio is gibberish, random characters, or has no logical connection to
+      the name or photo
+    - Profile elements appear assembled from different identities
+    - The combination doesn't make sense for any real person
+
+    BOT / MASS-CREATED PATTERNS (score 3.0-4.5):
+    - Name follows a template: CATEGORY + KEYWORD format
+      (e.g., "CRYPTO TRADING", "FOREX SIGNALS", "SEO EXPERT")
+    - All-caps display name styled as a brand or service header
+    - Empty profile with only a commercial or promotional name
+    - Sequential or generated-looking username (dev1234, user_8837)
+
+    SCAM / SCHEME PROMOTION (score 4.0-5.0):
+    - Bio or channel containing known spam domains or URL shorteners
+    - Cryptocurrency/investment scheme promotion with guaranteed returns
+    - Phishing or impersonation indicators
+    - Gambling or casino promotion
+    - Get-rich-quick schemes or unrealistic profit promises
+    NOTE: Decentralized identity strings (Nostr npub keys, Lightning
+    addresses, ENS .eth names) are legitimate social identifiers, not
+    scam signals. Only flag cryptocurrency content when it promotes
+    schemes, guaranteed returns, or investment solicitation.
+
+    IMPERSONATION (score 3.5-5.0):
+    - Profile mimics a public figure, celebrity, or well-known person
+    - Name and photo combination designed to appear as someone famous
+    - Bio claims to be a notable individual
+    NOTE: Group admin impersonation is handled by a separate system.
+    This category covers public figure impersonation only.
+
+    ══════════════════════════════════════
+     WHAT A CLEAN PROFILE LOOKS LIKE
+    ══════════════════════════════════════
+
+    A clean profile (score near 0.0) has:
+    - A name that sounds like a real person's name, in any language or culture
+    - A photo that is personal: selfie, pet, landscape, avatar, anime,
+      artwork, group photo, or no photo at all
+    - A bio (if present) about personal interests, hobbies, work, education,
+      a quote, or simply empty
+    - Profile elements that don't contradict each other
+
+    An EMPTY profile (no bio, no photo, basic human name) is CLEAN.
+    Most real users have minimal profiles. Do not penalize absence of
+    information — penalize presence of wrong information.
+
+    ══════════════════════════════════════
+     SIGNAL CONVERGENCE
+    ══════════════════════════════════════
+
+    Multiple signals pointing in the same direction COMPOUND — do not
+    average them. Each additional aligned signal makes the case stronger.
+
+    Examples:
+    - Suggestive photo alone → 2.0-2.5
+    - Suggestive photo + suggestive name → 3.0-3.5
+    - Suggestive photo + suggestive name + suggestive username + empty
+      profile → 4.0-4.5 (four aligned signals = clearly not normal)
+
+    - Business name alone → 2.0-2.5 (some people use business names casually)
+    - Business name + product photo → 3.5-4.0
+    - Business name + product photo + incoherent bio → 4.0-4.5
+
+    The guiding question: "Could a reasonable person look at this entire
+    profile and believe it belongs to a genuine community member?"
+    If the answer is clearly no, score should be 4.0+.
+    """;
+```
+
+- [ ] **Step 4: Add `GetBehavioralGuardrails` method**
+
+```csharp
+private static string GetBehavioralGuardrails() =>
+    """
+    ══════════════════════════════════════
+     URL METADATA ANALYSIS
+    ══════════════════════════════════════
+
+    When <url_metadata> is provided, it contains scraped page titles and
+    descriptions from URLs in the bio, channel, or stories. Use to identify:
+    - Adult/pornographic sites (score 4.0+)
+    - Cryptocurrency/investment scam landing pages
+    - Phishing or impersonation pages
+    - Gambling or casino promotion
+    - URL shortener redirects to suspicious content
+    Legitimate URLs (social media, GitHub, personal blogs) are neutral.
+
+    ══════════════════════════════════════
+     NUDITY FLAG
+    ══════════════════════════════════════
+
+    Set "contains_nudity" to true ONLY for visible nudity that would
+    violate public indecency laws:
+    - Bare breasts (not cleavage in clothing/lingerie)
+    - Exposed genitalia
+    - Exposed buttocks
+
+    Lingerie, swimwear, revealing clothing, suggestive poses, and
+    cleavage do NOT set this flag. Those are handled by the score,
+    not the nudity flag.
+
+    This flag triggers image censoring in admin review.
+    """;
+```
+
+- [ ] **Step 5: Update `BuildUserPrompt` opening line**
+
+In `BuildUserPrompt` method, change the first line of the return string (line ~113) from:
+```
+Analyze this Telegram user profile for spam/adult content indicators.
+```
+To:
+```
+Assess whether this Telegram user profile belongs to a genuine community member.
+```
+
+Also update the JSON instruction at the end of the user prompt (line ~136) from:
+```
+Respond with JSON: {"spam": true/false, "confidence": 0-100, "reason": "...", "signals_detected": [...], "contains_nudity": true/false}
+```
+To:
+```
+Respond with JSON: {"score": 0.0-5.0, "reason": "...", "signals_detected": [...], "contains_nudity": true/false}
+```
+
+- [ ] **Step 6: Verify build compiles**
+
+Run: `dotnet build --no-restore`
+Expected: Build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanPrompts.cs
+git commit -m "feat: new three-part profile scan prompt with 6 detection categories"
+```
+
+---
+
+### Task 5: Replace AI-Layer Tests
+
+This task replaces the old confidence-tier tests with new score-passthrough tests and adds nudity flag tests.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.UnitTests/Telegram/Services/UserApi/ProfileScoringEngineTests.cs`
+
+- [ ] **Step 1: Update the test class docstring**
+
+Update the summary comment at the top of the test class (lines 13-24) to reflect the new scoring model. Change the Layer 2 description from "confidence tiers (>=80 → 4.5, >=40 → 2.5, <40 → 0.0)" to "direct 0.0-5.0 score passthrough with clamp".
+
+- [ ] **Step 2: Delete old AI-layer tests that test the 3-bucket mapping**
+
+Remove these test methods entirely (they test behavior that no longer exists):
+- `ScoreAsync_AiReturnsSpamFalse_AiScoreIsZeroAndClean` (the `Spam=false` gate is gone)
+- `ScoreAsync_AiSpamTrueConfidence80_AiScoreIsFourPointFive`
+- `ScoreAsync_AiSpamTrueConfidenceExactly80_AiScoreIsFourPointFive`
+- `ScoreAsync_AiSpamTrueConfidence50_AiScoreIsTwoPointFive`
+- `ScoreAsync_AiSpamTrueConfidenceExactly40_AiScoreIsTwoPointFive`
+- `ScoreAsync_AiSpamTrueConfidence20_AiScoreIsZero`
+- `ScoreAsync_AiSpamTrueConfidenceExactly39_AiScoreIsZero`
+
+- [ ] **Step 3: Add new score passthrough tests**
+
+Add a helper method for enabling AI and setting up text completion mocks:
+
+```csharp
+private void EnableAiWithResponse(string json)
+{
+    _chatService
+        .IsFeatureAvailableAsync(AIFeatureType.ProfileScan, Arg.Any<CancellationToken>())
+        .Returns(true);
+    _chatService
+        .GetCompletionAsync(
+            Arg.Any<AIFeatureType>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<ChatCompletionOptions?>(), Arg.Any<CancellationToken>())
+        .Returns(AiResponse(json));
+}
+```
+
+Then add the new tests:
+
+```csharp
+// ═══════════════════════════════════════════════════════════════════════════
+// Layer 2: AI score passthrough (new 0-5 direct scoring)
+// ═══════════════════════════════════════════════════════════════════════════
+
+[Test]
+public async Task ScoreAsync_AiReturnsCleanScore_AiScoreIsZero()
+{
+    var profile = BuildProfile(bio: "Some bio text");
+    EnableAiWithResponse("""{"score": 0.0, "reason": "genuine community member", "signals_detected": [], "contains_nudity": false}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    using (Assert.EnterMultipleScope())
+    {
+        Assert.That(result.AiScore, Is.EqualTo(0.0m));
+        Assert.That(result.AiReason, Is.EqualTo("genuine community member"));
+        Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Clean));
+    }
+}
+
+[Test]
+public async Task ScoreAsync_AiReturnsSuspiciousScore_OutcomeIsHeldForReview()
+{
+    var profile = BuildProfile(bio: "Some bio text");
+    EnableAiWithResponse("""{"score": 2.8, "reason": "suggestive photo + name", "signals_detected": ["suggestive_photo", "suggestive_name"], "contains_nudity": false}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    using (Assert.EnterMultipleScope())
+    {
+        Assert.That(result.AiScore, Is.EqualTo(2.8m));
+        Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.HeldForReview));
+    }
+}
+
+[Test]
+public async Task ScoreAsync_AiReturnsBanScore_OutcomeIsBanned()
+{
+    var profile = BuildProfile(bio: "Some bio text");
+    EnableAiWithResponse("""{"score": 4.5, "reason": "commercial account with product photos", "signals_detected": ["commercial_name", "product_photo"], "contains_nudity": false}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    using (Assert.EnterMultipleScope())
+    {
+        Assert.That(result.AiScore, Is.EqualTo(4.5m));
+        Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Banned));
+    }
+}
+
+[Test]
+public async Task ScoreAsync_AiScoreExceedsFive_ClampedToMaxScore()
+{
+    var profile = BuildProfile(bio: "Some bio text");
+    EnableAiWithResponse("""{"score": 7.5, "reason": "extreme risk", "signals_detected": [], "contains_nudity": false}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    Assert.That(result.AiScore, Is.EqualTo(5.0m));
+}
+
+[Test]
+public async Task ScoreAsync_AiScoreNegative_ClampedToZero()
+{
+    var profile = BuildProfile(bio: "Some bio text");
+    EnableAiWithResponse("""{"score": -1.0, "reason": "invalid", "signals_detected": [], "contains_nudity": false}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    Assert.That(result.AiScore, Is.EqualTo(0.0m));
+}
+
+[Test]
+public async Task ScoreAsync_RuleScorePlusAiScore_Additive()
+{
+    // Rule: stop word (+1.5) + AI score 3.0 = 4.5 → ban
+    var profile = BuildProfile(bio: "guaranteed profits from my service");
+    _stopWordsRepository
+        .GetEnabledStopWordsAsync(Arg.Any<CancellationToken>())
+        .Returns(["guaranteed profits"]);
+    EnableAiWithResponse("""{"score": 3.0, "reason": "scam promotion", "signals_detected": ["scam_language"], "contains_nudity": false}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    using (Assert.EnterMultipleScope())
+    {
+        Assert.That(result.RuleScore, Is.EqualTo(1.5m));
+        Assert.That(result.AiScore, Is.EqualTo(3.0m));
+        Assert.That(result.Score, Is.EqualTo(4.5m));
+        Assert.That(result.Outcome, Is.EqualTo(ProfileScanOutcome.Banned));
+    }
+}
+```
+
+- [ ] **Step 4: Add nudity flag passthrough tests**
+
+```csharp
+// ═══════════════════════════════════════════════════════════════════════════
+// Layer 2: Nudity flag passthrough
+// ═══════════════════════════════════════════════════════════════════════════
+
+[Test]
+public async Task ScoreAsync_AiReturnsNudityTrue_ContainsNudityIsTrue()
+{
+    var profile = BuildProfile(bio: "Some bio text");
+    EnableAiWithResponse("""{"score": 4.8, "reason": "visible nudity in profile photo", "signals_detected": ["nudity"], "contains_nudity": true}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    Assert.That(result.ContainsNudity, Is.True);
+}
+
+[Test]
+public async Task ScoreAsync_AiReturnsNudityFalse_ContainsNudityIsFalse()
+{
+    var profile = BuildProfile(bio: "Some bio text");
+    EnableAiWithResponse("""{"score": 3.5, "reason": "suggestive but not nude", "signals_detected": ["suggestive_photo"], "contains_nudity": false}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    Assert.That(result.ContainsNudity, Is.False);
+}
+
+[Test]
+public async Task ScoreAsync_NudityFlagIndependentOfScore_LowScoreCanHaveNudity()
+{
+    // Edge case: nudity detected but AI gave low overall score (shouldn't happen in practice, but tests independence)
+    var profile = BuildProfile(bio: "Some bio text");
+    EnableAiWithResponse("""{"score": 1.5, "reason": "minimal risk but nudity present", "signals_detected": ["nudity"], "contains_nudity": true}""");
+
+    var result = await _sut.ScoreAsync(profile, [], null, BanThreshold, NotifyThreshold, CancellationToken.None);
+
+    using (Assert.EnterMultipleScope())
+    {
+        Assert.That(result.ContainsNudity, Is.True);
+        Assert.That(result.AiScore, Is.EqualTo(1.5m));
+    }
+}
+```
+
+- [ ] **Step 5: Update existing tests that reference old JSON format or AiConfidence**
+
+Update these tests to use the new JSON format (`score` instead of `spam`/`confidence`) and remove `AiConfidence` assertions:
+
+- `ScoreAsync_AiFeatureUnavailable_ReturnsRuleScoreOnly` — remove `Assert.That(result.AiConfidence, Is.Null)`
+- `ScoreAsync_AiReturnsNull_AiScoreIsZero` — remove `Assert.That(result.AiConfidence, Is.Null)`
+- `ScoreAsync_AiReturnsMalformedJson_AiScoreIsZeroGracefully` — remove `Assert.That(result.AiConfidence, Is.Null)`
+- `ScoreAsync_CleanProfile_ReturnsExpectedScoringResultFields` — remove `Assert.That(result.AiConfidence, Is.Null)`
+- `ScoreAsync_NoImages_UsesTextCompletionNotVision` — update JSON from `{"spam": false, "confidence": 10, ...}` to `{"score": 0.0, ...}`
+- `ScoreAsync_SingleImage_UsesSingleVisionCompletion` — update JSON
+- `ScoreAsync_MultipleImages_UsesMultiImageVisionCompletion` — update JSON
+- `ScoreAsync_TotalScoreAtNotifyThreshold_OutcomeIsHeldForReview` — update JSON from `{"spam": true, "confidence": 50, ...}` to `{"score": 2.5, ...}` and update score assertion
+- `ScoreAsync_TotalScoreAtBanThreshold_OutcomeIsBanned` — update JSON from `{"spam": true, "confidence": 95, ...}` to `{"score": 4.5, ...}` and update score assertion
+- `ScoreAsync_CombinedRuleAndAiScoreExceedsFive_CappedAtFive` — update JSON from `{"spam": true, "confidence": 95, ...}` to `{"score": 4.5, ...}`
+- `ScoreAsync_CustomHighBanThreshold_ScoreBelowThresholdIsHeldForReview` — update JSON to `{"score": 4.5, ...}`
+- `ScoreAsync_CustomLowNotifyThreshold_LowScoreTriggersHeldForReview` — update JSON from `{"spam": false, "confidence": 30, ...}` to `{"score": 0.0, ...}` (this test triggers via rule score only)
+- `ScoreAsync_AiSpamWithSignals_SignalsPopulatedOnResult` — update JSON mock from `{"spam": true, "confidence": 85, ...}` to `{"score": 4.5, ...}` (signal assertions are unchanged, no score assertion exists in this test)
+- `ScoreAsync_UrlMetadataPassedToAiPrompt_WhenScrapingReturnsData` — update JSON and score assertion
+- `ScoreAsync_UrlScrapingFailure_ContinuesWithoutMetadata` — update JSON
+- `ScoreAsync_NoUrlMetadata_PromptDoesNotContainUrlMetadataSection` — update JSON
+- `ScoreAsync_AiReturnsEmptyJsonObject_AiScoreIsZero` — this one still works since `Score` defaults to `0` for `decimal`
+
+- [ ] **Step 6: Run all tests**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --no-restore --verbosity normal`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin.UnitTests/Telegram/Services/UserApi/ProfileScoringEngineTests.cs
+git commit -m "test: replace confidence-tier tests with score passthrough and nudity flag tests"
+```
+
+---
+
+### Task 6: Update Feature Documentation
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Docs/features/08-profile-scanning.md`
+
+- [ ] **Step 1: Read the full documentation file**
+
+Read the entire file to understand structure and find all references to the old model.
+
+- [ ] **Step 2: Update Layer 2 AI response documentation**
+
+Replace the section describing the AI response (around lines 166-182) with the new format:
+
+- Change bullet list from `spam`, `confidence`, `reason`, `signals_detected`, `contains_nudity` to `score` (0.0-5.0), `reason`, `signals_detected`, `contains_nudity`
+- Replace the confidence-to-score mapping table with a note that the AI returns the score directly on the 0.0-5.0 scale
+- Remove the "When `spam` is false, the AI score is 0.0 regardless of confidence" paragraph
+- Add brief mention of the 6 detection categories
+
+- [ ] **Step 3: Update scan history description**
+
+In Step 7 (line ~104), update "confidence" reference to reflect the new data model.
+
+- [ ] **Step 4: Verify build compiles** (documentation doesn't affect build, but verify content)
+
+Read the file again to confirm all changes are consistent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Docs/features/08-profile-scanning.md
+git commit -m "docs: update profile scanning docs for new scoring model"
+```
+
+---
+
+### Task 7: Final Verification
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build --no-restore`
+Expected: Clean build, zero errors, zero warnings related to changed code.
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --no-restore --verbosity normal`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run migrate-only to validate migration**
+
+Run: `dotnet run --project TelegramGroupsAdmin -- --migrate-only`
+Expected: Migration applies successfully.
+
+- [ ] **Step 4: Verify no stale references**
+
+Search for any remaining references to old field names:
+```bash
+grep -r "AiConfidence" --include="*.cs" --include="*.razor" | grep -v "/Migrations/" | grep -v "Designer.cs"
+grep -r '"spam"' --include="*.cs" TelegramGroupsAdmin.Telegram/ TelegramGroupsAdmin.UnitTests/
+grep -r '"confidence"' --include="*.cs" TelegramGroupsAdmin.Telegram/ TelegramGroupsAdmin.UnitTests/
+```
+Expected: No matches outside of migration files.

--- a/docs/superpowers/specs/2026-03-23-profile-scanner-redesign-design.md
+++ b/docs/superpowers/specs/2026-03-23-profile-scanner-redesign-design.md
@@ -1,0 +1,208 @@
+# Profile Scanner Redesign — Design Spec
+
+## Problem
+
+The current profile scanner is narrowly focused on adult/explicit content and known spam patterns. It misses entire categories of non-genuine profiles (commercial accounts, incoherent/manufactured identities, bot patterns, scam promotion, impersonation). The detection model needs to invert from "flag known-bad" to "flag anything that deviates from a genuine community member."
+
+Additional issues with the current system:
+- The nudity detection prompt language primes the AI to be conservative, causing it to rationalize away visible nudity
+- Signal convergence is artificially capped at confidence 70, preventing multi-signal profiles from reaching ban threshold
+- The 3-bucket confidence-to-score mapping (0 / 2.5 / 4.5) has no granularity — confidence 79 scores identically to 40
+
+## Design Decisions
+
+### Detection Model: Normalcy Assessment
+
+- **Old question**: "Is this spam/adult content?"
+- **New question**: "Does this profile belong to a genuine community member?"
+- Flag deviation from normalcy; the score indicates severity
+
+### AI Response Contract
+
+The AI returns an assessment, not a decision. No threshold awareness, no flagging — just a score.
+
+```json
+{
+  "score": 0.0-5.0,
+  "reason": "clear explanation",
+  "signals_detected": ["signal1", "signal2"],
+  "contains_nudity": true/false
+}
+```
+
+- **`score`**: Continuous 0.0–5.0 scale. The application decides outcomes based on configurable thresholds.
+- **`reason`**: Human-readable explanation for admin review UI.
+- **`signals_detected`**: Structured tags for logging/analytics.
+- **`contains_nudity`**: Drives Gaussian blur censoring only, not scoring. Narrow definition: bare breasts, exposed genitalia, exposed buttocks. Lingerie/swimwear/cleavage do NOT set this flag.
+- **Removed fields**: `spam`/`flagged` (score replaces the boolean gate), `confidence` (score IS the assessment on the application's scale).
+
+### Prompt Architecture: Three-Part Sandwich
+
+Code-controlled top and bottom, swappable middle section:
+
+| Section | Method | Editable? |
+|---------|--------|-----------|
+| Top | `GetTechnicalContract()` | Code-controlled, always |
+| Middle | `GetDefaultDetectionCriteria()` | Hardcoded now, wirable to config later |
+| Bottom | `GetBehavioralGuardrails()` | Code-controlled, always |
+
+```csharp
+internal static string BuildSystemPrompt(string? customDetectionCriteria = null)
+{
+    var technical = GetTechnicalContract();
+    var criteria = customDetectionCriteria ?? GetDefaultDetectionCriteria();
+    var guardrails = GetBehavioralGuardrails();
+    return $"{technical}\n\n{criteria}\n\n{guardrails}";
+}
+```
+
+The `customDetectionCriteria` parameter is plumbed but never populated — all callers pass `null` for now. When UI configurability is added later, only the middle section changes. The response contract and behavioral guardrails remain code-controlled.
+
+**Future UI configurability**: When ready, the custom detection criteria can be stored via a new `ConfigType` entry or the existing `prompt_versions` table with a feature type discriminator. The architectural seams are in place.
+
+### Detection Categories (6)
+
+1. **Adult / Explicit** (score 4.0–5.0): Visible nudity, implied nudity, adult services, adult-branded channels, explicit stories/content.
+
+2. **Commercial / Service Account** (score 4.0–5.0): Business/brand display name, product/logo photos, ad-like bios, business usernames. Profile exists to promote commercial activity.
+
+3. **Incoherent / Manufactured** (score 3.0–4.5): Name/bio/photo tell unrelated stories, gibberish bio, elements assembled from different identities.
+
+4. **Bot / Mass-Created** (score 3.0–4.5): Template names (CATEGORY + KEYWORD), all-caps brand names, sequential/generated usernames, empty profile with promotional name.
+
+5. **Scam / Scheme Promotion** (score 4.0–5.0): Crypto/investment schemes, guaranteed returns, gambling promotion, phishing, spam domains, URL shorteners to suspicious content. Note: Decentralized identity strings (Nostr npub keys, Lightning addresses, ENS .eth names) are legitimate social identifiers, not scam signals.
+
+6. **Impersonation** (score 3.5–5.0): Pretending to be a public figure, celebrity, or well-known person. Note: Group admin impersonation is handled by a separate system in the welcome flow.
+
+### Clean Profile Definition
+
+A clean profile (score near 0.0) has:
+- A name that sounds like a real person's name, in any language or culture
+- A photo that is personal: selfie, pet, landscape, avatar, anime, artwork, group photo, or no photo
+- A bio (if present) about personal interests, hobbies, work, education, a quote, or simply empty
+- Profile elements that don't contradict each other
+
+**Empty profiles are clean.** Most real users have minimal profiles. Do not penalize absence of information — penalize presence of wrong information.
+
+### Signal Convergence
+
+Multiple signals pointing in the same direction compound — do not average. Each additional aligned signal makes the case stronger.
+
+- Suggestive photo alone → 2.0–2.5
+- Suggestive photo + suggestive name → 3.0–3.5
+- Suggestive photo + suggestive name + suggestive username + empty profile → 4.0–4.5
+- Business name + product photo → 3.5–4.0
+- Business name + product photo + incoherent bio → 4.0–4.5
+
+Guiding question: "Could a reasonable person look at this entire profile and believe it belongs to a genuine community member?" If clearly no → 4.0+.
+
+### Nudity Flag (`contains_nudity`)
+
+Set to true ONLY for visible nudity that would violate public indecency laws:
+- Bare breasts (not cleavage in clothing/lingerie)
+- Exposed genitalia
+- Exposed buttocks
+
+Does NOT include: lingerie, swimwear, revealing clothing, suggestive poses, cleavage, implied nudity. Those are handled by the score. Purpose: triggers Gaussian blur censoring in admin review.
+
+### User Prompt Update
+
+Opening line changes from:
+> "Analyze this Telegram user profile for spam/adult content indicators."
+
+To:
+> "Assess whether this Telegram user profile belongs to a genuine community member."
+
+All prompt injection protections remain unchanged — `SanitizeForPrompt()` XML-escapes all user-generated content, wrapped in XML boundary tags.
+
+## Scoring Engine Changes
+
+### AI Score Passthrough
+
+The 3-bucket confidence-to-score mapping is eliminated. The AI returns a score directly on the 0–5 scale, clamped to valid range:
+
+```csharp
+var score = Math.Clamp(response.Score, 0.0m, MaxScore);
+```
+
+### Layer 1 + Layer 2: Additive (Unchanged)
+
+- Layer 1 runs first: Telegram scam/fake flags → 5.0, blocked URLs → +3.0, stop words → +1.5
+- If Layer 1 >= ban threshold → skip AI, done
+- Otherwise Layer 2 (AI) runs: `total = ruleScore + aiScore`, capped at 5.0
+
+### Thresholds (Unchanged)
+
+- Ban: score >= 4.0 (configurable per chat)
+- Review: score >= 2.0 (configurable per chat)
+- Clean: score < 2.0
+
+### Record Changes
+
+`ProfileScanAIResponse`:
+```csharp
+// Old
+record ProfileScanAIResponse(bool Spam, int Confidence, string? Reason, string[]? SignalsDetected, bool ContainsNudity);
+
+// New
+record ProfileScanAIResponse(decimal Score, string? Reason, string[]? SignalsDetected, bool ContainsNudity);
+```
+
+`ScoringResult` — drop `AiConfidence`:
+```csharp
+record ScoringResult(decimal Score, ProfileScanOutcome Outcome, decimal RuleScore,
+    decimal AiScore, string? AiReason, string[]? AiSignals, bool ContainsNudity);
+```
+
+### Database Migration
+
+Drop `ai_confidence` column from `profile_scan_results` table. No data migration — existing `score` and `ai_score` values are already on the 0–5 scale and represent accurate historical records under the old model.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `Telegram/Services/UserApi/ProfileScanPrompts.cs` | Three-part system prompt, updated user prompt opening, updated `ProfileScanAIResponse` record |
+| `Telegram/Services/UserApi/ProfileScoringEngine.cs` | Score passthrough with clamp, drop `Confidence` from `AiScoringResult` |
+| `Telegram/Services/UserApi/ScoringResult.cs` | Drop `AiConfidence` |
+| `Telegram/Models/ProfileScanResultRecord.cs` | Drop `AiConfidence` |
+| `Telegram/Repositories/Mappings/ProfileScanResultMappings.cs` | Remove `AiConfidence` from both mapping directions |
+| `Telegram/Services/UserApi/ProfileScanService.cs` | Remove `AiConfidence` from `ScoringResult` usage and history insert |
+| `Data/Models/ProfileScanResultDto.cs` | Drop `AiConfidence` property |
+| `Components/Shared/ProfileScanHistoryDialog.razor` | Remove confidence display |
+| `UnitTests/.../ProfileScoringEngineTests.cs` | Updated AI response mocks, new passthrough/clamp/nudity tests |
+| New EF Core migration | Drop `ai_confidence` column |
+
+## Test Plan
+
+Unit tests in `ProfileScoringEngineTests.cs`:
+
+- AI returns score on 0–5 scale → verify passthrough
+- AI returns score > 5.0 → verify clamped to 5.0
+- AI returns score < 0.0 → verify clamped to 0.0
+- AI returns clean profile (score 0.0) → verify 0.0 passthrough
+- Layer 1 + Layer 2 additive: rule score 1.5 + AI score 3.0 = 4.5 → ban
+- AI returns `contains_nudity: true` → verify `ScoringResult.ContainsNudity` is true
+- AI returns `contains_nudity: false` → verify `ScoringResult.ContainsNudity` is false
+- Nudity flag passes through independently of score value
+- Malformed JSON fallback → `AiScoringResult.Empty`
+- Existing Layer 1 tests updated for any record shape changes
+
+## Out of Scope
+
+- Username blocklist stays in welcome flow (may move to profile scanner Layer 1 in future)
+- "No shared groups" signal (deferred)
+- Per-chat custom detection criteria (architectural seams in place, not wired to UI)
+- UI for custom prompt editing (future work)
+
+## Test Cases (From Discussion)
+
+| Profile | Expected Score | Nudity | Reasoning |
+|---------|---------------|--------|-----------|
+| VOIP DEVELOPMENT — business name, @VOIPDEVELOP, bio "Atiku oo1", product photo | 4.0–5.0 (ban) | false | Commercial name + product photo + incoherent bio |
+| Scarlett Lux — tongue photo with visible bare breasts, suggestive name/username | 4.5+ (ban) | true | Visible nudity + suggestive identity + empty profile |
+| Scarlett Lux — lingerie on hotel bed, suggestive name/username | 4.0–4.5 (ban) | false | Lingerie photo + suggestive identity + empty profile. Lingerie != nudity |
+| PeeJay / Morkai Paraka — real name, brand logo photo | 2.0–3.0 (review) | false | Brand logo as photo + identity mismatch. Could be a real DJ |
+| Rehema Otieno — real name, photo in a shop, empty bio | 0.0–1.0 (clean) | false | Real name, personal photo, coherent |
+| I_Am_Coded — handle-style name, anime avatar, "Coffee & good vibes" | 0.0–0.5 (clean) | false | Personal handle, anime avatar, coherent identity |
+| Beatriz Figueira — real name, travel photos, polished aesthetic | 0.0–1.0 (clean) | false | Real name, personal photos, coherent. Undetectable at profile level |

--- a/docs/superpowers/specs/2026-03-23-profile-scanner-redesign-design.md
+++ b/docs/superpowers/specs/2026-03-23-profile-scanner-redesign-design.md
@@ -34,7 +34,7 @@ The AI returns an assessment, not a decision. No threshold awareness, no flaggin
 - **`reason`**: Human-readable explanation for admin review UI.
 - **`signals_detected`**: Structured tags for logging/analytics.
 - **`contains_nudity`**: Drives Gaussian blur censoring only, not scoring. Narrow definition: bare breasts, exposed genitalia, exposed buttocks. Lingerie/swimwear/cleavage do NOT set this flag.
-- **Removed fields**: `spam`/`flagged` (score replaces the boolean gate), `confidence` (score IS the assessment on the application's scale).
+- **Removed fields**: `spam` (score replaces the boolean gate), `confidence` (score IS the assessment on the application's scale).
 
 ### Prompt Architecture: Three-Part Sandwich
 
@@ -170,12 +170,15 @@ Drop `ai_confidence` column from `profile_scan_results` table. No data migration
 | `Telegram/Services/UserApi/ProfileScanService.cs` | Remove `AiConfidence` from `ScoringResult` usage and history insert |
 | `Data/Models/ProfileScanResultDto.cs` | Drop `AiConfidence` property |
 | `Components/Shared/ProfileScanHistoryDialog.razor` | Remove confidence display |
-| `UnitTests/.../ProfileScoringEngineTests.cs` | Updated AI response mocks, new passthrough/clamp/nudity tests |
+| `Docs/features/08-profile-scanning.md` | Update AI response docs, remove confidence references, document new detection categories |
+| `UnitTests/.../ProfileScoringEngineTests.cs` | Replace AI-layer tests, update Layer 1 tests for record shape |
 | New EF Core migration | Drop `ai_confidence` column |
 
 ## Test Plan
 
 Unit tests in `ProfileScoringEngineTests.cs`:
+
+**Replace existing AI-layer tests** — all tests using the old `{"spam": true/false, "confidence": N}` JSON format and 3-bucket mapping assertions are replaced with:
 
 - AI returns score on 0–5 scale → verify passthrough
 - AI returns score > 5.0 → verify clamped to 5.0
@@ -186,7 +189,8 @@ Unit tests in `ProfileScoringEngineTests.cs`:
 - AI returns `contains_nudity: false` → verify `ScoringResult.ContainsNudity` is false
 - Nudity flag passes through independently of score value
 - Malformed JSON fallback → `AiScoringResult.Empty`
-- Existing Layer 1 tests updated for any record shape changes
+
+**Update existing Layer 1 tests** — record shape changes only (remove `AiConfidence` from assertions). Test logic unchanged.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- **Inverts detection model** from "flag known-bad" to "flag deviation from genuine community member"
- **New AI response contract**: returns `score` (0.0-5.0) directly instead of `spam`/`confidence` (0-100) with 3-bucket mapping
- **Three-part prompt architecture**: technical contract (top) + detection criteria (middle, swappable) + behavioral guardrails (bottom)
- **6 detection categories**: Adult/Explicit, Commercial/Service Account, Incoherent/Manufactured, Bot/Mass-Created, Scam/Scheme Promotion, Impersonation
- **Removes `AiConfidence`** from entire stack (records, mappings, service, UI, database)
- **Signal convergence**: multiple aligned signals compound instead of averaging
- **Nostr/Lightning/ENS** identifiers explicitly excluded from scam signals
- **Nudity flag** narrowed: only bare breasts/genitalia/buttocks (lingerie/swimwear handled by score)

Related: #417 (follow-up for ai_signals column migration to text[])

## Test plan

- [x] All 1834 unit tests pass
- [x] Migration applies cleanly (`--migrate-only`)
- [x] Build succeeds with zero errors
- [x] No stale `AiConfidence`/`spam`/`confidence` references outside migrations
- [ ] Manual testing: verify profile scan works end-to-end after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)