### PR TITLE
fix: reduce noisy production logs to Debug level

### DIFF
--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/ScheduledBackupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/ScheduledBackupJob.cs
@@ -119,11 +119,6 @@ public class ScheduledBackupJob : IJob
 
                 _logger.LogInformation("Backup saved to {Filepath} ({SizeMB:F2} MB)", result.FilePath, backupSizeMb);
 
-                if (result.DeletedCount > 0)
-                {
-                    _logger.LogInformation("Deleted {Count} old backups via retention policy", result.DeletedCount);
-                }
-
                 _logger.LogInformation("Scheduled backup completed successfully");
                 success = true;
             }

--- a/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
@@ -289,7 +289,7 @@ public class TelegramUserRepository : ITelegramUserRepository
 
             _logger.LogDebug(
                 "Enabled bot DMs for {User}",
-                entity.ToLogInfo());
+                entity.ToLogDebug());
         }
     }
 

--- a/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
@@ -152,10 +152,9 @@ public class TelegramUserRepository : ITelegramUserRepository
                 updated_at = {now}
             """, cancellationToken);
 
-        _logger.LogInformation(
-            "Upserted Telegram user {TelegramUserId} (@{Username})",
-            user.TelegramUserId,
-            user.Username);
+        _logger.LogDebug(
+            "Upserted Telegram user {User}",
+            user.ToLogDebug());
     }
 
     /// <summary>
@@ -288,7 +287,7 @@ public class TelegramUserRepository : ITelegramUserRepository
 
             await context.SaveChangesAsync(cancellationToken);
 
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Enabled bot DMs for {User}",
                 entity.ToLogInfo());
         }

--- a/TelegramGroupsAdmin.Telegram/Repositories/UserActionsRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/UserActionsRepository.cs
@@ -39,7 +39,7 @@ public class UserActionsRepository : IUserActionsRepository
             .Select(u => new { u.FirstName, u.LastName, u.Username })
             .FirstOrDefaultAsync(cancellationToken);
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Inserted user action {ActionType} for {User} (expires: {ExpiresAt})",
             action.ActionType,
             LogDisplayName.UserInfo(targetUser?.FirstName, targetUser?.LastName, targetUser?.Username, action.UserId),

--- a/TelegramGroupsAdmin/Services/NotificationService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationService.cs
@@ -492,7 +492,7 @@ public sealed class NotificationService : INotificationService
 
             if (result.DmSent)
             {
-                _logger.LogInformation("Sent typed Telegram DM to {User}", user.ToLogInfo());
+                _logger.LogDebug("Sent typed Telegram DM to {User}", user.ToLogInfo());
                 return true;
             }
 


### PR DESCRIPTION
## Summary
- Downgrade high-volume per-message logs from Information to Debug (upsert user, enable DMs, insert user action, send typed DM)
- Fix `(@null)` display for users without usernames by using `ToLogDebug()` extension
- Remove duplicate "Deleted old backups via retention policy" log (was logged in both BackupService and ScheduledBackupJob)

## Test plan
- [ ] Verify build passes in CI
- [x] Deploy and confirm production logs are significantly quieter
- [x] Confirm important events (bans, joins, spam detection) still log at Information
- [x] Enable Debug level in Seq to verify downgraded logs still appear when needed