### PR TITLE
perf: reduce memory footprint with GC tuning and streaming backups

### DIFF
--- a/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
@@ -196,6 +196,8 @@ public class BackupService : IBackupService
         var tempPath = $"{filepath}.{Guid.NewGuid().ToString("N")[..8]}.tmp";
         try
         {
+            // leaveOpen: TarWriter leaves gzipStream open for the await using to flush/close;
+            // gzipStream closes fileStream when it disposes (leaveOpen defaults to false)
             await using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
             await using (var gzipStream = new GZipStream(fileStream, CompressionLevel.Optimal))
             await using (var tarWriter = new TarWriter(gzipStream, leaveOpen: true))

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
@@ -193,7 +193,7 @@ public class BackupService : IBackupService
         var metadataJson = JsonSerializer.SerializeToUtf8Bytes(backup.Metadata, jsonOptions);
 
         // Stream tar.gz directly to disk via temp file for atomic write
-        var tempPath = filepath + ".tmp";
+        var tempPath = $"{filepath}.{Guid.NewGuid().ToString("N")[..8]}.tmp";
         try
         {
             await using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
@@ -72,30 +72,33 @@ public class BackupService : IBackupService
         _mediaBasePath = appOptions.Value.DataPath;
     }
 
-    public async Task<byte[]> ExportAsync()
+    public async Task ExportToFileAsync(string filepath, CancellationToken cancellationToken = default)
     {
-        return await ExportInternalAsync();
+        await ExportToFileInternalAsync(filepath, cancellationToken: cancellationToken);
     }
 
     /// <summary>
     /// Export backup with explicit passphrase override (for CLI usage)
     /// </summary>
-    public async Task<byte[]> ExportAsync(string passphraseOverride)
+    public async Task ExportToFileAsync(string filepath, string passphraseOverride, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(passphraseOverride))
             throw new ArgumentException("Passphrase cannot be empty", nameof(passphraseOverride));
 
         _logger.LogInformation("Starting backup export with explicit passphrase");
-        return await ExportInternalAsync(passphraseOverride: passphraseOverride);
+        await ExportToFileInternalAsync(filepath, passphraseOverride: passphraseOverride, cancellationToken: cancellationToken);
     }
 
     /// <summary>
-    /// Internal export method that can skip encryption for passphrase override scenario.
+    /// Internal export method that streams the tar.gz archive directly to disk via a temp file.
     /// Creates a real tar.gz archive containing metadata, database, and media files.
     /// </summary>
-    private async Task<byte[]> ExportInternalAsync(string? passphraseOverride = null)
+    private async Task ExportToFileInternalAsync(
+        string filepath,
+        string? passphraseOverride = null,
+        CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Starting full system backup export (tar.gz format)");
+        _logger.LogInformation("Starting full system backup export (tar.gz format, streaming to disk)");
 
         var backup = new SystemBackup
         {
@@ -107,7 +110,7 @@ public class BackupService : IBackupService
             }
         };
 
-        await using var connection = await _dataSource.OpenConnectionAsync();
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
 
         // Discover all tables dynamically from database
         var allTables = await _tableDiscoveryService.DiscoverTablesAsync(connection);
@@ -136,7 +139,7 @@ public class BackupService : IBackupService
             {
                 _logger.LogError(ex, "Failed to export table {TableName}", tableName);
 
-                // Notify Owners about backup failure (Phase 5.1)
+                // Notify Owners about backup failure
                 _ = _notificationService.SendBackupFailedAsync(
                     tableName: tableName,
                     error: ex.Message,
@@ -154,7 +157,7 @@ public class BackupService : IBackupService
             TypeInfoResolver = new NotMappedPropertiesIgnoringResolver()
         };
 
-        // Serialize database content
+        // Serialize database content (kept as byte[] — AES-GCM requires full buffer)
         var databaseJson = JsonSerializer.SerializeToUtf8Bytes(backup.Data, jsonOptions);
         _logger.LogInformation("Serialized database to JSON: {Size} bytes", databaseJson.Length);
 
@@ -174,7 +177,7 @@ public class BackupService : IBackupService
             passphrase = await _passphraseService.GetDecryptedPassphraseAsync();
         }
 
-        // Encrypt database content (entry inside tar, not the whole archive)
+        // Encrypt database content (AES-GCM requires full plaintext in memory)
         var databaseContent = _encryptionService.EncryptBackup(databaseJson, passphrase);
         _logger.LogInformation("Encrypted database: {OriginalSize} bytes → {EncryptedSize} bytes",
             databaseJson.Length, databaseContent.Length);
@@ -189,51 +192,66 @@ public class BackupService : IBackupService
         // Serialize metadata (always unencrypted - readable by backup browser)
         var metadataJson = JsonSerializer.SerializeToUtf8Bytes(backup.Metadata, jsonOptions);
 
-        // Create real tar.gz archive
-        using var tarStream = new MemoryStream();
-        await using (var gzipStream = new GZipStream(tarStream, CompressionLevel.Optimal, leaveOpen: true))
-        await using (var tarWriter = new TarWriter(gzipStream, leaveOpen: true))
+        // Stream tar.gz directly to disk via temp file for atomic write
+        var tempPath = filepath + ".tmp";
+        try
         {
-            // Add metadata.json (unencrypted - readable by backup browser without passphrase)
-            var metadataEntry = new PaxTarEntry(TarEntryType.RegularFile, "metadata.json")
+            await using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            await using (var gzipStream = new GZipStream(fileStream, CompressionLevel.Optimal))
+            await using (var tarWriter = new TarWriter(gzipStream, leaveOpen: true))
             {
-                DataStream = new MemoryStream(metadataJson)
-            };
-            await tarWriter.WriteEntryAsync(metadataEntry);
-            _logger.LogDebug("Added metadata.json to archive: {Size} bytes", metadataJson.Length);
-
-            // Add encrypted database entry
-            var databaseEntry = new PaxTarEntry(TarEntryType.RegularFile, "database.json.enc")
-            {
-                DataStream = new MemoryStream(databaseContent)
-            };
-            await tarWriter.WriteEntryAsync(databaseEntry);
-            _logger.LogDebug("Added database.json.enc to archive: {Size} bytes", databaseContent.Length);
-
-            // Add ban celebration GIFs (unencrypted - not sensitive)
-            if (gifFiles.Length > 0)
-            {
-                foreach (var gifPath in gifFiles)
+                // Add metadata.json (unencrypted - readable by backup browser without passphrase)
+                var metadataEntry = new PaxTarEntry(TarEntryType.RegularFile, "metadata.json")
                 {
-                    var entryName = $"media/ban-gifs/{Path.GetFileName(gifPath)}";
-                    await tarWriter.WriteEntryAsync(gifPath, entryName);
+                    DataStream = new MemoryStream(metadataJson)
+                };
+                await tarWriter.WriteEntryAsync(metadataEntry, cancellationToken);
+                _logger.LogDebug("Added metadata.json to archive: {Size} bytes", metadataJson.Length);
+
+                // Add encrypted database entry
+                var databaseEntry = new PaxTarEntry(TarEntryType.RegularFile, "database.json.enc")
+                {
+                    DataStream = new MemoryStream(databaseContent)
+                };
+                await tarWriter.WriteEntryAsync(databaseEntry, cancellationToken);
+                _logger.LogDebug("Added database.json.enc to archive: {Size} bytes", databaseContent.Length);
+
+                // Add ban celebration GIFs (streamed from disk, not buffered)
+                if (gifFiles.Length > 0)
+                {
+                    foreach (var gifPath in gifFiles)
+                    {
+                        var entryName = $"media/ban-gifs/{Path.GetFileName(gifPath)}";
+                        await tarWriter.WriteEntryAsync(gifPath, entryName, cancellationToken);
+                    }
+                    _logger.LogInformation("Added {Count} ban celebration GIFs to archive", gifFiles.Length);
                 }
-                _logger.LogInformation("Added {Count} ban celebration GIFs to archive", gifFiles.Length);
+            }
+
+            var archiveSize = new FileInfo(tempPath).Length;
+            _logger.LogInformation("Created tar.gz archive: {Size} bytes", archiveSize);
+
+            // Validate by reading metadata back from the file on disk
+            var metadata = await GetMetadataAsync(tempPath);
+            if (string.IsNullOrEmpty(metadata.Version) || metadata.TableCount <= 0)
+            {
+                throw new InvalidOperationException("Backup validation failed - archive may be corrupted");
+            }
+
+            _logger.LogInformation("Backup validated successfully");
+
+            // Atomic rename: temp → final (same filesystem = atomic on Linux)
+            File.Move(tempPath, filepath, overwrite: true);
+        }
+        finally
+        {
+            // Clean up temp file on failure
+            if (File.Exists(tempPath))
+            {
+                try { File.Delete(tempPath); }
+                catch (Exception ex) { _logger.LogWarning(ex, "Failed to delete temp backup file: {TempPath}", tempPath); }
             }
         }
-
-        var finalBackup = tarStream.ToArray();
-        _logger.LogInformation("Created tar.gz archive: {Size} bytes", finalBackup.Length);
-
-        // Validate the backup
-        if (!await ValidateBackupAsync(finalBackup))
-        {
-            throw new InvalidOperationException("Backup validation failed - archive may be corrupted");
-        }
-
-        _logger.LogInformation("✅ Backup validated successfully");
-
-        return finalBackup;
     }
 
 
@@ -960,38 +978,6 @@ public class BackupService : IBackupService
     }
 
     /// <summary>
-    /// Validates backup by attempting to decompress and verify metadata
-    /// </summary>
-    private async Task<bool> ValidateBackupAsync(byte[] backupBytes)
-    {
-        try
-        {
-            // Try to read metadata
-            var metadata = await GetMetadataInternalAsync(backupBytes);
-
-            // Basic validation checks
-            if (metadata == null)
-                return false;
-
-            if (string.IsNullOrEmpty(metadata.Version))
-                return false;
-
-            if (metadata.TableCount <= 0)
-                return false;
-
-            _logger.LogDebug("Backup validation successful: version={Version}, tables={TableCount}",
-                metadata.Version, metadata.TableCount);
-
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Backup validation failed");
-            return false;
-        }
-    }
-
-    /// <summary>
     /// Disables the Telegram bot after restore to prevent dual instances
     /// Updates the telegram_bot_config JSONB column to set bot_enabled = false
     /// </summary>
@@ -1037,9 +1023,6 @@ public class BackupService : IBackupService
         RetentionConfig retentionConfig,
         CancellationToken cancellationToken = default)
     {
-        // Generate backup
-        var backupBytes = await ExportAsync();
-
         // Ensure directory exists
         Directory.CreateDirectory(backupDirectory);
 
@@ -1048,7 +1031,7 @@ public class BackupService : IBackupService
         var filename = $"backup_{timestamp}.tar.gz";
         var filepath = Path.Combine(backupDirectory, filename);
 
-        await File.WriteAllBytesAsync(filepath, backupBytes, cancellationToken);
+        await ExportToFileAsync(filepath, cancellationToken);
 
         // Apply retention cleanup
         var backupFiles = Directory.GetFiles(backupDirectory, "backup_*.tar.gz")
@@ -1087,7 +1070,7 @@ public class BackupService : IBackupService
             _logger.LogInformation("Deleted {Count} old backups via retention policy", deletedCount);
         }
 
-        return new BackupResult(filename, filepath, backupBytes.Length, deletedCount);
+        return new BackupResult(filename, filepath, new FileInfo(filepath).Length, deletedCount);
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/IBackupService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/Backup/IBackupService.cs
@@ -6,18 +6,22 @@ namespace TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
 public interface IBackupService
 {
     /// <summary>
-    /// Export all system data to a gzip-compressed (and optionally encrypted) JSON file
-    /// Uses passphrase from database config if encryption is enabled
+    /// Export all system data to a tar.gz file streamed directly to disk.
+    /// Uses passphrase from database config for encryption.
+    /// Writes to a temp file first, then atomically renames on success.
     /// </summary>
-    /// <returns>Compressed (and optionally encrypted) backup file bytes</returns>
-    Task<byte[]> ExportAsync();
+    /// <param name="filepath">Destination file path for the backup</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task ExportToFileAsync(string filepath, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Export all system data with explicit passphrase (for CLI usage)
+    /// Export all system data to a tar.gz file with explicit passphrase (for CLI usage).
+    /// Writes to a temp file first, then atomically renames on success.
     /// </summary>
+    /// <param name="filepath">Destination file path for the backup</param>
     /// <param name="passphraseOverride">Passphrase to use (overrides DB config)</param>
-    /// <returns>Encrypted and compressed backup file bytes</returns>
-    Task<byte[]> ExportAsync(string passphraseOverride);
+    /// <param name="cancellationToken">Cancellation token</param>
+    Task ExportToFileAsync(string filepath, string passphraseOverride, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Restore system from backup file (WIPES ALL DATA FIRST)

--- a/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
@@ -162,7 +162,7 @@ public class BackupServiceTests
     #region Export Tests
 
     [Test]
-    public async Task ExportAsync_WithDbPassphrase_ShouldCreateEncryptedBackup()
+    public async Task ExportToFileAsync_WithDbPassphrase_ShouldCreateEncryptedBackup()
     {
         // Arrange - encryption config already set up in SetUp()
 
@@ -188,7 +188,7 @@ public class BackupServiceTests
     }
 
     [Test]
-    public async Task ExportAsync_WithExplicitPassphrase_ShouldOverrideDbPassphrase()
+    public async Task ExportToFileAsync_WithExplicitPassphrase_ShouldOverrideDbPassphrase()
     {
         // Arrange - Set DB passphrase (should be ignored)
         await using (var context = _testHelper!.GetDbContext())
@@ -212,7 +212,7 @@ public class BackupServiceTests
     }
 
     [Test]
-    public async Task ExportAsync_ShouldIncludeAllExpectedTables()
+    public async Task ExportToFileAsync_ShouldIncludeAllExpectedTables()
     {
         // Act
         var backupBytes = await ExportBackupAsBytesAsync();
@@ -229,7 +229,7 @@ public class BackupServiceTests
     }
 
     [Test]
-    public async Task ExportAsync_ShouldDecryptDataProtectionFields()
+    public async Task ExportToFileAsync_ShouldDecryptDataProtectionFields()
     {
         // Arrange - Golden dataset has encrypted API keys
         // Verify seed worked
@@ -540,7 +540,7 @@ public class BackupServiceTests
     #region Error Handling Tests
 
     [Test]
-    public async Task ExportAsync_WithCorruptedJsonbColumn_ShouldFailFastWithClearError()
+    public async Task ExportToFileAsync_WithCorruptedJsonbColumn_ShouldFailFastWithClearError()
     {
         // Arrange - Corrupt the warnings JSONB column with JSON that can't deserialize to List<WarningEntry>
         // This simulates database corruption or schema mismatch that would produce an incomplete backup
@@ -573,7 +573,7 @@ public class BackupServiceTests
     }
 
     [Test]
-    public async Task ExportAsync_WithValidJsonbColumn_ShouldSucceed()
+    public async Task ExportToFileAsync_WithValidJsonbColumn_ShouldSucceed()
     {
         // Arrange - Ensure we have valid JSONB data (golden dataset already has this)
         // This test verifies the happy path still works after adding error handling

--- a/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
@@ -591,6 +591,50 @@ public class BackupServiceTests
     }
 
     [Test]
+    public async Task ExportToFileAsync_CancelledDuringWrite_ShouldCleanUpTempFile()
+    {
+        // Arrange - Use a pre-cancelled token so the export creates the temp file
+        // but fails during tar entry writing (WriteEntryAsync checks the token).
+        // This exercises the finally block's temp file cleanup.
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"backup_cleanup_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var filepath = Path.Combine(tempDir, "test_backup.tar.gz");
+
+        try
+        {
+            // Act - Export should fail with cancellation after temp file is created
+            await Assert.ThatAsync(
+                () => _backupService!.ExportToFileAsync(filepath, cts.Token),
+                Throws.InstanceOf<OperationCanceledException>());
+
+            // Assert - No temp files should remain (finally block cleaned up)
+            var tempFiles = Directory.GetFiles(tempDir, "*.tmp");
+            Assert.That(tempFiles, Is.Empty, "Temp file should be cleaned up after cancelled export");
+
+            // Final file should not exist either
+            Assert.That(File.Exists(filepath), Is.False, "Final backup file should not exist after cancelled export");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    public async Task ExportToFileAsync_WithEmptyPassphrase_ShouldThrowArgumentException(string passphrase)
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"test_backup_{Guid.NewGuid():N}.tar.gz");
+
+        await Assert.ThatAsync(
+            () => _backupService!.ExportToFileAsync(tempPath, passphrase),
+            Throws.ArgumentException.With.Property(nameof(ArgumentException.ParamName)).EqualTo("passphraseOverride"));
+    }
+
+    [Test]
     public async Task ExportAndRestore_ShouldPreserveDateTimeOffsetTimezone()
     {
         // Arrange - Insert a DateTimeOffset with a non-UTC timezone (+05:30 IST)

--- a/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
@@ -134,6 +134,31 @@ public class BackupServiceTests
         (_serviceProvider as IDisposable)?.Dispose();
     }
 
+    /// <summary>
+    /// Helper to export backup to temp file and read back as bytes (for tests using old API)
+    /// </summary>
+    private async Task<byte[]> ExportBackupAsBytesAsync(string? passphraseOverride = null)
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"test_backup_{Guid.NewGuid():N}.tar.gz");
+        try
+        {
+            if (passphraseOverride != null)
+            {
+                await _backupService!.ExportToFileAsync(tempPath, passphraseOverride, CancellationToken.None);
+            }
+            else
+            {
+                await _backupService!.ExportToFileAsync(tempPath, CancellationToken.None);
+            }
+            return await File.ReadAllBytesAsync(tempPath);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+    }
+
     #region Export Tests
 
     [Test]
@@ -142,18 +167,18 @@ public class BackupServiceTests
         // Arrange - encryption config already set up in SetUp()
 
         // Act
-        var backupBytes = await _backupService!.ExportAsync();
+        var backupBytes = await ExportBackupAsBytesAsync();
 
         // Assert
         Assert.That(backupBytes, Is.Not.Null);
         Assert.That(backupBytes.Length, Is.GreaterThan(0));
 
         // Verify backup contains encrypted database entry
-        var isEncrypted = await _backupService.IsEncryptedAsync(backupBytes);
+        var isEncrypted = await _backupService!.IsEncryptedAsync(backupBytes);
         Assert.That(isEncrypted, Is.True, "Backup should be encrypted when passphrase is configured");
 
         // Verify can extract metadata from encrypted backup (metadata is always unencrypted in tar)
-        var metadata = await _backupService.GetMetadataAsync(backupBytes);
+        var metadata = await _backupService!.GetMetadataAsync(backupBytes);
         Assert.That(metadata, Is.Not.Null);
         using (Assert.EnterMultipleScope())
         {
@@ -177,10 +202,10 @@ public class BackupServiceTests
         const string explicitPassphrase = "explicit-override-pass";
 
         // Act - Export with explicit passphrase
-        var backupBytes = await _backupService!.ExportAsync(explicitPassphrase);
+        var backupBytes = await ExportBackupAsBytesAsync(explicitPassphrase);
 
         // Assert - Should be encrypted (database.json.enc entry in tar)
-        Assert.That(await _backupService.IsEncryptedAsync(backupBytes), Is.True);
+        Assert.That(await _backupService!.IsEncryptedAsync(backupBytes), Is.True);
 
         // Verify restore with explicit passphrase works (decrypts database.json.enc inside tar)
         Assert.DoesNotThrowAsync(() => _backupService.RestoreAsync(backupBytes, explicitPassphrase));
@@ -190,8 +215,8 @@ public class BackupServiceTests
     public async Task ExportAsync_ShouldIncludeAllExpectedTables()
     {
         // Act
-        var backupBytes = await _backupService!.ExportAsync();
-        var metadata = await _backupService.GetMetadataAsync(backupBytes);
+        var backupBytes = await ExportBackupAsBytesAsync();
+        var metadata = await _backupService!.GetMetadataAsync(backupBytes);
 
         // Assert - Verify table count matches golden dataset
         Assert.That(metadata.TableCount, Is.EqualTo(GoldenDataset.TotalTableCount),
@@ -215,7 +240,7 @@ public class BackupServiceTests
         }
 
         // Act - Export (should decrypt Data Protection fields)
-        var backupBytes = await _backupService!.ExportAsync();
+        var backupBytes = await ExportBackupAsBytesAsync();
 
         // Assert - Export should succeed without errors
         Assert.That(backupBytes, Is.Not.Null);
@@ -233,8 +258,8 @@ public class BackupServiceTests
         // We can't call private methods directly, but export implicitly tests this
 
         // Act - Export triggers table discovery
-        var backupBytes = await _backupService!.ExportAsync();
-        var metadata = await _backupService.GetMetadataAsync(backupBytes);
+        var backupBytes = await ExportBackupAsBytesAsync();
+        var metadata = await _backupService!.GetMetadataAsync(backupBytes);
 
         // Assert - Count should match actual tables in database (excluding tables without DTOs)
         var actualTableCount = await _testHelper!.ExecuteScalarAsync<long>(@"
@@ -253,14 +278,14 @@ public class BackupServiceTests
     public async Task DiscoverTablesAsync_ShouldExcludeSystemTables()
     {
         // Act
-        var backupBytes = await _backupService!.ExportAsync();
+        var backupBytes = await ExportBackupAsBytesAsync();
 
         // Parse backup to verify exclusions (indirect test via successful export)
         Assert.That(backupBytes, Is.Not.Null);
 
         // Verify __EFMigrationsHistory and cached_blocked_domains were excluded
         // (implicitly tested by table count matching non-system tables)
-        var metadata = await _backupService.GetMetadataAsync(backupBytes);
+        var metadata = await _backupService!.GetMetadataAsync(backupBytes);
         Assert.That(metadata.TableCount, Is.LessThan(50),
             "Should exclude system/cache tables, keeping count reasonable");
     }
@@ -274,7 +299,7 @@ public class BackupServiceTests
     {
         // Arrange - Create encrypted backup
         const string passphrase = "restore-test-pass-123";
-        var originalBackup = await _backupService!.ExportAsync(passphrase);
+        var originalBackup = await ExportBackupAsBytesAsync(passphrase);
 
         // Verify original data exists
         var originalUserCount = await _testHelper!.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM users");
@@ -287,7 +312,7 @@ public class BackupServiceTests
         }
 
         // Act - Restore (destructive operation)
-        await _backupService.RestoreAsync(originalBackup, passphrase);
+        await _backupService!.RestoreAsync(originalBackup, passphrase);
 
         // Assert - Verify data was restored
         var restoredUserCount = await _testHelper.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM users");
@@ -304,13 +329,13 @@ public class BackupServiceTests
     public async Task RestoreAsync_WithDbPassphrase_ShouldRestoreWithoutExplicitPassphrase()
     {
         // Arrange - Export uses DB passphrase (configured in SetUp), restore reads it back
-        var originalBackup = await _backupService!.ExportAsync();
+        var originalBackup = await ExportBackupAsBytesAsync();
 
         var originalChatCount = await _testHelper!.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM managed_chats");
         Assert.That(originalChatCount, Is.GreaterThan(0));
 
         // Act - Restore without explicit passphrase (reads DB passphrase automatically)
-        await _backupService.RestoreAsync(originalBackup);
+        await _backupService!.RestoreAsync(originalBackup);
 
         // Assert
         var restoredChatCount = await _testHelper.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM managed_chats");
@@ -318,16 +343,15 @@ public class BackupServiceTests
     }
 
     [Test]
-    public void RestoreAsync_WrongPassphrase_ShouldThrowException()
+    public async Task RestoreAsync_WrongPassphrase_ShouldThrowException()
     {
         // Arrange - Create encrypted backup
-        var backupTask = _backupService!.ExportAsync("correct-passphrase");
-        var backup = backupTask.GetAwaiter().GetResult();
+        var backup = await ExportBackupAsBytesAsync("correct-passphrase");
 
         // Act & Assert - Restore with wrong passphrase should fail (throws CryptographicException)
         Assert.ThrowsAsync<System.Security.Cryptography.CryptographicException>(async () =>
         {
-            await _backupService.RestoreAsync(backup, "wrong-passphrase");
+            await _backupService!.RestoreAsync(backup, "wrong-passphrase");
         });
     }
 
@@ -335,7 +359,7 @@ public class BackupServiceTests
     public async Task RestoreAsync_ShouldWipeAllTablesFirst()
     {
         // Arrange - Create backup and add extra data after backup
-        var backup = await _backupService!.ExportAsync();
+        var backup = await ExportBackupAsBytesAsync();
 
         // Add extra user after backup (should be wiped during restore)
         await _testHelper!.ExecuteSqlAsync(@"
@@ -347,7 +371,7 @@ public class BackupServiceTests
         Assert.That(countBeforeRestore, Is.EqualTo(13), "Should have 12 golden users + 1 extra = 13 before restore");
 
         // Act - Restore (should wipe extra_user)
-        await _backupService.RestoreAsync(backup);
+        await _backupService!.RestoreAsync(backup);
 
         // Assert - Extra user should be gone
         var extraUserExists = await _testHelper.ExecuteScalarAsync<bool>(
@@ -359,10 +383,10 @@ public class BackupServiceTests
     public async Task RestoreAsync_ShouldHandleSelfReferencingForeignKeys()
     {
         // Arrange - Golden dataset has users.invited_by → users.id (self-reference)
-        var backup = await _backupService!.ExportAsync();
+        var backup = await ExportBackupAsBytesAsync();
 
         // Act - Restore (should handle self-referencing FK)
-        await _backupService.RestoreAsync(backup);
+        await _backupService!.RestoreAsync(backup);
 
         // Assert - Verify self-referencing FK relationships preserved
         var user2 = await _testHelper!.ExecuteScalarAsync<string>($@"
@@ -379,10 +403,10 @@ public class BackupServiceTests
     public async Task RestoreAsync_ShouldReencryptDataProtectionFields()
     {
         // Arrange - Export with decrypted API keys
-        var backup = await _backupService!.ExportAsync();
+        var backup = await ExportBackupAsBytesAsync();
 
         // Act - Restore (should re-encrypt using test Data Protection)
-        await _backupService.RestoreAsync(backup);
+        await _backupService!.RestoreAsync(backup);
 
         // Assert - Verify API keys are re-encrypted
         await using (var context = _testHelper!.GetDbContext())
@@ -402,10 +426,10 @@ public class BackupServiceTests
     public async Task RestoreAsync_ShouldResetSequences()
     {
         // Arrange - Create backup with data
-        var backup = await _backupService!.ExportAsync();
+        var backup = await ExportBackupAsBytesAsync();
 
         // Act - Restore
-        await _backupService.RestoreAsync(backup);
+        await _backupService!.RestoreAsync(backup);
 
         // Assert - Insert new message_edit, verify ID continues from max
         // (message_edits.id still has identity/sequence, unlike messages.message_id which uses ValueGeneratedNever)
@@ -438,10 +462,10 @@ public class BackupServiceTests
         // detection_results → messages
         // configs (no dependencies)
 
-        var backup = await _backupService!.ExportAsync();
+        var backup = await ExportBackupAsBytesAsync();
 
         // Act - Restore (topological sort must order tables correctly)
-        await _backupService.RestoreAsync(backup);
+        await _backupService!.RestoreAsync(backup);
 
         // Assert - Verify all FK relationships intact
         var detectionCount = await _testHelper!.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM detection_results");
@@ -465,10 +489,10 @@ public class BackupServiceTests
     public async Task GetMetadataAsync_FromEncryptedBackup_ShouldReturnMetadata()
     {
         // Arrange - Use DB passphrase (SetUp() already configured "test-passphrase-12345")
-        var encryptedBackup = await _backupService!.ExportAsync();
+        var encryptedBackup = await ExportBackupAsBytesAsync();
 
         // Act - GetMetadataAsync will retrieve passphrase from DB to decrypt
-        var metadata = await _backupService.GetMetadataAsync(encryptedBackup);
+        var metadata = await _backupService!.GetMetadataAsync(encryptedBackup);
 
         // Assert
         Assert.That(metadata, Is.Not.Null);
@@ -484,10 +508,10 @@ public class BackupServiceTests
     public async Task GetMetadataAsync_FromDbPassphraseBackup_ShouldReturnMetadata()
     {
         // Arrange - ExportAsync() encrypts with DB passphrase; metadata is always readable
-        var backup = await _backupService!.ExportAsync();
+        var backup = await ExportBackupAsBytesAsync();
 
         // Act
-        var metadata = await _backupService.GetMetadataAsync(backup);
+        var metadata = await _backupService!.GetMetadataAsync(backup);
 
         // Assert
         Assert.That(metadata, Is.Not.Null);
@@ -498,10 +522,10 @@ public class BackupServiceTests
     public async Task IsEncryptedAsync_WithEncryptedBackup_ShouldReturnTrue()
     {
         // Arrange
-        var encrypted = await _backupService!.ExportAsync("test-pass");
+        var encrypted = await ExportBackupAsBytesAsync("test-pass");
 
         // Act
-        var isEncrypted = await _backupService.IsEncryptedAsync(encrypted);
+        var isEncrypted = await _backupService!.IsEncryptedAsync(encrypted);
 
         // Assert
         Assert.That(isEncrypted, Is.True);
@@ -536,7 +560,7 @@ public class BackupServiceTests
         // Act & Assert - Export should fail fast with InvalidOperationException
         var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
-            await _backupService!.ExportAsync();
+            await ExportBackupAsBytesAsync();
         });
 
         using (Assert.EnterMultipleScope())
@@ -555,14 +579,14 @@ public class BackupServiceTests
         // This test verifies the happy path still works after adding error handling
 
         // Act
-        var backupBytes = await _backupService!.ExportAsync();
+        var backupBytes = await ExportBackupAsBytesAsync();
 
         // Assert - Export should succeed
         Assert.That(backupBytes, Is.Not.Null);
         Assert.That(backupBytes.Length, Is.GreaterThan(0));
 
         // Verify the backup contains telegram_users table with warnings column
-        var metadata = await _backupService.GetMetadataAsync(backupBytes);
+        var metadata = await _backupService!.GetMetadataAsync(backupBytes);
         Assert.That(metadata.TableCount, Is.EqualTo(GoldenDataset.TotalTableCount));
     }
 
@@ -591,8 +615,8 @@ public class BackupServiceTests
             "Test setup: DateTimeOffset should be stored correctly");
 
         // Act - Export and restore
-        var backupBytes = await _backupService!.ExportAsync();
-        await _backupService.RestoreAsync(backupBytes);
+        var backupBytes = await ExportBackupAsBytesAsync();
+        await _backupService!.RestoreAsync(backupBytes);
 
         // Assert - Verify the DateTimeOffset was preserved through the roundtrip
         var restoredOffset = await _testHelper.ExecuteScalarAsync<DateTimeOffset>($@"
@@ -617,8 +641,8 @@ public class BackupServiceTests
             "Test setup: User3 should have Deleted status (3)");
 
         // Act - Export and restore
-        var backupBytes = await _backupService!.ExportAsync();
-        await _backupService.RestoreAsync(backupBytes);
+        var backupBytes = await ExportBackupAsBytesAsync();
+        await _backupService!.RestoreAsync(backupBytes);
 
         // Assert - Verify enum was preserved
         var restoredStatus = await _testHelper.ExecuteScalarAsync<int>($@"

--- a/TelegramGroupsAdmin/Dockerfile
+++ b/TelegramGroupsAdmin/Dockerfile
@@ -240,7 +240,8 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 # Set environment variables for production
 # TZ can be overridden at runtime: -e TZ=America/Phoenix
-# GC tuning: ConserveMemory=7 auto-compacts LOH, HighMemPercent=70% triggers earlier compaction
+# GC tuning: ConserveMemory=7 auto-compacts LOH, HighMemPercent triggers earlier compaction
+# NOTE: DOTNET_ env vars use hex per .NET convention — 0x46 = 70 decimal = 70% threshold
 # These are defaults — override via compose.yml if CPU overhead is too high (dial ConserveMemory back to 5)
 ENV ASPNETCORE_ENVIRONMENT=Production \
     DOTNET_RUNNING_IN_CONTAINER=true \

--- a/TelegramGroupsAdmin/Dockerfile
+++ b/TelegramGroupsAdmin/Dockerfile
@@ -240,12 +240,16 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 # Set environment variables for production
 # TZ can be overridden at runtime: -e TZ=America/Phoenix
+# GC tuning: ConserveMemory=7 auto-compacts LOH, HighMemPercent=70% triggers earlier compaction
+# These are defaults — override via compose.yml if CPU overhead is too high (dial ConserveMemory back to 5)
 ENV ASPNETCORE_ENVIRONMENT=Production \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_EnableDiagnostics=0 \
     ASPNETCORE_HTTP_PORTS=8080 \
     TZ=UTC \
-    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    DOTNET_GCConserveMemory=7 \
+    DOTNET_GCHighMemPercent=46
 
 # Entrypoint
 ENTRYPOINT ["dotnet", "TelegramGroupsAdmin.dll"]

--- a/TelegramGroupsAdmin/Program.cs
+++ b/TelegramGroupsAdmin/Program.cs
@@ -232,11 +232,11 @@ if (args.Contains("--backup"))
     var backupService = scope.ServiceProvider.GetRequiredService<TelegramGroupsAdmin.BackgroundJobs.Services.Backup.IBackupService>();
 
     app.Logger.LogInformation("Creating encrypted backup...");
-    var backupBytes = await backupService.ExportAsync(passphrase); // Use passphrase override for CLI
-    await File.WriteAllBytesAsync(backupPath, backupBytes);
+    await backupService.ExportToFileAsync(backupPath, passphrase, CancellationToken.None);
 
+    var backupSize = new FileInfo(backupPath).Length;
     app.Logger.LogInformation("✅ Encrypted backup created: {Path} ({Size:F2} MB)",
-        backupPath, backupBytes.Length / 1024.0 / 1024.0);
+        backupPath, backupSize / 1024.0 / 1024.0);
     app.Logger.LogInformation("🔐 Store your passphrase securely - you'll need it to restore this backup!");
     app.Logger.LogInformation("Exiting (--backup flag).");
     Environment.Exit(0);

--- a/docs/superpowers/plans/2026-03-24-memory-reduction.md
+++ b/docs/superpowers/plans/2026-03-24-memory-reduction.md
@@ -1,0 +1,534 @@
+# Memory Reduction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce production RSS from 2.4 GiB to <1 GiB by adding GC tuning and streaming backups directly to disk.
+
+**Architecture:** Two-phase approach in a single PR. Phase 1 adds GC conservation env vars to the Dockerfile. Phase 2 refactors `BackupService.ExportAsync` from returning `byte[]` to streaming a tar.gz archive directly to a `FileStream`, with atomic temp-file write for failure safety.
+
+**Tech Stack:** .NET 10, AES-256-GCM, System.Formats.Tar, GZipStream, PostgreSQL
+
+**Spec:** `docs/superpowers/specs/2026-03-24-memory-reduction-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `TelegramGroupsAdmin/Dockerfile` | Modify | Add GC tuning env vars |
+| `TelegramGroupsAdmin.BackgroundJobs/Services/Backup/IBackupService.cs` | Modify | Replace `ExportAsync` with `ExportToFileAsync` |
+| `TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs` | Modify | Streaming export, atomic write, updated retention |
+| `TelegramGroupsAdmin/Program.cs` | Modify | CLI `--backup` uses file-based export |
+| `TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs` | Modify | File-based export assertions |
+
+**No changes needed:** `BackupResult.cs` (SizeBytes already `long`), `ScheduledBackupJob.cs` (only calls `CreateBackupWithRetentionAsync`, not `ExportAsync` — spec listed it but verified unnecessary), `ScheduledBackupJobTests.cs` (mocks `CreateBackupWithRetentionAsync`), `BackupRestore.razor` (calls `CreateBackupWithRetentionAsync` internally), `BackupEncryptionService.cs` (stays `byte[]` → `byte[]`).
+
+---
+
+### Task 1: GC Tuning — Dockerfile Environment Variables
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Dockerfile:241-248`
+
+- [ ] **Step 1: Add GC conservation env vars to Dockerfile**
+
+In the existing `ENV` block (line 243), add the GC tuning variables:
+
+```dockerfile
+# Set environment variables for production
+# TZ can be overridden at runtime: -e TZ=America/Phoenix
+# GC tuning: ConserveMemory=7 auto-compacts LOH, HighMemPercent=70% triggers earlier compaction
+# These are defaults — override via compose.yml if CPU overhead is too high (dial ConserveMemory back to 5)
+ENV ASPNETCORE_ENVIRONMENT=Production \
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    DOTNET_EnableDiagnostics=0 \
+    ASPNETCORE_HTTP_PORTS=8080 \
+    TZ=UTC \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    DOTNET_GCConserveMemory=7 \
+    DOTNET_GCHighMemPercent=46
+```
+
+Note: `DOTNET_GCHighMemPercent=46` is hex for 70 decimal (env vars use hex per .NET convention).
+
+- [ ] **Step 2: Verify Dockerfile builds**
+
+Run: `docker build -t tga-test -f TelegramGroupsAdmin/Dockerfile . --no-cache --target final 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Dockerfile
+git commit -m "perf: add GC conservation env vars to reduce memory footprint
+
+DOTNET_GCConserveMemory=7 enables automatic LOH compaction and tighter heap.
+DOTNET_GCHighMemPercent=70 (0x46) triggers aggressive GC at lower memory threshold.
+Both are defaults overridable via compose.yml."
+```
+
+---
+
+### Task 2: Interface Change — Replace ExportAsync with ExportToFileAsync
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Services/Backup/IBackupService.cs`
+
+- [ ] **Step 1: Update IBackupService interface**
+
+Replace the two `ExportAsync` methods with `ExportToFileAsync`:
+
+```csharp
+// REMOVE these two methods:
+// Task<byte[]> ExportAsync();
+// Task<byte[]> ExportAsync(string passphraseOverride);
+
+// ADD these two methods:
+
+/// <summary>
+/// Export all system data to a tar.gz file streamed directly to disk.
+/// Uses passphrase from database config for encryption.
+/// Writes to a temp file first, then atomically renames on success.
+/// </summary>
+/// <param name="filepath">Destination file path for the backup</param>
+/// <param name="cancellationToken">Cancellation token</param>
+Task ExportToFileAsync(string filepath, CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Export all system data to a tar.gz file with explicit passphrase (for CLI usage).
+/// Writes to a temp file first, then atomically renames on success.
+/// </summary>
+/// <param name="filepath">Destination file path for the backup</param>
+/// <param name="passphraseOverride">Passphrase to use (overrides DB config)</param>
+/// <param name="cancellationToken">Cancellation token</param>
+Task ExportToFileAsync(string filepath, string passphraseOverride, CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 2: Verify build fails (callers still reference old methods)**
+
+Run: `dotnet build --no-restore 2>&1 | grep "error CS" | head -10`
+Expected: Compile errors in `BackupService.cs`, `Program.cs`, and `BackupServiceTests.cs` referencing `ExportAsync`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin.BackgroundJobs/Services/Backup/IBackupService.cs
+git commit -m "refactor: replace ExportAsync byte[] with ExportToFileAsync streaming interface"
+```
+
+---
+
+### Task 3: Streaming Export Implementation
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs:75-237`
+
+- [ ] **Step 1: Replace the public ExportAsync methods**
+
+Replace lines 75-90 (the two public `ExportAsync` overloads) with:
+
+```csharp
+public async Task ExportToFileAsync(string filepath, CancellationToken cancellationToken = default)
+{
+    await ExportToFileInternalAsync(filepath, cancellationToken: cancellationToken);
+}
+
+/// <summary>
+/// Export backup with explicit passphrase override (for CLI usage)
+/// </summary>
+public async Task ExportToFileAsync(string filepath, string passphraseOverride, CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(passphraseOverride))
+        throw new ArgumentException("Passphrase cannot be empty", nameof(passphraseOverride));
+
+    _logger.LogInformation("Starting backup export with explicit passphrase");
+    await ExportToFileInternalAsync(filepath, passphraseOverride: passphraseOverride, cancellationToken: cancellationToken);
+}
+```
+
+- [ ] **Step 2: Rewrite ExportInternalAsync to stream to FileStream**
+
+Replace `ExportInternalAsync` (lines 96-237) with `ExportToFileInternalAsync`. The key changes:
+- Accepts `string filepath` parameter
+- Writes to `filepath + ".tmp"` temp path
+- Tar writer targets `GZipStream(FileStream)` instead of `GZipStream(MemoryStream)`
+- Validates by reading metadata from the temp file on disk
+- Atomically renames temp → final on success
+- `finally` block cleans up temp file on failure
+
+```csharp
+private async Task ExportToFileInternalAsync(
+    string filepath,
+    string? passphraseOverride = null,
+    CancellationToken cancellationToken = default)
+{
+    _logger.LogInformation("Starting full system backup export (tar.gz format, streaming to disk)");
+
+    var backup = new SystemBackup
+    {
+        Metadata = new BackupMetadata
+        {
+            Version = CurrentVersion,
+            CreatedAt = DateTimeOffset.UtcNow,
+            AppVersion = "1.0.0"
+        }
+    };
+
+    await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+
+    // Discover all tables dynamically from database
+    var allTables = await _tableDiscoveryService.DiscoverTablesAsync(connection);
+
+    // Exclude repullable cached data (blocklist domains can be re-synced)
+    var excludedTables = new HashSet<string> { "cached_blocked_domains" };
+    var tables = allTables.Where(kvp => !excludedTables.Contains(kvp.Key)).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+    _logger.LogInformation("Discovered {TableCount} tables to backup (excluded {ExcludedCount} repullable tables)",
+        tables.Count, excludedTables.Count);
+
+    backup.Metadata.Tables = tables.Keys.ToList();
+    backup.Metadata.TableCount = tables.Count;
+
+    // Export each table using reflection
+    foreach (var (tableName, dtoType) in tables)
+    {
+        try
+        {
+            _logger.LogDebug("Exporting table: {TableName}", tableName);
+            var records = await _tableExportService.ExportTableAsync(connection, tableName, dtoType);
+            backup.Data[tableName] = records;
+            _logger.LogDebug("Exported {Count} records from {TableName}", records.Count, tableName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export table {TableName}", tableName);
+
+            // Notify Owners about backup failure
+            _ = _notificationService.SendBackupFailedAsync(
+                tableName: tableName,
+                error: ex.Message,
+                ct: CancellationToken.None);
+
+            throw;
+        }
+    }
+
+    // JSON serialization options (exclude [NotMapped] properties)
+    var jsonOptions = new JsonSerializerOptions
+    {
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        TypeInfoResolver = new NotMappedPropertiesIgnoringResolver()
+    };
+
+    // Serialize database content (kept as byte[] — AES-GCM requires full buffer)
+    var databaseJson = JsonSerializer.SerializeToUtf8Bytes(backup.Data, jsonOptions);
+    _logger.LogInformation("Serialized database to JSON: {Size} bytes", databaseJson.Length);
+
+    // Determine passphrase: explicit override takes priority, then DB config
+    string? passphrase = passphraseOverride;
+
+    if (passphrase == null)
+    {
+        var encryptionConfig = await _configService.GetEncryptionConfigAsync();
+        if (encryptionConfig?.Enabled != true)
+        {
+            throw new InvalidOperationException(
+                "Backup encryption is not configured. Please set up encryption before creating backups. " +
+                "Navigate to Settings → Backup & Restore to enable encryption.");
+        }
+
+        passphrase = await _passphraseService.GetDecryptedPassphraseAsync();
+    }
+
+    // Encrypt database content (AES-GCM requires full plaintext in memory)
+    var databaseContent = _encryptionService.EncryptBackup(databaseJson, passphrase);
+    _logger.LogInformation("Encrypted database: {OriginalSize} bytes → {EncryptedSize} bytes",
+        databaseJson.Length, databaseContent.Length);
+
+    // Count media files for metadata
+    var banGifDir = Path.Combine(_mediaBasePath, "media", "ban-gifs");
+    var gifFiles = Directory.Exists(banGifDir)
+        ? Directory.GetFiles(banGifDir, "*.gif")
+        : [];
+    backup.Metadata.MediaFileCount = gifFiles.Length;
+
+    // Serialize metadata (always unencrypted - readable by backup browser)
+    var metadataJson = JsonSerializer.SerializeToUtf8Bytes(backup.Metadata, jsonOptions);
+
+    // Stream tar.gz directly to disk via temp file for atomic write
+    var tempPath = filepath + ".tmp";
+    try
+    {
+        await using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+        await using (var gzipStream = new GZipStream(fileStream, CompressionLevel.Optimal))
+        await using (var tarWriter = new TarWriter(gzipStream, leaveOpen: true))
+        {
+            // Add metadata.json (unencrypted - readable by backup browser without passphrase)
+            var metadataEntry = new PaxTarEntry(TarEntryType.RegularFile, "metadata.json")
+            {
+                DataStream = new MemoryStream(metadataJson)
+            };
+            await tarWriter.WriteEntryAsync(metadataEntry, cancellationToken);
+            _logger.LogDebug("Added metadata.json to archive: {Size} bytes", metadataJson.Length);
+
+            // Add encrypted database entry
+            var databaseEntry = new PaxTarEntry(TarEntryType.RegularFile, "database.json.enc")
+            {
+                DataStream = new MemoryStream(databaseContent)
+            };
+            await tarWriter.WriteEntryAsync(databaseEntry, cancellationToken);
+            _logger.LogDebug("Added database.json.enc to archive: {Size} bytes", databaseContent.Length);
+
+            // Add ban celebration GIFs (streamed from disk, not buffered)
+            if (gifFiles.Length > 0)
+            {
+                foreach (var gifPath in gifFiles)
+                {
+                    var entryName = $"media/ban-gifs/{Path.GetFileName(gifPath)}";
+                    await tarWriter.WriteEntryAsync(gifPath, entryName, cancellationToken);
+                }
+                _logger.LogInformation("Added {Count} ban celebration GIFs to archive", gifFiles.Length);
+            }
+        }
+
+        var archiveSize = new FileInfo(tempPath).Length;
+        _logger.LogInformation("Created tar.gz archive: {Size} bytes", archiveSize);
+
+        // Validate by reading metadata back from the file on disk
+        var metadata = await GetMetadataAsync(tempPath);
+        if (string.IsNullOrEmpty(metadata.Version) || metadata.TableCount <= 0)
+        {
+            throw new InvalidOperationException("Backup validation failed - archive may be corrupted");
+        }
+
+        _logger.LogInformation("✅ Backup validated successfully");
+
+        // Atomic rename: temp → final (same filesystem = atomic on Linux)
+        File.Move(tempPath, filepath, overwrite: true);
+    }
+    finally
+    {
+        // Clean up temp file on failure
+        if (File.Exists(tempPath))
+        {
+            try { File.Delete(tempPath); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Update CreateBackupWithRetentionAsync**
+
+Replace lines 1040-1051 in `CreateBackupWithRetentionAsync`:
+
+```csharp
+// Before:
+// var backupBytes = await ExportAsync();
+// await File.WriteAllBytesAsync(filepath, backupBytes, cancellationToken);
+
+// After:
+await ExportToFileAsync(filepath, cancellationToken);
+```
+
+And update the return statement (line 1090):
+
+```csharp
+// Before:
+// return new BackupResult(filename, filepath, backupBytes.Length, deletedCount);
+
+// After:
+return new BackupResult(filename, filepath, new FileInfo(filepath).Length, deletedCount);
+```
+
+- [ ] **Step 4: Remove old ValidateBackupAsync(byte[]) private method**
+
+The `ValidateBackupAsync(byte[])` method (lines 965-992) is no longer called. Delete it. Validation now happens inline via `GetMetadataAsync(string filepath)` in `ExportToFileInternalAsync`.
+
+- [ ] **Step 5: Verify build compiles (except Program.cs and tests)**
+
+Run: `dotnet build --no-restore TelegramGroupsAdmin.BackgroundJobs/TelegramGroupsAdmin.BackgroundJobs.csproj 2>&1 | tail -5`
+Expected: Build succeeds for the BackgroundJobs project
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs
+git commit -m "perf: stream backup tar.gz directly to FileStream instead of memory
+
+Eliminates ~386 MB of LOH allocations per hourly backup:
+- TarWriter writes to GZipStream(FileStream) instead of MemoryStream
+- Removes tarStream.ToArray() copy (186 MB)
+- Validates from file on disk instead of re-parsing byte[]
+- Atomic temp file write with cleanup on failure
+
+JSON serialization (37 MB) and AES-GCM encryption (37 MB) remain
+as byte[] — AES-GCM requires full plaintext buffer."
+```
+
+---
+
+### Task 4: CLI Backup Path Update
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Program.cs:234-239`
+
+- [ ] **Step 1: Update --backup CLI handler**
+
+Replace lines 234-239:
+
+```csharp
+// Before:
+// app.Logger.LogInformation("Creating encrypted backup...");
+// var backupBytes = await backupService.ExportAsync(passphrase);
+// await File.WriteAllBytesAsync(backupPath, backupBytes);
+//
+// app.Logger.LogInformation("✅ Encrypted backup created: {Path} ({Size:F2} MB)",
+//     backupPath, backupBytes.Length / 1024.0 / 1024.0);
+
+// After:
+app.Logger.LogInformation("Creating encrypted backup...");
+await backupService.ExportToFileAsync(backupPath, passphrase, CancellationToken.None);
+
+var backupSize = new FileInfo(backupPath).Length;
+app.Logger.LogInformation("✅ Encrypted backup created: {Path} ({Size:F2} MB)",
+    backupPath, backupSize / 1024.0 / 1024.0);
+```
+
+- [ ] **Step 2: Verify full solution builds**
+
+Run: `dotnet build --no-restore 2>&1 | tail -5`
+Expected: Build succeeds (only test project may still have errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Program.cs
+git commit -m "refactor: CLI --backup uses streaming ExportToFileAsync"
+```
+
+---
+
+### Task 5: Integration Test Updates
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs`
+
+- [ ] **Step 1: Update export tests to use file-based API**
+
+Each test that calls `ExportAsync()` needs to:
+1. Create a temp file path
+2. Call `ExportToFileAsync(tempPath)` instead
+3. Read the file back with `File.ReadAllBytesAsync(tempPath)` where byte[] assertions are needed
+4. Clean up the temp file
+
+Example pattern for `ExportAsync_WithDbPassphrase_ShouldCreateEncryptedBackup`:
+
+```csharp
+[Test]
+public async Task ExportToFileAsync_WithDbPassphrase_ShouldCreateEncryptedBackup()
+{
+    // Arrange
+    var tempPath = Path.Combine(Path.GetTempPath(), $"test_backup_{Guid.NewGuid():N}.tar.gz");
+
+    try
+    {
+        // Act
+        await _backupService!.ExportToFileAsync(tempPath);
+
+        // Assert
+        Assert.That(File.Exists(tempPath), Is.True);
+        Assert.That(new FileInfo(tempPath).Length, Is.GreaterThan(0));
+
+        // Verify backup contains encrypted database entry (use file-based overload)
+        var isEncrypted = await _backupService.IsEncryptedAsync(tempPath);
+        Assert.That(isEncrypted, Is.True, "Backup should be encrypted when passphrase is configured");
+
+        // Verify can extract metadata (use file-based overload)
+        var metadata = await _backupService.GetMetadataAsync(tempPath);
+        Assert.That(metadata, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(metadata.Version, Is.EqualTo("3.0"));
+            Assert.That(metadata.TableCount, Is.GreaterThan(0));
+        }
+    }
+    finally
+    {
+        if (File.Exists(tempPath)) File.Delete(tempPath);
+    }
+}
+```
+
+Apply the same pattern to **all 21 call sites** of `ExportAsync()` in this file. There are three categories:
+
+**Export-only tests** (use file-based overloads for assertions):
+- `ExportAsync_WithExplicitPassphrase_ShouldOverrideDbPassphrase` — use `ExportToFileAsync(tempPath, explicitPassphrase)`, use `IsEncryptedAsync(tempPath)` for assertion
+- `ExportAsync_ShouldIncludeAllExpectedTables` — use file-based `GetMetadataAsync(tempPath)`
+- `ExportAsync_ShouldDecryptDataProtectionFields` — just verify export succeeds without throwing
+- `DiscoverTablesAsync_ShouldFindAllDatabaseTables` — same pattern
+- `ExportAsync_WithCorruptedJsonbColumn_ShouldFailFastWithClearError` (line 539)
+- `ExportAsync_WithValidJsonbColumn_ShouldSucceed` (line 558)
+
+**Export-then-restore round-trip tests** (export to file, read back as `byte[]` for `RestoreAsync`):
+- `RestoreAsync_EncryptedBackupWithPassphrase_ShouldRestoreSuccessfully` (line 277)
+- `RestoreAsync_WithDbPassphrase_ShouldRestoreWithoutExplicitPassphrase` (line 307)
+- `RestoreAsync_WrongPassphrase_ShouldThrowException` (line 324)
+- `RestoreAsync_ShouldWipeAllTablesFirst` (line 338)
+- `RestoreAsync_ShouldHandleSelfReferencingForeignKeys` (line 362)
+- `RestoreAsync_ShouldReencryptDataProtectionFields` (line 382)
+- `RestoreAsync_ShouldResetSequences` (line 405)
+- `Restore_WithComplexDependencyGraph_ShouldSucceed` (line 441)
+- `ExportAndRestore_ShouldPreserveDateTimeOffsetTimezone` (line 594)
+- `ExportAndRestore_ShouldPreserveEnumValues` (line 620)
+
+**Metadata/encryption check tests** (use file-based overloads):
+- `GetMetadataAsync_FromEncryptedBackup_ShouldReturnMetadata` (line 468)
+- `GetMetadataAsync_FromDbPassphraseBackup_ShouldReturnMetadata` (line 487)
+- `IsEncryptedAsync_WithEncryptedBackup_ShouldReturnTrue` (line 501)
+
+**Note:** Round-trip tests use `File.ReadAllBytesAsync(tempPath)` to get bytes for `RestoreAsync(byte[])`. This re-introduces memory allocation in tests, which is acceptable — the goal is production memory reduction, not test memory. Do NOT refactor `RestoreAsync` to be file-based (out of scope per spec).
+
+- [ ] **Step 2: Verify tests compile**
+
+Run: `dotnet build --no-restore TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj 2>&1 | tail -5`
+Expected: Build succeeds
+
+- [ ] **Step 3: Run integration tests**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~BackupServiceTests" --no-build`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
+git commit -m "test: update backup integration tests for file-based ExportToFileAsync"
+```
+
+---
+
+### Task 6: Full Build and Test Verification
+
+- [ ] **Step 1: Full solution build**
+
+Run: `dotnet build --no-restore`
+Expected: Build succeeded, 0 errors
+
+- [ ] **Step 2: Run all tests**
+
+Run: `dotnet test --no-build`
+Expected: All tests pass
+
+- [ ] **Step 3: Verify with --migrate-only**
+
+Run: `dotnet run --project TelegramGroupsAdmin -- --migrate-only`
+Expected: "Migration complete. Exiting (--migrate-only flag)."
+
+- [ ] **Step 4: Final commit if any cleanup needed, then push**
+
+```bash
+git push origin perf/memory-reduction
+```

--- a/docs/superpowers/specs/2026-03-24-memory-reduction-design.md
+++ b/docs/superpowers/specs/2026-03-24-memory-reduction-design.md
@@ -1,0 +1,174 @@
+# Memory Reduction: Backup Streaming + GC Tuning
+
+## Problem
+
+Production RSS is 2.4 GiB after 44 hours of uptime. Target is <1 GiB average for a homelab single-instance app.
+
+Key findings from production analysis:
+- LOH: 395 MiB with 35 MiB fragmented
+- GC committed: 922 MiB vs 535 MiB in use (387 MiB headroom)
+- Gen2 collections (108) > Gen0 (78) — LOH pressure triggering full GCs
+- 64 GiB lifetime allocations in 44 hours
+- No GC tuning configured (default Server GC with no conservation flags)
+
+## Strategy
+
+Two phases, both in a single PR:
+
+1. **GC tuning** — Dockerfile env vars (as defaults, overridable via compose) to make Server GC + DATAS more memory-conservative
+2. **Backup streaming** — refactor hourly backup to stream tar.gz directly to disk
+
+## Phase 1: GC Tuning
+
+Add environment variables to Dockerfile:
+
+```dockerfile
+ENV DOTNET_GCConserveMemory=7 \
+    DOTNET_GCHighMemPercent=46
+```
+
+### DOTNET_GCConserveMemory=7
+
+Scale of 0-9. At 7, the GC:
+- Works harder to keep the heap small (more frequent, shorter collections)
+- **Automatically compacts LOH** when fragmentation is too high (directly addresses the 395 MiB / 35 MiB fragmented LOH)
+- Feeds into DATAS gen0 budget formula: `(20 - conserve_memory) / sqrt(app_size_MB)` — DATAS internally defaults to 5 for this formula, so setting 7 tightens the budget moderately (not from 0)
+
+**CPU risk:** ConserveMemory=7 increases GC CPU overhead due to more frequent collections. Monitor CPU% after deployment — if it spikes, dial back to 5.
+
+### DOTNET_GCHighMemPercent=70 (0x46)
+
+Lowers the threshold where GC starts aggressive compaction from the default 90% to 70%. Causes GC to react earlier when memory pressure rises. Soft trigger, not a hard cap — the app can still grow if it genuinely needs memory during bursts.
+
+### Why no HeapHardLimit
+
+The app processes continuous Telegram messages, OpenAI API calls, and periodic backup/ML retraining simultaneously. A hard limit risks `OutOfMemoryException` during burst scenarios (spam wave + backup + retraining), which crashes the singleton process. The conservation flags nudge GC to be frugal without creating a ceiling.
+
+### DATAS (already active)
+
+`DOTNET_GCDynamicAdaptationMode=1` is enabled by default starting in .NET 9 (and therefore active in .NET 10). DATAS dynamically adjusts heap count from 1 (like Workstation) up to core count (like Server), adapting to workload. Combined with `ConserveMemory=7`, DATAS will use a tighter gen0 budget and compact more aggressively.
+
+## Phase 2: Backup Streaming
+
+### Current flow (per hourly backup)
+
+```
+ExportAsync() → byte[]
+  DB → Dictionary → SerializeToUtf8Bytes(37MB byte[])     ← LOH
+  → EncryptBackup(37MB byte[])                             ← LOH
+  → MemoryStream for tar writer (grows to ~186MB)          ← LOH
+  → tarStream.ToArray() (186MB byte[])                     ← LOH
+  → File.WriteAllBytesAsync()
+  → ValidateBackupAsync(byte[]) re-parses entire archive   ← LOH
+Peak: ~460 MB of LOH allocations
+```
+
+### New flow
+
+```
+ExportToFileAsync(filepath)
+  DB → Dictionary → SerializeToUtf8Bytes(37MB byte[])     ← LOH (kept, sunk cost)
+  → EncryptBackup(37MB byte[])                             ← LOH (kept, AES-GCM requires full buffer)
+  → TarWriter(GZipStream(FileStream(tempPath)))            ← streams to disk, no memory buffer
+  → GIFs: WriteEntryAsync(filePath, entryName)             ← streams from disk
+  → Validate via GetMetadataAsync(tempPath)                ← streams from file
+  → File.Move(tempPath, filepath)                          ← atomic rename on success
+  → finally: delete tempPath if it still exists            ← cleanup on failure
+Peak: ~74 MB (JSON + encrypted copy, both short-lived)
+```
+
+### Atomic file write
+
+The streaming approach means a failure midway leaves a partial file on disk. The in-memory approach either fully succeeded or failed cleanly. To preserve this guarantee:
+
+- Write to a temp path in the same directory (e.g., `filepath + ".tmp"`)
+- Validate the temp file (read metadata back)
+- `File.Move(tempPath, filepath)` — atomic rename on same filesystem
+- `finally` block deletes the temp file if it still exists (failure cleanup)
+
+### Interface changes
+
+`IBackupService`:
+
+```csharp
+// REMOVE:
+Task<byte[]> ExportAsync();
+Task<byte[]> ExportAsync(string passphraseOverride);
+
+// ADD:
+Task ExportToFileAsync(string filepath, CancellationToken cancellationToken = default);
+Task ExportToFileAsync(string filepath, string passphraseOverride, CancellationToken cancellationToken = default);
+```
+
+Restore methods stay `byte[]`-based (infrequent, user-initiated).
+`GetMetadataAsync(byte[])` stays for the restore UI (uploaded file already in memory).
+`IsEncryptedAsync` — both overloads stay.
+
+### CreateBackupWithRetentionAsync changes
+
+```csharp
+// Before:
+var backupBytes = await ExportAsync();
+await File.WriteAllBytesAsync(filepath, backupBytes, cancellationToken);
+return new BackupResult(filename, filepath, backupBytes.Length, deletedCount);
+
+// After:
+await ExportToFileAsync(filepath, cancellationToken);
+var fileInfo = new FileInfo(filepath);
+return new BackupResult(filename, filepath, fileInfo.Length, deletedCount);
+```
+
+`BackupResult.SizeBytes` is already `long`. The change here is the source: `backupBytes.Length` (int, implicit widening) → `fileInfo.Length` (long, native).
+
+### Validation change
+
+Current: `ValidateBackupAsync(byte[])` re-parses the entire archive from memory.
+New: Use existing `GetMetadataAsync(string filepath)` which streams from disk. Same checks (version, table count), zero memory.
+
+### Test impact
+
+Integration tests that call `ExportAsync()` switch to `ExportToFileAsync(tempFilePath)` then `File.ReadAllBytesAsync(tempFilePath)` for round-trip assertions. Same verification logic, slightly more setup.
+
+CLI `--backup` in Program.cs switches to `ExportToFileAsync(filepath)` directly — actually simpler. Pass `CancellationToken.None` or wire up `app.Lifetime.ApplicationStopping`.
+
+Unit tests for `ScheduledBackupJob` mock `IBackupService.CreateBackupWithRetentionAsync` and do not call `ExportAsync` directly — no changes needed.
+
+Blazor UI (`BackupRestore.razor`) calls `CreateBackupWithRetentionAsync` which is refactored internally — no UI code changes needed.
+
+### Encryption unchanged
+
+`BackupEncryptionService` stays `byte[] → byte[]`. AES-256-GCM requires the full plaintext in memory. The 37MB JSON + 37MB encrypted are acceptable given the overall savings.
+
+Future follow-ups could reduce the 74 MB further:
+- `JsonSerializer.SerializeAsync` to a `MemoryStream` instead of `SerializeToUtf8Bytes` (drops peak to ~37 MB by avoiding the separate JSON byte array)
+- Chunked encryption to eliminate the remaining buffer entirely
+
+## Expected impact
+
+| Metric | Before | After (estimated) |
+|---|---|---|
+| Backup peak memory | ~460 MB | ~74 MB |
+| LOH size | 395 MiB | Significantly reduced (auto-compaction + less churn) |
+| GC committed headroom | 387 MiB | Reduced by ConserveMemory pressure |
+| Gen2 > Gen0 anomaly | Yes | Should normalize (less LOH-triggered full GCs) |
+| Target RSS | 2.4 GiB | <1 GiB |
+
+If these changes don't achieve <1 GiB, next steps would be:
+- Investigate WTelegram native memory (1.5 GiB native gap)
+- Profile Npgsql connection buffer pooling
+- Consider Workstation GC as a more aggressive fallback
+- Add chunked encryption to eliminate the remaining 74 MB
+
+## Files to modify
+
+- `TelegramGroupsAdmin/Dockerfile` — add GC env vars (defaults, overridable via compose)
+- `TelegramGroupsAdmin.BackgroundJobs/Services/Backup/IBackupService.cs` — new interface methods
+- `TelegramGroupsAdmin.BackgroundJobs/Services/Backup/BackupService.cs` — streaming export, atomic write, updated retention method
+- `TelegramGroupsAdmin.BackgroundJobs/Jobs/ScheduledBackupJob.cs` — adapt to new interface
+- `TelegramGroupsAdmin/Program.cs` — CLI backup path
+- `TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs` — file-based export
+
+**No changes needed:**
+- `BackupResult.cs` — `SizeBytes` is already `long`
+- `ScheduledBackupJobTests.cs` — mocks `CreateBackupWithRetentionAsync`, doesn't touch `ExportAsync`
+- `BackupRestore.razor` — calls `CreateBackupWithRetentionAsync` (refactored internally)


### PR DESCRIPTION
## Summary
- Add GC conservation env vars to Dockerfile (`DOTNET_GCConserveMemory=7`, `DOTNET_GCHighMemPercent=70`) to enable automatic LOH compaction and earlier aggressive GC
- Refactor backup export from in-memory `byte[]` (~460 MB LOH allocations) to streaming directly to `FileStream` (~74 MB peak)
- Atomic temp file write pattern with GUID-suffixed naming and `finally` cleanup
- Interface change: `ExportAsync() → ExportToFileAsync(filepath)` across service, CLI, and tests

## Context
Production RSS was 2.4 GiB after 44 hours. LOH at 395 MiB with Gen2 > Gen0 collections. The hourly backup was allocating ~460 MB of byte arrays (JSON serialization + encryption + tar MemoryStream + ToArray copy) that fragmented the LOH. Target is <1 GiB average.

## Test plan
- [x] 3,736 tests pass (unit, component, integration, E2E)
- [x] New test: temp file cleanup after cancelled export
- [x] New test: empty/whitespace passphrase guard
- [x] Multi-agent code review (refactor advisor, test specialist, security reviewer, concurrency specialist)
- [ ] Deploy to production and monitor RSS, LOH size, GC gen counts
- [ ] If GC CPU overhead spikes, dial `DOTNET_GCConserveMemory` back to 5 via compose override