### PR TITLE
perf: add ObservableGauge instrumentation for memory attribution

### DIFF
--- a/TelegramGroupsAdmin.ContentDetection/ML/BayesClassifier.cs
+++ b/TelegramGroupsAdmin.ContentDetection/ML/BayesClassifier.cs
@@ -13,6 +13,9 @@ internal class BayesClassifier
     private int _spamMessageCount;
     private int _hamMessageCount;
 
+    public int SpamVocabularySize => _spamWordCounts.Count;
+    public int HamVocabularySize => _hamWordCounts.Count;
+
     public BayesClassifier(ITokenizerService tokenizerService)
     {
         _tokenizerService = tokenizerService;

--- a/TelegramGroupsAdmin.ContentDetection/ML/BayesClassifierMetadata.cs
+++ b/TelegramGroupsAdmin.ContentDetection/ML/BayesClassifierMetadata.cs
@@ -32,4 +32,14 @@ public sealed record BayesClassifierMetadata
     public double SpamRatio => TotalSampleCount > 0
         ? (double)SpamSampleCount / TotalSampleCount
         : 0.0;
+
+    /// <summary>
+    /// Number of unique words in the spam vocabulary.
+    /// </summary>
+    public int SpamVocabularySize { get; init; }
+
+    /// <summary>
+    /// Number of unique words in the ham vocabulary.
+    /// </summary>
+    public int HamVocabularySize { get; init; }
 }

--- a/TelegramGroupsAdmin.ContentDetection/ML/BayesClassifierService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/ML/BayesClassifierService.cs
@@ -94,7 +94,9 @@ public sealed class BayesClassifierService : IBayesClassifierService, IDisposabl
             {
                 TrainedAt = DateTimeOffset.UtcNow,
                 SpamSampleCount = spamCount,
-                HamSampleCount = hamCount
+                HamSampleCount = hamCount,
+                SpamVocabularySize = newClassifier.SpamVocabularySize,
+                HamVocabularySize = newClassifier.HamVocabularySize
             };
 
             // Log balance warning

--- a/TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs
+++ b/TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs
@@ -25,6 +25,8 @@ public class SemanticKernelChatService : IChatService
     private readonly ISystemConfigRepository _configRepository;
     private readonly ILogger<SemanticKernelChatService> _logger;
 
+    public static int CachedKernelCount => KernelCache.Count;
+
     public SemanticKernelChatService(
         ISystemConfigRepository configRepository,
         ILogger<SemanticKernelChatService> logger)

--- a/TelegramGroupsAdmin.Core/TelemetryConstants.cs
+++ b/TelegramGroupsAdmin.Core/TelemetryConstants.cs
@@ -47,6 +47,12 @@ public static class TelemetryConstants
     /// </summary>
     public static readonly Meter Metrics = new("TelegramGroupsAdmin.Metrics");
 
+    /// <summary>
+    /// Meter for memory attribution and cache size tracking.
+    /// Observable gauges on this meter help identify which components hold memory.
+    /// </summary>
+    public static readonly Meter Memory = new("TelegramGroupsAdmin.Memory");
+
     // =========================================================================
     // Counters - Monotonically increasing values
     // =========================================================================

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/ChatHealthCache.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/ChatHealthCache.cs
@@ -70,4 +70,6 @@ public class ChatHealthCache(ILogger<ChatHealthCache> logger) : IChatHealthCache
 
     public void ResetFailureCount(long chatId)
         => _failureCounts.TryRemove(chatId, out _);
+
+    public int Count => _healthCache.Count;
 }

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/IChatHealthCache.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/IChatHealthCache.cs
@@ -60,4 +60,9 @@ public interface IChatHealthCache
     /// Called on successful reachability check or after MarkInactiveAsync is invoked.
     /// </summary>
     void ResetFailureCount(long chatId);
+
+    /// <summary>
+    /// Get the number of chats currently tracked in the health cache.
+    /// </summary>
+    int Count { get; }
 }

--- a/TelegramGroupsAdmin.Telegram/Services/ChatCache.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ChatCache.cs
@@ -26,4 +26,7 @@ public class ChatCache : IChatCache
     /// <inheritdoc />
     public IReadOnlyCollection<Chat> GetAllChats()
         => _cache.Values.ToList().AsReadOnly();
+
+    /// <inheritdoc />
+    public int Count => _cache.Count;
 }

--- a/TelegramGroupsAdmin.Telegram/Services/IChatCache.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/IChatCache.cs
@@ -31,4 +31,9 @@ public interface IChatCache
     /// Get all cached chats.
     /// </summary>
     IReadOnlyCollection<Chat> GetAllChats();
+
+    /// <summary>
+    /// Get the number of chats currently in the cache.
+    /// </summary>
+    int Count { get; }
 }

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ITelegramSessionManager.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ITelegramSessionManager.cs
@@ -29,4 +29,7 @@ public interface ITelegramSessionManager : IAsyncDisposable
 
     /// <summary>Disconnect and cleanup a session. Deactivates in DB, disposes client, removes from cache.</summary>
     Task DisconnectAsync(string webUserId, Actor executor, CancellationToken ct);
+
+    /// <summary>Number of WTelegram clients currently held in the cache.</summary>
+    int ActiveClientCount { get; }
 }

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/TelegramSessionManager.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/TelegramSessionManager.cs
@@ -28,6 +28,8 @@ public sealed class TelegramSessionManager(
     private readonly ConcurrentDictionary<string, CachedClient> _clients = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _reconnectLocks = new();
 
+    public int ActiveClientCount => _clients.Count;
+
     private sealed record CachedClient(IWTelegramApiClient ApiClient, long SessionId, DatabaseSessionStream SessionStream);
 
     public async Task<IWTelegramApiClient?> GetClientAsync(string webUserId, CancellationToken ct)

--- a/TelegramGroupsAdmin/Program.cs
+++ b/TelegramGroupsAdmin/Program.cs
@@ -355,6 +355,10 @@ app.MapApiEndpoints();
 // Map Prometheus metrics endpoint (if metrics pipeline is enabled)
 if (metricsEnabled)
 {
+    // Force-resolve MemoryInstrumentation to register ObservableGauges on stateful singletons.
+    // Without this, DI never instantiates it since nothing injects it.
+    app.Services.GetRequiredService<MemoryInstrumentation>();
+
     app.MapPrometheusScrapingEndpoint();
     var activatedBy = !string.IsNullOrEmpty(otlpEndpoint)
         ? "OTEL_EXPORTER_OTLP_ENDPOINT"

--- a/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
@@ -165,6 +165,9 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<Services.Docs.IDocumentationService, Services.Docs.DocumentationService>();
             services.AddHostedService<Services.Docs.DocumentationStartupService>();
 
+            // Memory instrumentation — ObservableGauges on all stateful singletons for Prometheus/Grafana
+            services.AddSingleton<MemoryInstrumentation>();
+
             return services;
         }
 

--- a/TelegramGroupsAdmin/Services/Auth/IIntermediateAuthService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/IIntermediateAuthService.cs
@@ -39,4 +39,9 @@ public interface IIntermediateAuthService
     /// <param name="userId">The user ID that must match the token</param>
     /// <returns>True if token is valid and matches userId, false otherwise</returns>
     bool ValidateAndConsumeToken(string token, string userId);
+
+    /// <summary>
+    /// Number of pending intermediate auth tokens (for memory instrumentation).
+    /// </summary>
+    int EntryCount { get; }
 }

--- a/TelegramGroupsAdmin/Services/Auth/IPendingRecoveryCodesService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/IPendingRecoveryCodesService.cs
@@ -32,4 +32,9 @@ public interface IPendingRecoveryCodesService
     /// <param name="userId">The user ID (must match stored userId)</param>
     /// <returns>True if recovery codes are available</returns>
     bool HasRecoveryCodes(string token, string userId);
+
+    /// <summary>
+    /// Number of pending recovery code entries (for memory instrumentation).
+    /// </summary>
+    int EntryCount { get; }
 }

--- a/TelegramGroupsAdmin/Services/Auth/IRateLimitService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/IRateLimitService.cs
@@ -14,4 +14,9 @@ public interface IRateLimitService
     /// Records an attempt for rate limiting
     /// </summary>
     Task RecordAttemptAsync(string identifier, string endpointKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Number of active rate limit tracking entries (for memory instrumentation).
+    /// </summary>
+    int EntryCount { get; }
 }

--- a/TelegramGroupsAdmin/Services/Auth/IntermediateAuthService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/IntermediateAuthService.cs
@@ -13,6 +13,8 @@ public class IntermediateAuthService : IIntermediateAuthService
     private readonly ConcurrentDictionary<string, TokenData> _tokens = new();
     private readonly ILogger<IntermediateAuthService> _logger;
 
+    public int EntryCount => _tokens.Count;
+
     public IntermediateAuthService(ILogger<IntermediateAuthService> logger)
     {
         _logger = logger;

--- a/TelegramGroupsAdmin/Services/Auth/PendingRecoveryCodesService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/PendingRecoveryCodesService.cs
@@ -18,6 +18,8 @@ public class PendingRecoveryCodesService : IPendingRecoveryCodesService
     private readonly ConcurrentDictionary<string, PendingCodesData> _pendingCodes = new();
     private readonly ILogger<PendingRecoveryCodesService> _logger;
 
+    public int EntryCount => _pendingCodes.Count;
+
     public PendingRecoveryCodesService(ILogger<PendingRecoveryCodesService> logger)
     {
         _logger = logger;

--- a/TelegramGroupsAdmin/Services/Auth/RateLimitService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/RateLimitService.cs
@@ -13,6 +13,8 @@ public class RateLimitService : IRateLimitService
     private readonly ConcurrentDictionary<string, List<DateTimeOffset>> _attempts = new();
     private readonly Lock _lock = new();
 
+    public int EntryCount => _attempts.Count;
+
     // Rate limit configurations (attempts / time window)
     private static readonly Dictionary<string, (int MaxAttempts, TimeSpan Window)> RateLimits = new()
     {

--- a/TelegramGroupsAdmin/Services/MemoryInstrumentation.cs
+++ b/TelegramGroupsAdmin/Services/MemoryInstrumentation.cs
@@ -1,0 +1,106 @@
+using TelegramGroupsAdmin.ContentDetection.ML;
+using TelegramGroupsAdmin.Core.Services.AI;
+using TelegramGroupsAdmin.Core.Telemetry;
+using TelegramGroupsAdmin.Services.Auth;
+using TelegramGroupsAdmin.Services.Docs;
+using TelegramGroupsAdmin.Telegram.Services;
+using TelegramGroupsAdmin.Telegram.Services.Bot;
+using TelegramGroupsAdmin.Telegram.Services.Media;
+using TelegramGroupsAdmin.Telegram.Services.UserApi;
+
+namespace TelegramGroupsAdmin.Services;
+
+/// <summary>
+/// Registers ObservableGauge instruments on every stateful singleton to enable
+/// per-component memory attribution in Prometheus/Grafana.
+/// Gauges are pull-based — callbacks only fire on /metrics scrape, zero overhead between scrapes.
+/// </summary>
+public sealed class MemoryInstrumentation
+{
+    public MemoryInstrumentation(
+        IChatCache chatCache,
+        IChatHealthCache chatHealthCache,
+        ITelegramSessionManager sessionManager,
+        IMediaRefetchQueueService mediaRefetchQueue,
+        IDocumentationService documentationService,
+        IRateLimitService rateLimitService,
+        IIntermediateAuthService intermediateAuthService,
+        IPendingRecoveryCodesService pendingRecoveryCodesService,
+        IMLTextClassifierService mlClassifier,
+        IBayesClassifierService bayesClassifier)
+    {
+        var meter = TelemetryConstants.Memory;
+
+        // --- Telegram caches ---
+        meter.CreateObservableGauge(
+            "tga.cache.chat.count",
+            () => chatCache.Count,
+            description: "Number of Telegram Chat objects in ChatCache");
+
+        meter.CreateObservableGauge(
+            "tga.cache.chat_health.count",
+            () => chatHealthCache.Count,
+            description: "Number of entries in ChatHealthCache");
+
+        // --- WTelegram session manager ---
+        meter.CreateObservableGauge(
+            "tga.sessions.client.count",
+            () => sessionManager.ActiveClientCount,
+            description: "Number of active WTelegram client connections");
+
+        // --- Media refetch queue ---
+        meter.CreateObservableGauge(
+            "tga.queue.media_refetch.depth",
+            () => mediaRefetchQueue.GetQueueDepth(),
+            description: "Number of in-flight media refetch requests");
+
+        // --- Documentation cache ---
+        meter.CreateObservableGauge(
+            "tga.cache.docs.initialized",
+            () => documentationService.IsInitialized ? 1 : 0,
+            description: "Whether the documentation cache has been loaded (1=yes, 0=no)");
+
+        // --- Auth state ---
+        meter.CreateObservableGauge(
+            "tga.cache.rate_limit.count",
+            () => rateLimitService.EntryCount,
+            description: "Number of active rate limit tracking entries");
+
+        meter.CreateObservableGauge(
+            "tga.cache.auth_tokens.count",
+            () => intermediateAuthService.EntryCount,
+            description: "Number of pending intermediate auth tokens");
+
+        meter.CreateObservableGauge(
+            "tga.cache.recovery_codes.count",
+            () => pendingRecoveryCodesService.EntryCount,
+            description: "Number of pending recovery code entries");
+
+        // --- ML models ---
+        meter.CreateObservableGauge(
+            "tga.ml.sdca.loaded",
+            () => mlClassifier.GetMetadata() is not null ? 1 : 0,
+            description: "Whether the ML.NET SDCA spam model is loaded (1=yes, 0=no)");
+
+        meter.CreateObservableGauge(
+            "tga.ml.bayes.loaded",
+            () => bayesClassifier.GetMetadata() is not null ? 1 : 0,
+            description: "Whether the Bayes spam model is loaded (1=yes, 0=no)");
+
+        meter.CreateObservableGauge(
+            "tga.ml.bayes.vocab.spam",
+            () => bayesClassifier.GetMetadata()?.SpamVocabularySize ?? 0,
+            description: "Number of unique words in the Bayes spam vocabulary");
+
+        meter.CreateObservableGauge(
+            "tga.ml.bayes.vocab.ham",
+            () => bayesClassifier.GetMetadata()?.HamVocabularySize ?? 0,
+            description: "Number of unique words in the Bayes ham vocabulary");
+
+        // --- Semantic Kernel cache (static) ---
+        meter.CreateObservableGauge(
+            "tga.cache.kernel.count",
+            () => SemanticKernelChatService.CachedKernelCount,
+            description: "Number of cached Semantic Kernel instances");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `TelegramGroupsAdmin.Memory` meter with 13 `ObservableGauge` instruments across all stateful singletons
- Enables per-component memory attribution when paired with Prometheus + Grafana
- Gauges are pull-based (zero overhead between scrapes), auto-exported via existing wildcard `.AddMeter("TelegramGroupsAdmin.*")`

### Instrumented components

| Gauge | Source |
|-------|--------|
| `tga.cache.chat.count` | ChatCache |
| `tga.cache.chat_health.count` | ChatHealthCache |
| `tga.sessions.client.count` | TelegramSessionManager |
| `tga.queue.media_refetch.depth` | MediaRefetchQueueService |
| `tga.cache.docs.initialized` | DocumentationService |
| `tga.cache.rate_limit.count` | RateLimitService |
| `tga.cache.auth_tokens.count` | IntermediateAuthService |
| `tga.cache.recovery_codes.count` | PendingRecoveryCodesService |
| `tga.ml.sdca.loaded` | MLTextClassifierService |
| `tga.ml.bayes.loaded` | BayesClassifierService |
| `tga.ml.bayes.vocab.spam` | BayesClassifier vocabulary |
| `tga.ml.bayes.vocab.ham` | BayesClassifier vocabulary |
| `tga.cache.kernel.count` | SemanticKernelChatService |

### Context

After PR #420 (streaming backup + GC tuning), RSS dropped from 2 GB to ~750 MB settled / 1.3 GB peak. However, 20-hour production data shows Gen2 and LOH still growing ~10-15 MiB/hour with Gen2 collections nearly matching Gen0 (63:69). Something is holding references. These gauges let us correlate per-component cache sizes with the GC growth curve in Grafana to identify the source. Prometheus + Grafana are already set up on prod waiting for this to merge.

## Code review findings

Four-agent parallel review (refactor, test, security, concurrency). Summary of findings and dispositions:

### Not fixing (by design)

| Finding | Disposition |
|---------|------------|
| **Discarded `ObservableGauge` return values risk GC collection** | False positive. [Microsoft docs](https://learn.microsoft.com/dotnet/core/diagnostics/metrics-instrumentation#types-of-instruments) explicitly state "in most cases you don't need to save it in a variable." `Meter` holds instruments via strong references (`List<Instrument>`), not weak references. The docs warn only about static lazy initialization — not our pattern (constructor-based). |
| **`SemanticKernelChatService.CachedKernelCount` bypasses DI** | Intentional. The kernel cache is a `private static ConcurrentDictionary` — exposing a static property is the correct way to access it without polluting `IChatService` with an implementation detail. |
| **Gauge naming (dotted) diverges from existing metrics (flat underscore)** | The new names follow [OpenTelemetry naming guidelines](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md). The existing flat names are legacy. Not renaming existing instruments in this PR. |
| **Three separate `GetMetadata()` calls per Bayes scrape could produce inconsistent triplet** | Cosmetic only. Metadata is an immutable record published via `volatile` + `Interlocked.Exchange`. A model swap mid-scrape would show stale-but-valid data for one 15s interval. |
| **`GetQueueDepth()` is a method, not a property** | Pre-existing on `IMediaRefetchQueueService`. Not changing in this PR. |
| **`RateLimitService` / `IntermediateAuthService` lack unit tests** | Pre-existing gap, not introduced by this PR. |
| **`MemoryInstrumentation` has no tests** | Constructor-only class with no conditional logic. Static `Meter` prevents repeated instrument registration in-process. Acceptable for now. |

### Security

No issues. All gauges expose aggregate integer counts only — no PII, no token values, no chat IDs. Consistent with existing unauthenticated `/metrics` endpoint access model.

### Concurrency

All `Count`/`EntryCount` reads are on `ConcurrentDictionary` (atomic). Bayes vocabulary sizes read from immutable metadata records, not live dictionaries. No race conditions.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] Full test suite — 3,739 tests passed (1,834 unit + 1,042 component + 578 integration + 285 E2E)
- [ ] Deploy to prod, verify `tga_*` gauges appear on `/metrics` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)