### PR TITLE
feat: metrics expansion — 9 domain-scoped classes with ~58 instruments

### DIFF
--- a/TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Constants;
 using TelegramGroupsAdmin.BackgroundJobs.Jobs;
 using TelegramGroupsAdmin.BackgroundJobs.Listeners;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.BackgroundJobs.Services;
 using TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
 using TelegramGroupsAdmin.BackgroundJobs.Services.Backup.Handlers;
@@ -27,6 +28,9 @@ public static class ServiceCollectionExtensions
 
         // Register ad-hoc job scheduler (for one-time delayed jobs)
         services.AddSingleton<Core.BackgroundJobs.IJobScheduler, QuartzJobScheduler>();
+
+        // Register job metrics
+        services.AddSingleton<JobMetrics>();
 
         // Register Backup services
         services.AddBackupServices();

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/BayesClassifierRetrainingJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/BayesClassifierRetrainingJob.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.ContentDetection.ML;
-using TelegramGroupsAdmin.Core.Telemetry;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -16,13 +16,16 @@ public class BayesClassifierRetrainingJob : IJob
 {
     private readonly IBayesClassifierService _bayesClassifier;
     private readonly ILogger<BayesClassifierRetrainingJob> _logger;
+    private readonly JobMetrics _jobMetrics;
 
     public BayesClassifierRetrainingJob(
         IBayesClassifierService bayesClassifier,
-        ILogger<BayesClassifierRetrainingJob> logger)
+        ILogger<BayesClassifierRetrainingJob> logger,
+        JobMetrics jobMetrics)
     {
         _bayesClassifier = bayesClassifier;
         _logger = logger;
+        _jobMetrics = jobMetrics;
     }
 
     public async Task Execute(IJobExecutionContext context)
@@ -61,15 +64,7 @@ public class BayesClassifierRetrainingJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/BlocklistSyncJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/BlocklistSyncJob.cs
@@ -2,8 +2,8 @@ using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
-using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Core.JobPayloads;
 using TelegramGroupsAdmin.ContentDetection.Services.Blocklists;
 
@@ -18,13 +18,16 @@ public class BlocklistSyncJob : IJob
 {
     private readonly IBlocklistSyncService _syncService;
     private readonly ILogger<BlocklistSyncJob> _logger;
+    private readonly JobMetrics _jobMetrics;
 
     public BlocklistSyncJob(
         IBlocklistSyncService syncService,
-        ILogger<BlocklistSyncJob> logger)
+        ILogger<BlocklistSyncJob> logger,
+        JobMetrics jobMetrics)
     {
         _syncService = syncService;
         _logger = logger;
+        _jobMetrics = jobMetrics;
     }
 
     /// <summary>
@@ -101,16 +104,7 @@ public class BlocklistSyncJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/ChatHealthCheckJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/ChatHealthCheckJob.cs
@@ -2,11 +2,11 @@ using System.Text.Json;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Configuration;
 using TelegramGroupsAdmin.Configuration.Models;
 using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
-using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Core.JobPayloads;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Telegram.Services;
@@ -23,15 +23,18 @@ public class ChatHealthCheckJob : IJob
     private readonly IChatHealthRefreshOrchestrator _chatHealthRefreshOrchestrator;
     private readonly IConfigService _configService;
     private readonly ILogger<ChatHealthCheckJob> _logger;
+    private readonly JobMetrics _jobMetrics;
 
     public ChatHealthCheckJob(
         IChatHealthRefreshOrchestrator chatHealthRefreshOrchestrator,
         IConfigService configService,
-        ILogger<ChatHealthCheckJob> logger)
+        ILogger<ChatHealthCheckJob> logger,
+        JobMetrics jobMetrics)
     {
         _chatHealthRefreshOrchestrator = chatHealthRefreshOrchestrator;
         _configService = configService;
         _logger = logger;
+        _jobMetrics = jobMetrics;
     }
 
     /// <summary>
@@ -112,16 +115,7 @@ public class ChatHealthCheckJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
@@ -44,10 +44,11 @@ public class DataCleanupJob : IJob
         const string jobName = BackgroundJobNames.DataCleanup;
         var startTimestamp = Stopwatch.GetTimestamp();
         var success = false;
+        long totalRowsDeleted = 0;
 
         try
         {
-            await ExecuteCleanupAsync(context.CancellationToken);
+            totalRowsDeleted = await ExecuteCleanupAsync(context.CancellationToken);
             success = true;
         }
         catch (Exception ex)
@@ -59,10 +60,11 @@ public class DataCleanupJob : IJob
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
             _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
+            _jobMetrics.RecordRowsAffected(jobName, totalRowsDeleted);
         }
     }
 
-    private async Task ExecuteCleanupAsync(CancellationToken cancellationToken)
+    private async Task<long> ExecuteCleanupAsync(CancellationToken cancellationToken)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var sp = scope.ServiceProvider;
@@ -80,25 +82,28 @@ public class DataCleanupJob : IJob
 
         _logger.LogInformation("Data cleanup job started");
 
+        long totalDeleted = 0;
+
         // 1. Clean up expired messages + disk files
-        await CleanupMessagesAsync(sp, messageRetention, cancellationToken);
+        totalDeleted += await CleanupMessagesAsync(sp, messageRetention, cancellationToken);
 
         // 2. Clean up old resolved reports
-        await CleanupReportsAsync(sp, reportRetention, cancellationToken);
+        totalDeleted += await CleanupReportsAsync(sp, reportRetention, cancellationToken);
 
         // 3. Clean up expired DM callback contexts
-        await CleanupCallbackContextsAsync(sp, contextRetention, cancellationToken);
+        totalDeleted += await CleanupCallbackContextsAsync(sp, contextRetention, cancellationToken);
 
         // 4. Clean up old read web notifications
-        await CleanupNotificationsAsync(sp, notificationRetention, cancellationToken);
+        totalDeleted += await CleanupNotificationsAsync(sp, notificationRetention, cancellationToken);
 
         // 5. Clean up expired file scan results
-        await CleanupFileScanResultsAsync(sp, fileScanRetention, cancellationToken);
+        totalDeleted += await CleanupFileScanResultsAsync(sp, fileScanRetention, cancellationToken);
 
         _logger.LogInformation("Data cleanup job completed");
+        return totalDeleted;
     }
 
-    private async Task CleanupMessagesAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
+    private async Task<long> CleanupMessagesAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var repository = sp.GetRequiredService<IMessageHistoryRepository>();
         var result = await repository.CleanupExpiredAsync(retention, cancellationToken);
@@ -155,9 +160,11 @@ public class DataCleanupJob : IJob
             result.OldestTimestamp.HasValue
                 ? result.OldestTimestamp.Value.ToString("g")
                 : "none");
+
+        return result.DeletedCount;
     }
 
-    private async Task CleanupReportsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
+    private async Task<long> CleanupReportsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var reportsRepo = sp.GetRequiredService<IReportsRepository>();
         var reportsCutoff = DateTimeOffset.UtcNow - retention;
@@ -170,9 +177,11 @@ public class DataCleanupJob : IJob
                 reportsDeleted,
                 TimeSpanUtilities.FormatDuration(retention));
         }
+
+        return reportsDeleted;
     }
 
-    private async Task CleanupCallbackContextsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
+    private async Task<long> CleanupCallbackContextsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var callbackContextRepo = sp.GetRequiredService<IReportCallbackContextRepository>();
         var contextsDeleted = await callbackContextRepo.DeleteExpiredAsync(retention, cancellationToken);
@@ -184,9 +193,11 @@ public class DataCleanupJob : IJob
                 contextsDeleted,
                 TimeSpanUtilities.FormatDuration(retention));
         }
+
+        return contextsDeleted;
     }
 
-    private async Task CleanupNotificationsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
+    private async Task<long> CleanupNotificationsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         // Use repository directly - it's the domain expert for notification data
         var notificationRepo = sp.GetRequiredService<IWebNotificationRepository>();
@@ -199,9 +210,11 @@ public class DataCleanupJob : IJob
                 notificationsDeleted,
                 TimeSpanUtilities.FormatDuration(retention));
         }
+
+        return notificationsDeleted;
     }
 
-    private async Task CleanupFileScanResultsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
+    private async Task<long> CleanupFileScanResultsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var fileScanRepo = sp.GetRequiredService<IFileScanResultRepository>();
         var deleted = await fileScanRepo.CleanupExpiredResultsAsync(retention, cancellationToken);
@@ -213,5 +226,7 @@ public class DataCleanupJob : IJob
                 deleted,
                 TimeSpanUtilities.FormatDuration(retention));
         }
+
+        return deleted;
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
@@ -3,14 +3,14 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
+using TelegramGroupsAdmin.BackgroundJobs.Services;
 using TelegramGroupsAdmin.Configuration;
+using TelegramGroupsAdmin.ContentDetection.Repositories;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
 using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
-using TelegramGroupsAdmin.ContentDetection.Repositories;
 using TelegramGroupsAdmin.Core.Repositories;
-using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Core.Utilities;
-using TelegramGroupsAdmin.BackgroundJobs.Services;
 using TelegramGroupsAdmin.Telegram.Repositories;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
@@ -25,15 +25,18 @@ public class DataCleanupJob : IJob
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly string _dataPath;
     private readonly ILogger<DataCleanupJob> _logger;
+    private readonly JobMetrics _jobMetrics;
 
     public DataCleanupJob(
         IServiceScopeFactory scopeFactory,
         IOptions<AppOptions> appOptions,
-        ILogger<DataCleanupJob> logger)
+        ILogger<DataCleanupJob> logger,
+        JobMetrics jobMetrics)
     {
         _scopeFactory = scopeFactory;
         _dataPath = appOptions.Value.DataPath;
         _logger = logger;
+        _jobMetrics = jobMetrics;
     }
 
     public async Task Execute(IJobExecutionContext context)
@@ -55,15 +58,7 @@ public class DataCleanupJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DatabaseMaintenanceJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DatabaseMaintenanceJob.cs
@@ -4,8 +4,8 @@ using Microsoft.Extensions.Logging;
 using Npgsql;
 using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Constants;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
-using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Core.JobPayloads;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
@@ -19,11 +19,13 @@ public class DatabaseMaintenanceJob : IJob
 {
     private readonly ILogger<DatabaseMaintenanceJob> _logger;
     private readonly NpgsqlDataSource _dataSource;
+    private readonly JobMetrics _jobMetrics;
 
-    public DatabaseMaintenanceJob(ILogger<DatabaseMaintenanceJob> logger, NpgsqlDataSource dataSource)
+    public DatabaseMaintenanceJob(ILogger<DatabaseMaintenanceJob> logger, NpgsqlDataSource dataSource, JobMetrics jobMetrics)
     {
         _logger = logger;
         _dataSource = dataSource;
+        _jobMetrics = jobMetrics;
     }
 
     public async Task Execute(IJobExecutionContext context)
@@ -108,16 +110,7 @@ public class DatabaseMaintenanceJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DeleteMessageJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DeleteMessageJob.cs
@@ -2,9 +2,9 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Helpers;
-using TelegramGroupsAdmin.Core.Telemetry;
-using TelegramGroupsAdmin.Telegram.Services.Bot;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.Telegram.Services.Bot;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -15,7 +15,8 @@ namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 /// </summary>
 public class DeleteMessageJob(
     ILogger<DeleteMessageJob> logger,
-    IBotMessageService messageService) : IJob
+    IBotMessageService messageService,
+    JobMetrics jobMetrics) : IJob
 {
     /// <summary>
     /// Execute delayed message deletion (Quartz.NET entry point)
@@ -71,16 +72,7 @@ public class DeleteMessageJob(
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DeleteUserMessagesJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DeleteUserMessagesJob.cs
@@ -2,10 +2,10 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Helpers;
-using TelegramGroupsAdmin.Core.Telemetry;
-using TelegramGroupsAdmin.Telegram.Services.Bot;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Core.JobPayloads;
 using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services.Bot;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -17,7 +17,8 @@ namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 public class DeleteUserMessagesJob(
     ILogger<DeleteUserMessagesJob> logger,
     IBotMessageService messageService,
-    IMessageHistoryRepository messageHistoryRepository) : IJob
+    IMessageHistoryRepository messageHistoryRepository,
+    JobMetrics jobMetrics) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
@@ -36,6 +37,7 @@ public class DeleteUserMessagesJob(
         const string jobName = "DeleteUserMessages";
         var startTimestamp = Stopwatch.GetTimestamp();
         var success = false;
+        var deletedCount = 0;
         var user = payload.User;
 
         try
@@ -63,7 +65,6 @@ public class DeleteUserMessagesJob(
                 userMessages.Count,
                 user.DisplayName, user.Id);
 
-            var deletedCount = 0;
             var failedCount = 0;
             var skippedCount = 0;
 
@@ -141,16 +142,8 @@ public class DeleteUserMessagesJob(
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
+            jobMetrics.RecordRowsAffected(jobName, deletedCount);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/FetchUserPhotoJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/FetchUserPhotoJob.cs
@@ -3,15 +3,15 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Helpers;
-using TelegramGroupsAdmin.Core.Services;
-using TelegramGroupsAdmin.Core.Telemetry;
-using TelegramGroupsAdmin.Core.Utilities;
-using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Configuration;
 using TelegramGroupsAdmin.Configuration.Models;
+using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.Core.Services;
+using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Extensions;
-using TelegramGroupsAdmin.Telegram.Services;
 using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -27,7 +27,8 @@ public class FetchUserPhotoJob(
     ITelegramUserRepository telegramUserRepository,
     IPhotoHashService photoHashService,
     IConfigService configService,
-    IOptions<AppOptions> appOptions) : IJob
+    IOptions<AppOptions> appOptions,
+    JobMetrics jobMetrics) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
@@ -148,16 +149,7 @@ public class FetchUserPhotoJob(
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/FileScanJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/FileScanJob.cs
@@ -4,13 +4,13 @@ using Quartz;
 using Telegram.Bot.Exceptions;
 using TelegramGroupsAdmin.BackgroundJobs.Constants;
 using TelegramGroupsAdmin.BackgroundJobs.Helpers;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.ContentDetection.Abstractions;
 using TelegramGroupsAdmin.ContentDetection.Constants;
 using TelegramGroupsAdmin.ContentDetection.Models;
 using TelegramGroupsAdmin.ContentDetection.Repositories;
-using TelegramGroupsAdmin.Core.Telemetry;
-using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 
@@ -34,7 +34,8 @@ public class FileScanJob(
     IEnumerable<IContentCheckV2> contentChecks,
     ITelegramUserRepository telegramUserRepository,
     IMessageHistoryRepository messageHistoryRepository,
-    IDetectionResultsRepository detectionResultsRepository) : IJob
+    IDetectionResultsRepository detectionResultsRepository,
+    JobMetrics jobMetrics) : IJob
 {
     private readonly IContentCheckV2 _fileScanningCheck = contentChecks.First(c => c.CheckName == CheckName.FileScanning);
 
@@ -207,16 +208,7 @@ public class FileScanJob(
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/ProfileRescanJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/ProfileRescanJob.cs
@@ -1,11 +1,11 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.BackgroundJobs.Services;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
-using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services.UserApi;
@@ -23,7 +23,8 @@ public class ProfileRescanJob(
     IBackgroundJobConfigService jobConfigService,
     ITelegramSessionManager sessionManager,
     ITelegramUserRepository userRepository,
-    IProfileScanService profileScanService) : IJob
+    IProfileScanService profileScanService,
+    JobMetrics jobMetrics) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
@@ -122,15 +123,7 @@ public class ProfileRescanJob(
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/ProfileScanJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/ProfileScanJob.cs
@@ -2,9 +2,9 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Helpers;
-using TelegramGroupsAdmin.Core.Models;
-using TelegramGroupsAdmin.Core.Telemetry;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Telegram.Services.UserApi;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
@@ -17,7 +17,8 @@ namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 public class ProfileScanJob(
     ILogger<ProfileScanJob> logger,
     IProfileScanService profileScanService,
-    ITelegramSessionManager sessionManager) : IJob
+    ITelegramSessionManager sessionManager,
+    JobMetrics jobMetrics) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
@@ -68,15 +69,7 @@ public class ProfileScanJob(
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/RefreshUserPhotosJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/RefreshUserPhotosJob.cs
@@ -3,14 +3,14 @@ using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Configuration;
 using TelegramGroupsAdmin.Configuration.Models;
-using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
-using TelegramGroupsAdmin.Core.Telemetry;
-using TelegramGroupsAdmin.Telegram.Services.Media;
 using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services.Media;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -23,13 +23,16 @@ public class RefreshUserPhotosJob : IJob
 {
     private readonly ILogger<RefreshUserPhotosJob> _logger;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly JobMetrics _jobMetrics;
 
     public RefreshUserPhotosJob(
         ILogger<RefreshUserPhotosJob> logger,
-        IServiceScopeFactory scopeFactory)
+        IServiceScopeFactory scopeFactory,
+        JobMetrics jobMetrics)
     {
         _logger = logger;
         _scopeFactory = scopeFactory;
+        _jobMetrics = jobMetrics;
     }
 
     /// <summary>
@@ -117,16 +120,7 @@ public class RefreshUserPhotosJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/RotateBackupPassphraseJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/RotateBackupPassphraseJob.cs
@@ -2,11 +2,11 @@ using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Quartz;
-using TelegramGroupsAdmin.Core.Models;
-using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.BackgroundJobs.Helpers;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
 using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.Core.Models;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -22,19 +22,22 @@ public class RotateBackupPassphraseJob : IJob
     private readonly IPassphraseManagementService _passphraseService;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<RotateBackupPassphraseJob> _logger;
+    private readonly JobMetrics _jobMetrics;
 
     public RotateBackupPassphraseJob(
         IBackupEncryptionService encryptionService,
         IBackupService backupService,
         IPassphraseManagementService passphraseService,
         IServiceScopeFactory scopeFactory,
-        ILogger<RotateBackupPassphraseJob> logger)
+        ILogger<RotateBackupPassphraseJob> logger,
+        JobMetrics jobMetrics)
     {
         _encryptionService = encryptionService;
         _backupService = backupService;
         _passphraseService = passphraseService;
         _scopeFactory = scopeFactory;
         _logger = logger;
+        _jobMetrics = jobMetrics;
     }
 
     /// <summary>
@@ -201,16 +204,7 @@ public class RotateBackupPassphraseJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/ScheduledBackupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/ScheduledBackupJob.cs
@@ -4,12 +4,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Constants;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.BackgroundJobs.Services;
 using TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
-using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
-using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -22,13 +22,16 @@ public class ScheduledBackupJob : IJob
 {
     private readonly ILogger<ScheduledBackupJob> _logger;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly JobMetrics _jobMetrics;
 
     public ScheduledBackupJob(
         ILogger<ScheduledBackupJob> logger,
-        IServiceScopeFactory scopeFactory)
+        IServiceScopeFactory scopeFactory,
+        JobMetrics jobMetrics)
     {
         _logger = logger;
         _scopeFactory = scopeFactory;
+        _jobMetrics = jobMetrics;
     }
 
     public async Task Execute(IJobExecutionContext context)
@@ -131,16 +134,7 @@ public class ScheduledBackupJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/TempbanExpiryJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/TempbanExpiryJob.cs
@@ -2,10 +2,10 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Helpers;
-using TelegramGroupsAdmin.Core.Telemetry;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
+using TelegramGroupsAdmin.Core.JobPayloads;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
-using TelegramGroupsAdmin.Core.JobPayloads;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -17,7 +17,8 @@ namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 /// </summary>
 public class TempbanExpiryJob(
     ILogger<TempbanExpiryJob> logger,
-    IBotModerationService moderationService) : IJob
+    IBotModerationService moderationService,
+    JobMetrics jobMetrics) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
@@ -89,16 +90,7 @@ public class TempbanExpiryJob(
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/TextClassifierRetrainingJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/TextClassifierRetrainingJob.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Quartz;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.ContentDetection.ML;
-using TelegramGroupsAdmin.Core.Telemetry;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -16,13 +16,16 @@ public class TextClassifierRetrainingJob : IJob
 {
     private readonly IMLTextClassifierService _mlClassifier;
     private readonly ILogger<TextClassifierRetrainingJob> _logger;
+    private readonly JobMetrics _jobMetrics;
 
     public TextClassifierRetrainingJob(
         IMLTextClassifierService mlClassifier,
-        ILogger<TextClassifierRetrainingJob> logger)
+        ILogger<TextClassifierRetrainingJob> logger,
+        JobMetrics jobMetrics)
     {
         _mlClassifier = mlClassifier;
         _logger = logger;
+        _jobMetrics = jobMetrics;
     }
 
     /// <summary>
@@ -65,16 +68,7 @@ public class TextClassifierRetrainingJob : IJob
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            _jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 }

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/WelcomeTimeoutJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/WelcomeTimeoutJob.cs
@@ -8,6 +8,7 @@ using TelegramGroupsAdmin.Core.Extensions;
 using TelegramGroupsAdmin.Core.JobPayloads;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
@@ -25,7 +26,8 @@ public class WelcomeTimeoutJob(
     IBotModerationService moderationService,
     IBotMessageService messageService,
     IExamSessionRepository examSessionRepository,
-    JobMetrics jobMetrics) : IJob
+    JobMetrics jobMetrics,
+    WelcomeMetrics welcomeMetrics) : IJob
 {
 
     /// <summary>
@@ -154,6 +156,9 @@ public class WelcomeTimeoutJob(
             response.Response = Data.Models.WelcomeResponseType.Timeout;
             response.RespondedAt = DateTimeOffset.UtcNow;
             await dbContext.SaveChangesAsync(cancellationToken);
+
+            welcomeMetrics.RecordWelcomeTimeout();
+            welcomeMetrics.RecordWelcomeOutcome("timed_out", Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
 
             logger.LogInformation(
                 "Recorded welcome timeout for {User} in {Chat}",

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/WelcomeTimeoutJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/WelcomeTimeoutJob.cs
@@ -3,14 +3,14 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using TelegramGroupsAdmin.BackgroundJobs.Helpers;
-using TelegramGroupsAdmin.Core.Telemetry;
-using TelegramGroupsAdmin.Data;
-using TelegramGroupsAdmin.Telegram.Services.Bot;
-using TelegramGroupsAdmin.Telegram.Services.Moderation;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Core.Extensions;
 using TelegramGroupsAdmin.Core.JobPayloads;
 using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Data;
 using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services.Bot;
+using TelegramGroupsAdmin.Telegram.Services.Moderation;
 
 namespace TelegramGroupsAdmin.BackgroundJobs.Jobs;
 
@@ -24,7 +24,8 @@ public class WelcomeTimeoutJob(
     IDbContextFactory<AppDbContext> contextFactory,
     IBotModerationService moderationService,
     IBotMessageService messageService,
-    IExamSessionRepository examSessionRepository) : IJob
+    IExamSessionRepository examSessionRepository,
+    JobMetrics jobMetrics) : IJob
 {
 
     /// <summary>
@@ -173,16 +174,7 @@ public class WelcomeTimeoutJob(
         finally
         {
             var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
-
-            // Record metrics (using TagList to avoid boxing/allocations)
-            var tags = new TagList
-            {
-                { "job_name", jobName },
-                { "status", success ? "success" : "failure" }
-            };
-
-            TelemetryConstants.JobExecutions.Add(1, tags);
-            TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+            jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
         }
     }
 

--- a/TelegramGroupsAdmin.BackgroundJobs/Metrics/JobMetrics.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Metrics/JobMetrics.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace TelegramGroupsAdmin.BackgroundJobs.Metrics;
+
+/// <summary>
+/// Metrics for Quartz.NET background job execution.
+/// Replaces flat counters from TelemetryConstants.
+/// </summary>
+public sealed class JobMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Jobs");
+
+    private readonly Counter<long> _executionsTotal;
+    private readonly Histogram<double> _duration;
+    private readonly Counter<long> _rowsAffectedTotal;
+
+    public JobMetrics()
+    {
+        _executionsTotal = _meter.CreateCounter<long>(
+            "tga.jobs.executions_total",
+            description: "Job execution counts by name and status");
+
+        _duration = _meter.CreateHistogram<double>(
+            "tga.jobs.duration",
+            unit: "ms",
+            description: "Job execution time by name");
+
+        _rowsAffectedTotal = _meter.CreateCounter<long>(
+            "tga.jobs.rows_affected_total",
+            description: "Rows deleted or processed by cleanup jobs");
+    }
+
+    public void RecordJobExecution(string jobName, bool success, double durationMs)
+    {
+        var tags = new TagList
+        {
+            { "job_name", jobName },
+            { "status", success ? "success" : "failure" }
+        };
+        _executionsTotal.Add(1, tags);
+        _duration.Record(durationMs, new TagList { { "job_name", jobName } });
+    }
+
+    public void RecordRowsAffected(string jobName, long count)
+    {
+        if (count > 0)
+            _rowsAffectedTotal.Add(count, new TagList { { "job_name", jobName } });
+    }
+}

--- a/TelegramGroupsAdmin.ContentDetection/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using TelegramGroupsAdmin.ContentDetection.Abstractions;
+using TelegramGroupsAdmin.ContentDetection.Metrics;
 using TelegramGroupsAdmin.ContentDetection.ML;
 using TelegramGroupsAdmin.ContentDetection.Services;
 using TelegramGroupsAdmin.ContentDetection.Services.Blocklists;
@@ -34,6 +35,9 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<IImageTextExtractionService, ImageTextExtractionService>(); // ML-5: OCR service (Singleton: binary path lookup happens once)
             services.AddSingleton<IVideoFrameExtractionService, VideoFrameExtractionService>(); // ML-6: FFmpeg frame extraction (Singleton: binary path lookup happens once)
                                                                                                 // NOTE: IMessageContextProvider is registered by the main app (MessageContextAdapter)
+
+            // Register domain metrics
+            services.AddSingleton<DetectionMetrics>();
 
             // Register repositories (needed by engine for config)
             services.AddScoped<IContentDetectionConfigRepository, ContentDetectionConfigRepository>();

--- a/TelegramGroupsAdmin.ContentDetection/Metrics/DetectionMetrics.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Metrics/DetectionMetrics.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace TelegramGroupsAdmin.ContentDetection.Metrics;
+
+/// <summary>
+/// Metrics for spam detection, file scanning, and OpenAI veto tracking.
+/// Replaces flat counters/histograms from TelemetryConstants.
+/// </summary>
+public sealed class DetectionMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Detection");
+
+    private readonly Counter<long> _spamTotal;
+    private readonly Histogram<double> _algorithmDuration;
+    private readonly Counter<long> _fileScanTotal;
+    private readonly Histogram<double> _fileScanDuration;
+    private readonly Counter<long> _vetoTotal;
+
+    public DetectionMetrics()
+    {
+        _spamTotal = _meter.CreateCounter<long>(
+            "tga.detection.spam_total",
+            description: "Per-algorithm spam detection counts");
+
+        _algorithmDuration = _meter.CreateHistogram<double>(
+            "tga.detection.algorithm.duration",
+            unit: "ms",
+            description: "Per-algorithm execution time");
+
+        _fileScanTotal = _meter.CreateCounter<long>(
+            "tga.detection.file_scan_total",
+            description: "File scan results by tier and outcome");
+
+        _fileScanDuration = _meter.CreateHistogram<double>(
+            "tga.detection.file_scan.duration",
+            unit: "ms",
+            description: "File scan latency by tier");
+
+        _vetoTotal = _meter.CreateCounter<long>(
+            "tga.detection.veto_total",
+            description: "OpenAI veto count per algorithm");
+    }
+
+    public void RecordSpamDetection(string algorithm, string result, double durationMs)
+    {
+        var tags = new TagList
+        {
+            { "algorithm", algorithm },
+            { "result", result }
+        };
+        _spamTotal.Add(1, tags);
+        _algorithmDuration.Record(durationMs, new TagList { { "algorithm", algorithm } });
+    }
+
+    public void RecordFileScan(string tier, bool isMalicious, double durationMs)
+    {
+        var tags = new TagList
+        {
+            { "tier", tier },
+            { "result", isMalicious ? "malicious" : "clean" }
+        };
+        _fileScanTotal.Add(1, tags);
+        _fileScanDuration.Record(durationMs, new TagList { { "tier", tier } });
+    }
+
+    public void RecordVeto(string algorithm)
+    {
+        _vetoTotal.Add(1, new TagList { { "algorithm", algorithm } });
+    }
+}

--- a/TelegramGroupsAdmin.ContentDetection/Services/ClamAVScannerService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/ClamAVScannerService.cs
@@ -5,6 +5,7 @@ using nClam;
 using TelegramGroupsAdmin.Configuration.Models;
 using TelegramGroupsAdmin.Configuration.Repositories;
 using TelegramGroupsAdmin.ContentDetection.Constants;
+using TelegramGroupsAdmin.ContentDetection.Metrics;
 using TelegramGroupsAdmin.Core.Telemetry;
 
 namespace TelegramGroupsAdmin.ContentDetection.Services;
@@ -17,6 +18,7 @@ public class ClamAVScannerService : IFileScannerService
 {
     private readonly ILogger<ClamAVScannerService> _logger;
     private readonly ISystemConfigRepository _configRepository;
+    private readonly DetectionMetrics _detectionMetrics;
 
     /// <summary>
     /// Guards the one-time INFO log for env var override. Static because this service is Scoped
@@ -30,10 +32,12 @@ public class ClamAVScannerService : IFileScannerService
 
     public ClamAVScannerService(
         ILogger<ClamAVScannerService> logger,
-        ISystemConfigRepository configRepository)
+        ISystemConfigRepository configRepository,
+        DetectionMetrics detectionMetrics)
     {
         _logger = logger;
         _configRepository = configRepository;
+        _detectionMetrics = detectionMetrics;
     }
 
     // Helper method to get current config from database
@@ -317,19 +321,11 @@ public class ClamAVScannerService : IFileScannerService
     /// <summary>
     /// Record telemetry metrics for file scan execution
     /// </summary>
-    private static void RecordScanMetrics(long startTimestamp, FileScanResult result, Activity? activity)
+    private void RecordScanMetrics(long startTimestamp, FileScanResult result, Activity? activity)
     {
         var durationMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
 
-        // Record duration histogram
-        TelemetryConstants.FileScanDuration.Record(durationMs,
-            new KeyValuePair<string, object?>("tier", "tier1"));
-
-        // Record scan result counter
-        var resultType = result.IsClean ? "clean" : "malicious";
-        TelemetryConstants.FileScanResults.Add(1,
-            new KeyValuePair<string, object?>("tier", "tier1"),
-            new KeyValuePair<string, object?>("result", resultType));
+        _detectionMetrics.RecordFileScan("clamav", !result.IsClean, durationMs);
 
         // Enrich activity with scan result details
         if (activity != null)

--- a/TelegramGroupsAdmin.ContentDetection/Services/ContentDetectionEngineV2.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/ContentDetectionEngineV2.cs
@@ -9,6 +9,7 @@ using TelegramGroupsAdmin.Configuration.Models.ContentDetection;
 using TelegramGroupsAdmin.ContentDetection.Constants;
 using TelegramGroupsAdmin.ContentDetection.Models;
 using TelegramGroupsAdmin.ContentDetection.Repositories;
+using TelegramGroupsAdmin.ContentDetection.Metrics;
 using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Core.Extensions;
 
@@ -28,6 +29,7 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
     private readonly IEnumerable<IContentCheckV2> _contentChecksV2;
     private readonly IUrlPreFilterService _preFilterService;
     private readonly ContentDetectionOptions _spamDetectionOptions;
+    private readonly DetectionMetrics _detectionMetrics;
 
     // Action thresholds are per-chat config (ContentDetectionConfig.AutoBanThreshold / ReviewQueueThreshold)
     // Safety clamps are in ContentDetectionConstants (MinScore / MaxScore)
@@ -39,7 +41,8 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
         IPromptVersionRepository promptVersionRepo,
         IEnumerable<IContentCheckV2> contentChecksV2,
         IUrlPreFilterService preFilterService,
-        IOptions<ContentDetectionOptions> spamDetectionOptions)
+        IOptions<ContentDetectionOptions> spamDetectionOptions,
+        DetectionMetrics detectionMetrics)
     {
         _logger = logger;
         _configRepository = configRepository;
@@ -48,6 +51,7 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
         _contentChecksV2 = contentChecksV2;
         _preFilterService = preFilterService;
         _spamDetectionOptions = spamDetectionOptions.Value;
+        _detectionMetrics = detectionMetrics;
     }
 
     private async Task<ContentDetectionConfig> GetConfigAsync(ContentCheckRequest request, CancellationToken cancellationToken)
@@ -171,6 +175,13 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
                 {
                     _logger.LogInformation("AI vetoed spam detection for {User} (clean result with 0.0 score)",
                         request.User.ToLogInfo());
+
+                    // Record veto for each algorithm that was overridden
+                    foreach (var check in pipelineResult.CheckResults.Where(r => r.Score > 0 && !r.Abstained))
+                    {
+                        _detectionMetrics.RecordVeto(check.CheckName.ToString());
+                    }
+
                     var vetoedResult = CreateVetoedResult(updatedCheckResults, vetoResultV2);
                     RecordDetectionMetrics(startTimestamp, vetoedResult, activity);
                     return vetoedResult;
@@ -445,16 +456,8 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
         var durationMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
 
         // Record metrics
-        TelemetryConstants.SpamDetectionDuration.Record(durationMs,
-            new KeyValuePair<string, object?>("algorithm", check.CheckName),
-            new KeyValuePair<string, object?>("version", "v2"));
-
-        var resultType = result.Abstained ? "abstained" : (result.Score >= 1.0 ? "spam" : "low_confidence");
-
-        TelemetryConstants.SpamDetections.Add(1,
-            new KeyValuePair<string, object?>("algorithm", check.CheckName),
-            new KeyValuePair<string, object?>("result", resultType),
-            new KeyValuePair<string, object?>("version", "v2"));
+        var resultType = result.Abstained ? "abstained" : (result.Score >= 1.0 ? "spam" : "clean");
+        _detectionMetrics.RecordSpamDetection(check.CheckName.ToString(), resultType, durationMs);
 
         if (activity != null)
         {
@@ -490,19 +493,12 @@ public class ContentDetectionEngineV2 : IContentDetectionEngine
         };
     }
 
-    private static void RecordDetectionMetrics(long startTimestamp, ContentDetectionResult result, Activity? activity)
+    private void RecordDetectionMetrics(long startTimestamp, ContentDetectionResult result, Activity? activity)
     {
         var durationMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
 
-        TelemetryConstants.SpamDetectionDuration.Record(durationMs,
-            new KeyValuePair<string, object?>("algorithm", "pipeline"),
-            new KeyValuePair<string, object?>("version", "v2"));
-
         var resultType = result.IsSpam ? "spam" : "clean";
-        TelemetryConstants.SpamDetections.Add(1,
-            new KeyValuePair<string, object?>("algorithm", "pipeline"),
-            new KeyValuePair<string, object?>("result", resultType),
-            new KeyValuePair<string, object?>("version", "v2"));
+        _detectionMetrics.RecordSpamDetection("pipeline", resultType, durationMs);
 
         if (activity != null)
         {

--- a/TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs
@@ -6,6 +6,7 @@ using TelegramGroupsAdmin.Configuration.Repositories;
 using TelegramGroupsAdmin.ContentDetection.Constants;
 using TelegramGroupsAdmin.ContentDetection.Metrics;
 using TelegramGroupsAdmin.ContentDetection.Repositories;
+using TelegramGroupsAdmin.Core.Metrics;
 
 namespace TelegramGroupsAdmin.ContentDetection.Services;
 
@@ -22,6 +23,7 @@ public class VirusTotalScannerService : ICloudScannerService
     private readonly IFileScanQuotaRepository _quotaRepository;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly DetectionMetrics _detectionMetrics;
+    private readonly ApiMetrics _apiMetrics;
 
     public string ServiceName => "VirusTotal";
 
@@ -33,13 +35,15 @@ public class VirusTotalScannerService : ICloudScannerService
         ISystemConfigRepository configRepository,
         IFileScanQuotaRepository quotaRepository,
         IHttpClientFactory httpClientFactory,
-        DetectionMetrics detectionMetrics)
+        DetectionMetrics detectionMetrics,
+        ApiMetrics apiMetrics)
     {
         _logger = logger;
         _configRepository = configRepository;
         _quotaRepository = quotaRepository;
         _httpClientFactory = httpClientFactory;
         _detectionMetrics = detectionMetrics;
+        _apiMetrics = apiMetrics;
     }
 
     public async Task<CloudHashLookupResult?> LookupHashAsync(
@@ -64,6 +68,7 @@ public class VirusTotalScannerService : ICloudScannerService
             if (!quotaAvailable)
             {
                 _logger.LogInformation("VirusTotal daily quota exhausted, skipping hash lookup");
+                _apiMetrics.RecordVirusTotalQuotaExhausted();
                 return new CloudHashLookupResult
                 {
                     Status = HashLookupStatus.Error,
@@ -86,6 +91,7 @@ public class VirusTotalScannerService : ICloudScannerService
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
                 _logger.LogInformation("VirusTotal rate limit hit (429), marking service as unavailable");
+                _apiMetrics.RecordVirusTotalCall("hash_lookup", stopwatch.ElapsedMilliseconds, success: false);
                 return new CloudHashLookupResult
                 {
                     Status = HashLookupStatus.Error,
@@ -97,6 +103,7 @@ public class VirusTotalScannerService : ICloudScannerService
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 _logger.LogInformation("VirusTotal hash lookup: File not found (must upload to scan)");
+                _apiMetrics.RecordVirusTotalCall("hash_lookup", stopwatch.ElapsedMilliseconds, success: true);
 
                 // Increment quota (hash lookup counts as API call)
                 await _quotaRepository.IncrementQuotaUsageAsync(
@@ -118,6 +125,7 @@ public class VirusTotalScannerService : ICloudScannerService
                 var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
                 _logger.LogError("VirusTotal hash lookup failed: {StatusCode} - {Content}",
                     response.StatusCode, errorContent);
+                _apiMetrics.RecordVirusTotalCall("hash_lookup", stopwatch.ElapsedMilliseconds, success: false);
 
                 return new CloudHashLookupResult
                 {
@@ -188,6 +196,7 @@ public class VirusTotalScannerService : ICloudScannerService
             }
 
             _detectionMetrics.RecordFileScan("virustotal", status == HashLookupStatus.Malicious, stopwatch.ElapsedMilliseconds);
+            _apiMetrics.RecordVirusTotalCall("hash_lookup", stopwatch.ElapsedMilliseconds, success: true);
 
             return new CloudHashLookupResult
             {
@@ -209,6 +218,7 @@ public class VirusTotalScannerService : ICloudScannerService
         {
             stopwatch.Stop();
             _logger.LogError(ex, "Exception during VirusTotal hash lookup");
+            _apiMetrics.RecordVirusTotalCall("hash_lookup", stopwatch.ElapsedMilliseconds, success: false);
 
             return new CloudHashLookupResult
             {
@@ -251,6 +261,7 @@ public class VirusTotalScannerService : ICloudScannerService
             if (!quotaAvailable)
             {
                 _logger.LogInformation("VirusTotal daily quota exhausted, cannot upload file");
+                _apiMetrics.RecordVirusTotalQuotaExhausted();
                 return new CloudScanResult
                 {
                     ServiceName = ServiceName,
@@ -283,6 +294,7 @@ public class VirusTotalScannerService : ICloudScannerService
             {
                 stopwatch.Stop();
                 _logger.LogInformation("VirusTotal rate limit hit during file upload");
+                _apiMetrics.RecordVirusTotalCall("file_upload", stopwatch.ElapsedMilliseconds, success: false);
 
                 return new CloudScanResult
                 {
@@ -302,6 +314,7 @@ public class VirusTotalScannerService : ICloudScannerService
                     response.StatusCode, errorContent);
 
                 stopwatch.Stop();
+                _apiMetrics.RecordVirusTotalCall("file_upload", stopwatch.ElapsedMilliseconds, success: false);
 
                 return new CloudScanResult
                 {
@@ -399,6 +412,7 @@ public class VirusTotalScannerService : ICloudScannerService
                             detectionCount, totalEngines, threatName ?? "unknown");
 
                         _detectionMetrics.RecordFileScan("virustotal", true, stopwatch.ElapsedMilliseconds);
+                        _apiMetrics.RecordVirusTotalCall("file_upload", stopwatch.ElapsedMilliseconds, success: true);
 
                         return new CloudScanResult
                         {
@@ -425,6 +439,7 @@ public class VirusTotalScannerService : ICloudScannerService
                             detectionCount, totalEngines);
 
                         _detectionMetrics.RecordFileScan("virustotal", false, stopwatch.ElapsedMilliseconds);
+                        _apiMetrics.RecordVirusTotalCall("file_upload", stopwatch.ElapsedMilliseconds, success: true);
 
                         return new CloudScanResult
                         {
@@ -448,6 +463,7 @@ public class VirusTotalScannerService : ICloudScannerService
                 maxPolls, stopwatch.ElapsedMilliseconds);
 
             _detectionMetrics.RecordFileScan("virustotal", false, stopwatch.ElapsedMilliseconds);
+            _apiMetrics.RecordVirusTotalCall("file_upload", stopwatch.ElapsedMilliseconds, success: false);
 
             return new CloudScanResult
             {
@@ -465,6 +481,7 @@ public class VirusTotalScannerService : ICloudScannerService
             _logger.LogError(ex, "Exception during VirusTotal file scan");
 
             _detectionMetrics.RecordFileScan("virustotal", false, stopwatch.ElapsedMilliseconds);
+            _apiMetrics.RecordVirusTotalCall("file_upload", stopwatch.ElapsedMilliseconds, success: false);
 
             return new CloudScanResult
             {

--- a/TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs
@@ -447,6 +447,8 @@ public class VirusTotalScannerService : ICloudScannerService
             _logger.LogWarning("VirusTotal analysis timeout after {Polls} polls ({Duration}ms)",
                 maxPolls, stopwatch.ElapsedMilliseconds);
 
+            _detectionMetrics.RecordFileScan("virustotal", false, stopwatch.ElapsedMilliseconds);
+
             return new CloudScanResult
             {
                 ServiceName = ServiceName,
@@ -461,6 +463,8 @@ public class VirusTotalScannerService : ICloudScannerService
         {
             stopwatch.Stop();
             _logger.LogError(ex, "Exception during VirusTotal file scan");
+
+            _detectionMetrics.RecordFileScan("virustotal", false, stopwatch.ElapsedMilliseconds);
 
             return new CloudScanResult
             {

--- a/TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using TelegramGroupsAdmin.Configuration.Repositories;
 using TelegramGroupsAdmin.ContentDetection.Constants;
+using TelegramGroupsAdmin.ContentDetection.Metrics;
 using TelegramGroupsAdmin.ContentDetection.Repositories;
 
 namespace TelegramGroupsAdmin.ContentDetection.Services;
@@ -20,6 +21,7 @@ public class VirusTotalScannerService : ICloudScannerService
     private readonly ISystemConfigRepository _configRepository;
     private readonly IFileScanQuotaRepository _quotaRepository;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly DetectionMetrics _detectionMetrics;
 
     public string ServiceName => "VirusTotal";
 
@@ -30,12 +32,14 @@ public class VirusTotalScannerService : ICloudScannerService
         ILogger<VirusTotalScannerService> logger,
         ISystemConfigRepository configRepository,
         IFileScanQuotaRepository quotaRepository,
-        IHttpClientFactory httpClientFactory)
+        IHttpClientFactory httpClientFactory,
+        DetectionMetrics detectionMetrics)
     {
         _logger = logger;
         _configRepository = configRepository;
         _quotaRepository = quotaRepository;
         _httpClientFactory = httpClientFactory;
+        _detectionMetrics = detectionMetrics;
     }
 
     public async Task<CloudHashLookupResult?> LookupHashAsync(
@@ -182,6 +186,8 @@ public class VirusTotalScannerService : ICloudScannerService
                 _logger.LogInformation("VirusTotal hash lookup: CLEAN - {DetectionCount}/{TotalEngines} engines (below threshold)",
                     detectionCount, totalEngines);
             }
+
+            _detectionMetrics.RecordFileScan("virustotal", status == HashLookupStatus.Malicious, stopwatch.ElapsedMilliseconds);
 
             return new CloudHashLookupResult
             {
@@ -392,6 +398,8 @@ public class VirusTotalScannerService : ICloudScannerService
                         _logger.LogWarning("VirusTotal scan: INFECTED - {DetectionCount}/{TotalEngines} engines detected {ThreatName}",
                             detectionCount, totalEngines, threatName ?? "unknown");
 
+                        _detectionMetrics.RecordFileScan("virustotal", true, stopwatch.ElapsedMilliseconds);
+
                         return new CloudScanResult
                         {
                             ServiceName = ServiceName,
@@ -415,6 +423,8 @@ public class VirusTotalScannerService : ICloudScannerService
                     {
                         _logger.LogInformation("VirusTotal scan: CLEAN - {DetectionCount}/{TotalEngines} engines",
                             detectionCount, totalEngines);
+
+                        _detectionMetrics.RecordFileScan("virustotal", false, stopwatch.ElapsedMilliseconds);
 
                         return new CloudScanResult
                         {

--- a/TelegramGroupsAdmin.Core/CLAUDE.md
+++ b/TelegramGroupsAdmin.Core/CLAUDE.md
@@ -1,0 +1,96 @@
+# TelegramGroupsAdmin.Core - AI Reference
+
+## Metrics Pattern
+
+All custom metrics use **domain-scoped singleton classes** with wrapper methods. Do not add counters/histograms directly to `TelemetryConstants` — that file holds only `ActivitySource` fields for distributed tracing.
+
+### Adding a New Metric
+
+1. **Find the right metrics class** for your domain:
+
+| Class | Project | Domain |
+|---|---|---|
+| `ApiMetrics` | Core | External API calls (OpenAI, VirusTotal, SendGrid, Telegram) |
+| `CacheMetrics` | Core | Cache hit/miss/removal tracking |
+| `DetectionMetrics` | ContentDetection | Spam detection, file scanning, veto |
+| `PipelineMetrics` | Telegram | Message processing, moderation, profile scans |
+| `ChatMetrics` | Telegram | Chat health, managed chats, joins/leaves |
+| `WelcomeMetrics` | Telegram | Welcome flow outcomes, security checks |
+| `ReportMetrics` | Telegram | Report creation, resolution, pending count |
+| `JobMetrics` | BackgroundJobs | Quartz job execution, duration, rows affected |
+| `MemoryMetrics` | Main app | ObservableGauges for stateful singleton memory attribution |
+
+2. **Add the instrument** to the appropriate class:
+
+```csharp
+// In the metrics class constructor or field initializer
+private readonly Counter<long> _myCounter = _meter.CreateCounter<long>(
+    "tga.domain.my_counter_total",
+    description: "What this counts");
+```
+
+3. **Add a recording method** that enforces required tags:
+
+```csharp
+public void RecordMyEvent(string requiredTag, bool success)
+{
+    _myCounter.Add(1, new TagList
+    {
+        { "required_tag", requiredTag },
+        { "status", success ? "success" : "failure" }
+    });
+}
+```
+
+4. **Call the recording method** from the service, injecting the metrics class via DI:
+
+```csharp
+public class MyService(ApiMetrics apiMetrics)
+{
+    public async Task DoWorkAsync()
+    {
+        // ... do work ...
+        apiMetrics.RecordMyEvent("feature_name", success: true);
+    }
+}
+```
+
+### Naming Rules
+
+- **Prefix**: All metrics start with `tga.`
+- **Pattern**: `tga.<domain>.<subject>.<metric_type>`
+- **Counters**: End with `_total` (e.g., `tga.api.openai.calls_total`)
+- **Histograms**: Use `unit: "ms"` parameter, do NOT include `_ms` in the name (the Prometheus exporter appends the unit as `_milliseconds`)
+- **Gauges**: Use descriptive names (e.g., `tga.cache.chat.count`)
+- **Tags**: Use snake_case, bounded cardinality only (no user IDs, chat IDs, message IDs)
+
+### Histogram Unit Suffix
+
+The OTel Prometheus exporter auto-appends the unit as a suffix. A histogram named `tga.jobs.duration` with `unit: "ms"` exports as `tga_jobs_duration_milliseconds_bucket`. If you include `_ms` in the name, it exports as `tga_jobs_duration_ms_milliseconds_bucket` (redundant).
+
+### ObservableGauge Constraints
+
+`ObservableGauge` callbacks are `Func<T>` (synchronous). They **cannot** call async methods or query the database. Only read from in-memory singleton state:
+
+```csharp
+// OK - reads in-memory count
+meter.CreateObservableGauge("tga.cache.chat.count", () => chatCache.Count);
+
+// BAD - async DB call in synchronous callback
+meter.CreateObservableGauge("tga.reports.pending", () => repo.GetCountAsync().Result); // DEADLOCK RISK
+```
+
+For metrics that need DB-sourced values, maintain a cached counter via `Interlocked.Increment`/`Decrement` in the recording methods.
+
+### Creating a New Metrics Class
+
+If no existing class fits your domain, create a new one:
+
+1. Create `YourDomainMetrics.cs` in the appropriate project
+2. Make it a `sealed class` with a `Meter` field: `private readonly Meter _meter = new("TelegramGroupsAdmin.YourDomain");`
+3. Register as singleton in that project's `ServiceCollectionExtensions`
+4. The existing `AddMeter("TelegramGroupsAdmin.*")` wildcard in `Program.cs` auto-discovers new meters — no OTel config changes needed
+
+### Design Spec
+
+Full instrument catalog, tag schemas, and migration details: `docs/superpowers/specs/2026-03-26-metrics-expansion-design.md`

--- a/TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ public static class ServiceCollectionExtensions
     {
         // Metrics
         services.AddSingleton<ApiMetrics>();
+        services.AddSingleton<CacheMetrics>();
 
         // Utility services
         services.AddSingleton<SimHashService>(); // SimHash fingerprinting for O(1) deduplication

--- a/TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Core.Repositories;
 using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Core.Services.AI;
@@ -10,6 +11,9 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddCoreServices(this IServiceCollection services)
     {
+        // Metrics
+        services.AddSingleton<ApiMetrics>();
+
         // Utility services
         services.AddSingleton<SimHashService>(); // SimHash fingerprinting for O(1) deduplication
 

--- a/TelegramGroupsAdmin.Core/Metrics/ApiMetrics.cs
+++ b/TelegramGroupsAdmin.Core/Metrics/ApiMetrics.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace TelegramGroupsAdmin.Core.Metrics;
+
+/// <summary>
+/// Metrics for external API calls: OpenAI, VirusTotal, SendGrid, Telegram Bot API.
+/// Per-feature attribution via required tags on recording methods.
+/// </summary>
+public sealed class ApiMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Api");
+
+    private readonly Counter<long> _openAiCallsTotal;
+    private readonly Histogram<double> _openAiLatency;
+    private readonly Counter<long> _openAiTokensTotal;
+    private readonly Counter<long> _virusTotalCallsTotal;
+    private readonly Histogram<double> _virusTotalLatency;
+    private readonly Counter<long> _virusTotalQuotaExhaustedTotal;
+    private readonly Counter<long> _sendGridSendsTotal;
+    private readonly Counter<long> _telegramCallsTotal;
+    private readonly Counter<long> _telegramErrorsTotal;
+
+    public ApiMetrics()
+    {
+        _openAiCallsTotal = _meter.CreateCounter<long>(
+            "tga.api.openai.calls_total",
+            description: "OpenAI API call count per feature");
+
+        _openAiLatency = _meter.CreateHistogram<double>(
+            "tga.api.openai.latency",
+            unit: "ms",
+            description: "OpenAI API latency distribution");
+
+        _openAiTokensTotal = _meter.CreateCounter<long>(
+            "tga.api.openai.tokens_total",
+            description: "OpenAI token consumption per feature");
+
+        _virusTotalCallsTotal = _meter.CreateCounter<long>(
+            "tga.api.virustotal.calls_total",
+            description: "VirusTotal API calls by operation");
+
+        _virusTotalLatency = _meter.CreateHistogram<double>(
+            "tga.api.virustotal.latency",
+            unit: "ms",
+            description: "VirusTotal API latency per operation");
+
+        _virusTotalQuotaExhaustedTotal = _meter.CreateCounter<long>(
+            "tga.api.virustotal.quota_exhausted_total",
+            description: "VirusTotal daily quota exhaustion events");
+
+        _sendGridSendsTotal = _meter.CreateCounter<long>(
+            "tga.api.sendgrid.sends_total",
+            description: "SendGrid email sends by template and status");
+
+        _telegramCallsTotal = _meter.CreateCounter<long>(
+            "tga.api.telegram.calls_total",
+            description: "Telegram Bot API calls by operation");
+
+        _telegramErrorsTotal = _meter.CreateCounter<long>(
+            "tga.api.telegram.errors_total",
+            description: "Telegram Bot API error breakdown");
+    }
+
+    public void RecordOpenAiCall(string feature, string model, int promptTokens, int completionTokens, double durationMs, bool success)
+    {
+        _openAiCallsTotal.Add(1, new TagList
+        {
+            { "feature", feature },
+            { "model", model },
+            { "status", success ? "success" : "failure" }
+        });
+
+        _openAiLatency.Record(durationMs, new TagList
+        {
+            { "feature", feature },
+            { "model", model }
+        });
+
+        if (promptTokens > 0)
+            _openAiTokensTotal.Add(promptTokens, new TagList
+            {
+                { "feature", feature },
+                { "model", model },
+                { "type", "prompt" }
+            });
+
+        if (completionTokens > 0)
+            _openAiTokensTotal.Add(completionTokens, new TagList
+            {
+                { "feature", feature },
+                { "model", model },
+                { "type", "completion" }
+            });
+    }
+
+    public void RecordVirusTotalCall(string operation, double durationMs, bool success)
+    {
+        _virusTotalCallsTotal.Add(1, new TagList
+        {
+            { "operation", operation },
+            { "status", success ? "success" : "failure" }
+        });
+        _virusTotalLatency.Record(durationMs, new TagList { { "operation", operation } });
+    }
+
+    public void RecordVirusTotalQuotaExhausted()
+    {
+        _virusTotalQuotaExhaustedTotal.Add(1);
+    }
+
+    public void RecordSendGridSend(string template, bool success)
+    {
+        _sendGridSendsTotal.Add(1, new TagList
+        {
+            { "template", template },
+            { "status", success ? "success" : "failure" }
+        });
+    }
+
+    public void RecordTelegramApiCall(string operation, bool success)
+    {
+        _telegramCallsTotal.Add(1, new TagList
+        {
+            { "operation", operation },
+            { "status", success ? "success" : "failure" }
+        });
+    }
+
+    public void RecordTelegramApiError(string errorType)
+    {
+        _telegramErrorsTotal.Add(1, new TagList { { "error_type", errorType } });
+    }
+}

--- a/TelegramGroupsAdmin.Core/Metrics/CacheMetrics.cs
+++ b/TelegramGroupsAdmin.Core/Metrics/CacheMetrics.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace TelegramGroupsAdmin.Core.Metrics;
+
+/// <summary>
+/// Metrics for in-memory cache hit/miss/removal tracking.
+/// </summary>
+public sealed class CacheMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Cache");
+
+    private readonly Counter<long> _hitsTotal;
+    private readonly Counter<long> _missesTotal;
+    private readonly Counter<long> _removalsTotal;
+
+    public CacheMetrics()
+    {
+        _hitsTotal = _meter.CreateCounter<long>(
+            "tga.cache.hits_total",
+            description: "Cache hits by cache name");
+
+        _missesTotal = _meter.CreateCounter<long>(
+            "tga.cache.misses_total",
+            description: "Cache misses by cache name");
+
+        _removalsTotal = _meter.CreateCounter<long>(
+            "tga.cache.removals_total",
+            description: "Explicit cache removals by cache name");
+    }
+
+    public void RecordHit(string cacheName)
+    {
+        _hitsTotal.Add(1, new TagList { { "cache_name", cacheName } });
+    }
+
+    public void RecordMiss(string cacheName)
+    {
+        _missesTotal.Add(1, new TagList { { "cache_name", cacheName } });
+    }
+
+    public void RecordRemoval(string cacheName)
+    {
+        _removalsTotal.Add(1, new TagList { { "cache_name", cacheName } });
+    }
+}

--- a/TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs
+++ b/TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs
@@ -27,17 +27,20 @@ public class SemanticKernelChatService : IChatService
     private readonly ISystemConfigRepository _configRepository;
     private readonly ILogger<SemanticKernelChatService> _logger;
     private readonly ApiMetrics _apiMetrics;
+    private readonly CacheMetrics _cacheMetrics;
 
     public static int CachedKernelCount => KernelCache.Count;
 
     public SemanticKernelChatService(
         ISystemConfigRepository configRepository,
         ILogger<SemanticKernelChatService> logger,
-        ApiMetrics apiMetrics)
+        ApiMetrics apiMetrics,
+        CacheMetrics cacheMetrics)
     {
         _configRepository = configRepository;
         _logger = logger;
         _apiMetrics = apiMetrics;
+        _cacheMetrics = cacheMetrics;
     }
 
     /// <inheritdoc />
@@ -466,8 +469,15 @@ public class SemanticKernelChatService : IChatService
         // Generate cache key for test kernel
         var cacheKey = GenerateCacheKey(connection, testFeatureConfig, apiKey);
 
-        // Use GetOrAdd for thread-safe atomic cache access
-        var cachedKernel = KernelCache.GetOrAdd(cacheKey, _ =>
+        // Check cache first for hit/miss tracking, then use GetOrAdd for thread safety
+        if (KernelCache.TryGetValue(cacheKey, out var cachedKernel))
+        {
+            _cacheMetrics.RecordHit("kernel");
+            return cachedKernel;
+        }
+
+        _cacheMetrics.RecordMiss("kernel");
+        cachedKernel = KernelCache.GetOrAdd(cacheKey, _ =>
         {
             var kernel = BuildKernel(connection, testFeatureConfig, apiKey);
             var chatService = kernel.GetRequiredService<IChatCompletionService>();
@@ -523,19 +533,27 @@ public class SemanticKernelChatService : IChatService
 
         try
         {
-            var cachedKernel = KernelCache.GetOrAdd(cacheKey, _ =>
+            if (KernelCache.TryGetValue(cacheKey, out var cachedKernel))
             {
-                var kernel = BuildKernel(conn, featConfig, key);
-                var chatService = kernel.GetRequiredService<IChatCompletionService>();
-                var modelId = conn.Provider == AIProviderType.AzureOpenAI
-                    ? featConfig.AzureDeploymentName ?? featConfig.Model
-                    : featConfig.Model;
+                _cacheMetrics.RecordHit("kernel");
+            }
+            else
+            {
+                _cacheMetrics.RecordMiss("kernel");
+                cachedKernel = KernelCache.GetOrAdd(cacheKey, _ =>
+                {
+                    var kernel = BuildKernel(conn, featConfig, key);
+                    var chatService = kernel.GetRequiredService<IChatCompletionService>();
+                    var modelId = conn.Provider == AIProviderType.AzureOpenAI
+                        ? featConfig.AzureDeploymentName ?? featConfig.Model
+                        : featConfig.Model;
 
-                _logger.LogDebug("Created and cached kernel for connection {ConnectionId}, model {Model}",
-                    conn.Id, modelId);
+                    _logger.LogDebug("Created and cached kernel for connection {ConnectionId}, model {Model}",
+                        conn.Id, modelId);
 
-                return new CachedKernel(kernel, chatService, modelId);
-            });
+                    return new CachedKernel(kernel, chatService, modelId);
+                });
+            }
 
             // Return kernel with feature config so caller can use config defaults (Temperature, MaxTokens)
             return new KernelLookupResult(cachedKernel, featureConfig);

--- a/TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs
+++ b/TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs
@@ -1,10 +1,12 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using TelegramGroupsAdmin.Configuration.Models;
 using TelegramGroupsAdmin.Configuration.Repositories;
+using TelegramGroupsAdmin.Core.Metrics;
 
 namespace TelegramGroupsAdmin.Core.Services.AI;
 
@@ -24,15 +26,18 @@ public class SemanticKernelChatService : IChatService
     private static readonly ConcurrentDictionary<string, CachedKernel> KernelCache = new();
     private readonly ISystemConfigRepository _configRepository;
     private readonly ILogger<SemanticKernelChatService> _logger;
+    private readonly ApiMetrics _apiMetrics;
 
     public static int CachedKernelCount => KernelCache.Count;
 
     public SemanticKernelChatService(
         ISystemConfigRepository configRepository,
-        ILogger<SemanticKernelChatService> logger)
+        ILogger<SemanticKernelChatService> logger,
+        ApiMetrics apiMetrics)
     {
         _configRepository = configRepository;
         _logger = logger;
+        _apiMetrics = apiMetrics;
     }
 
     /// <inheritdoc />
@@ -53,6 +58,7 @@ public class SemanticKernelChatService : IChatService
         var kernelInfo = lookupResult.Kernel;
         var featureConfig = lookupResult.FeatureConfig;
 
+        var stopwatch = Stopwatch.StartNew();
         try
         {
             var chatHistory = new ChatHistory();
@@ -69,10 +75,27 @@ public class SemanticKernelChatService : IChatService
                 kernel: kernelInfo.Kernel,
                 cancellationToken: cancellationToken);
 
-            return CreateResult(response, kernelInfo.ModelId);
+            stopwatch.Stop();
+            var result = CreateResult(response, kernelInfo.ModelId);
+            _apiMetrics.RecordOpenAiCall(
+                feature.ToString(),
+                kernelInfo.ModelId,
+                result?.PromptTokens ?? 0,
+                result?.CompletionTokens ?? 0,
+                stopwatch.Elapsed.TotalMilliseconds,
+                success: true);
+
+            return result;
         }
         catch (Exception ex)
         {
+            stopwatch.Stop();
+            _apiMetrics.RecordOpenAiCall(
+                feature.ToString(),
+                kernelInfo.ModelId,
+                0, 0,
+                stopwatch.Elapsed.TotalMilliseconds,
+                success: false);
             _logger.LogError(ex, "Error getting chat completion from {Model} for feature {Feature}",
                 kernelInfo.ModelId, feature);
             throw; // Let caller handle the exception
@@ -99,6 +122,7 @@ public class SemanticKernelChatService : IChatService
         var kernelInfo = lookupResult.Kernel;
         var featureConfig = lookupResult.FeatureConfig;
 
+        var stopwatch = Stopwatch.StartNew();
         try
         {
             var chatHistory = new ChatHistory();
@@ -119,10 +143,27 @@ public class SemanticKernelChatService : IChatService
                 kernel: kernelInfo.Kernel,
                 cancellationToken: cancellationToken);
 
-            return CreateResult(response, kernelInfo.ModelId);
+            stopwatch.Stop();
+            var result = CreateResult(response, kernelInfo.ModelId);
+            _apiMetrics.RecordOpenAiCall(
+                feature.ToString(),
+                kernelInfo.ModelId,
+                result?.PromptTokens ?? 0,
+                result?.CompletionTokens ?? 0,
+                stopwatch.Elapsed.TotalMilliseconds,
+                success: true);
+
+            return result;
         }
         catch (Exception ex)
         {
+            stopwatch.Stop();
+            _apiMetrics.RecordOpenAiCall(
+                feature.ToString(),
+                kernelInfo.ModelId,
+                0, 0,
+                stopwatch.Elapsed.TotalMilliseconds,
+                success: false);
             _logger.LogError(ex, "Error getting vision completion from {Model} for feature {Feature}",
                 kernelInfo.ModelId, feature);
             throw; // Let caller handle the exception
@@ -148,6 +189,7 @@ public class SemanticKernelChatService : IChatService
         var kernelInfo = lookupResult.Kernel;
         var featureConfig = lookupResult.FeatureConfig;
 
+        var stopwatch = Stopwatch.StartNew();
         try
         {
             var chatHistory = new ChatHistory();
@@ -173,10 +215,27 @@ public class SemanticKernelChatService : IChatService
                 kernel: kernelInfo.Kernel,
                 cancellationToken: cancellationToken);
 
-            return CreateResult(response, kernelInfo.ModelId);
+            stopwatch.Stop();
+            var result = CreateResult(response, kernelInfo.ModelId);
+            _apiMetrics.RecordOpenAiCall(
+                feature.ToString(),
+                kernelInfo.ModelId,
+                result?.PromptTokens ?? 0,
+                result?.CompletionTokens ?? 0,
+                stopwatch.Elapsed.TotalMilliseconds,
+                success: true);
+
+            return result;
         }
         catch (Exception ex)
         {
+            stopwatch.Stop();
+            _apiMetrics.RecordOpenAiCall(
+                feature.ToString(),
+                kernelInfo.ModelId,
+                0, 0,
+                stopwatch.Elapsed.TotalMilliseconds,
+                success: false);
             _logger.LogError(ex, "Error getting multi-image vision completion from {Model} for feature {Feature}",
                 kernelInfo.ModelId, feature);
             throw;

--- a/TelegramGroupsAdmin.Core/TelemetryConstants.cs
+++ b/TelegramGroupsAdmin.Core/TelemetryConstants.cs
@@ -1,18 +1,13 @@
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 
 namespace TelegramGroupsAdmin.Core.Telemetry;
 
 /// <summary>
-/// Centralized telemetry constants for OpenTelemetry instrumentation.
-/// Provides ActivitySources for distributed tracing and Meters for custom metrics.
+/// ActivitySources for OpenTelemetry distributed tracing.
+/// Metrics have been migrated to domain-scoped classes (DetectionMetrics, JobMetrics, etc.)
 /// </summary>
 public static class TelemetryConstants
 {
-    // =========================================================================
-    // ActivitySources for Distributed Tracing
-    // =========================================================================
-
     /// <summary>
     /// ActivitySource for spam detection pipeline operations.
     /// Used to trace message analysis, algorithm execution, and detection results.
@@ -36,79 +31,4 @@ public static class TelemetryConstants
     /// Used to trace Quartz.NET job lifecycle and execution.
     /// </summary>
     public static readonly ActivitySource BackgroundJobs = new("TelegramGroupsAdmin.BackgroundJobs");
-
-    // =========================================================================
-    // Meters for Custom Metrics
-    // =========================================================================
-
-    /// <summary>
-    /// Meter for custom application metrics.
-    /// Provides counters, histograms, and gauges for operational insights.
-    /// </summary>
-    public static readonly Meter Metrics = new("TelegramGroupsAdmin.Metrics");
-
-    /// <summary>
-    /// Meter for memory attribution and cache size tracking.
-    /// Observable gauges on this meter help identify which components hold memory.
-    /// </summary>
-    public static readonly Meter Memory = new("TelegramGroupsAdmin.Memory");
-
-    // =========================================================================
-    // Counters - Monotonically increasing values
-    // =========================================================================
-
-    /// <summary>
-    /// Counter for total spam detections.
-    /// Tags: algorithm (string), result (spam|ham)
-    /// </summary>
-    public static readonly Counter<long> SpamDetections = Metrics.CreateCounter<long>(
-        "spam_detections_total",
-        description: "Total number of spam detections by algorithm and result");
-
-    /// <summary>
-    /// Counter for file scan results.
-    /// Tags: tier (string), result (malicious|clean)
-    /// </summary>
-    public static readonly Counter<long> FileScanResults = Metrics.CreateCounter<long>(
-        "file_scan_results_total",
-        description: "Total number of file scans by tier and result");
-
-    /// <summary>
-    /// Counter for background job executions.
-    /// Tags: job_name (string), status (success|failure)
-    /// </summary>
-    public static readonly Counter<long> JobExecutions = Metrics.CreateCounter<long>(
-        "job_executions_total",
-        description: "Total number of job executions by name and status");
-
-    // =========================================================================
-    // Histograms - Distribution of values over time
-    // =========================================================================
-
-    /// <summary>
-    /// Histogram for spam detection duration in milliseconds.
-    /// Tags: algorithm (string)
-    /// </summary>
-    public static readonly Histogram<double> SpamDetectionDuration = Metrics.CreateHistogram<double>(
-        "spam_detection_duration_ms",
-        unit: "ms",
-        description: "Duration of spam detection algorithm execution in milliseconds");
-
-    /// <summary>
-    /// Histogram for file scan duration in milliseconds.
-    /// Tags: tier (string)
-    /// </summary>
-    public static readonly Histogram<double> FileScanDuration = Metrics.CreateHistogram<double>(
-        "file_scan_duration_ms",
-        unit: "ms",
-        description: "Duration of file scanning operations in milliseconds");
-
-    /// <summary>
-    /// Histogram for background job duration in milliseconds.
-    /// Tags: job_name (string)
-    /// </summary>
-    public static readonly Histogram<double> JobDuration = Metrics.CreateHistogram<double>(
-        "job_duration_ms",
-        unit: "ms",
-        description: "Duration of background job execution in milliseconds");
 }

--- a/TelegramGroupsAdmin.IntegrationTests/Jobs/WelcomeTimeoutJobTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Jobs/WelcomeTimeoutJobTests.cs
@@ -16,6 +16,7 @@ using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.BackgroundJobs.Metrics;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
 
 namespace TelegramGroupsAdmin.IntegrationTests.Jobs;
@@ -142,7 +143,8 @@ public class WelcomeTimeoutJobTests
             _mockModerationService!,
             _mockMessageService!,
             _mockExamSessionRepository!,
-            new JobMetrics());
+            new JobMetrics(),
+            new WelcomeMetrics());
 
     /// <summary>
     /// Creates a mock IJobExecutionContext whose MergedJobDataMap contains the given payload.

--- a/TelegramGroupsAdmin.IntegrationTests/Jobs/WelcomeTimeoutJobTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Jobs/WelcomeTimeoutJobTests.cs
@@ -15,6 +15,7 @@ using TelegramGroupsAdmin.Data.Models;
 using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
 
 namespace TelegramGroupsAdmin.IntegrationTests.Jobs;
@@ -140,7 +141,8 @@ public class WelcomeTimeoutJobTests
             ContextFactory,
             _mockModerationService!,
             _mockMessageService!,
-            _mockExamSessionRepository!);
+            _mockExamSessionRepository!,
+            new JobMetrics());
 
     /// <summary>
     /// Creates a mock IJobExecutionContext whose MergedJobDataMap contains the given payload.

--- a/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
@@ -199,6 +199,7 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<IChatCache, ChatCache>();
             services.AddSingleton<ChatMetrics>(); // Depends on IChatCache for ObservableGauge callback
             services.AddSingleton<WelcomeMetrics>();
+            services.AddSingleton<ReportMetrics>();
             services.AddSingleton<IChatHealthCache, ChatHealthCache>();
             services.AddSingleton<IBotIdentityCache, BotIdentityCache>();
 

--- a/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
@@ -197,6 +197,7 @@ public static class ServiceCollectionExtensions
 
             // Caching services (singletons for cross-request state)
             services.AddSingleton<IChatCache, ChatCache>();
+            services.AddSingleton<ChatMetrics>(); // Depends on IChatCache for ObservableGauge callback
             services.AddSingleton<IChatHealthCache, ChatHealthCache>();
             services.AddSingleton<IBotIdentityCache, BotIdentityCache>();
 

--- a/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ using TelegramGroupsAdmin.Telegram.Services.Moderation.Handlers;
 using TelegramGroupsAdmin.Telegram.Services.Moderation.Infrastructure;
 using TelegramGroupsAdmin.Telegram.Services.Notifications;
 using TelegramGroupsAdmin.Telegram.Services.Telegram;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.UserApi;
 using TelegramGroupsAdmin.Telegram.Services.Welcome;
 using Testably.Abstractions;
@@ -192,6 +193,7 @@ public static class ServiceCollectionExtensions
             services.AddKeyedScoped<IBotCommand, DeleteCommand>(CommandNames.Delete);
             services.AddKeyedScoped<IBotCommand, MyStatusCommand>(CommandNames.MyStatus);
             services.AddSingleton<CommandRouter>();
+            services.AddSingleton<PipelineMetrics>();
 
             // Caching services (singletons for cross-request state)
             services.AddSingleton<IChatCache, ChatCache>();

--- a/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
@@ -198,6 +198,7 @@ public static class ServiceCollectionExtensions
             // Caching services (singletons for cross-request state)
             services.AddSingleton<IChatCache, ChatCache>();
             services.AddSingleton<ChatMetrics>(); // Depends on IChatCache for ObservableGauge callback
+            services.AddSingleton<WelcomeMetrics>();
             services.AddSingleton<IChatHealthCache, ChatHealthCache>();
             services.AddSingleton<IBotIdentityCache, BotIdentityCache>();
 

--- a/TelegramGroupsAdmin.Telegram/Metrics/ChatMetrics.cs
+++ b/TelegramGroupsAdmin.Telegram/Metrics/ChatMetrics.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using TelegramGroupsAdmin.Telegram.Services;
+
+namespace TelegramGroupsAdmin.Telegram.Metrics;
+
+/// <summary>
+/// Metrics for managed chats, health checks, message types, and user joins/leaves.
+/// </summary>
+public sealed class ChatMetrics
+{
+    private readonly Counter<long> _healthCheckTotal;
+    private readonly Counter<long> _markedInactiveTotal;
+    private readonly Counter<long> _messagesTotal;
+    private readonly Counter<long> _userJoinsTotal;
+    private readonly Counter<long> _userLeavesTotal;
+
+    public ChatMetrics(IChatCache chatCache)
+    {
+        var meter = new Meter("TelegramGroupsAdmin.Chats");
+
+        meter.CreateObservableGauge(
+            "tga.chats.managed_count",
+            () => chatCache.Count,
+            description: "Number of managed chats currently in the cache");
+
+        _healthCheckTotal = meter.CreateCounter<long>(
+            "tga.chats.health_check_total",
+            description: "Health checks by result");
+
+        _markedInactiveTotal = meter.CreateCounter<long>(
+            "tga.chats.marked_inactive_total",
+            description: "Chats marked inactive after consecutive failures");
+
+        _messagesTotal = meter.CreateCounter<long>(
+            "tga.chats.messages_total",
+            description: "Messages processed by type");
+
+        _userJoinsTotal = meter.CreateCounter<long>(
+            "tga.chats.user_joins_total",
+            description: "Users joined managed chats");
+
+        _userLeavesTotal = meter.CreateCounter<long>(
+            "tga.chats.user_leaves_total",
+            description: "Users left managed chats");
+    }
+
+    public void RecordHealthCheck(string result)
+    {
+        _healthCheckTotal.Add(1, new TagList { { "result", result } });
+    }
+
+    public void RecordChatMarkedInactive()
+    {
+        _markedInactiveTotal.Add(1);
+    }
+
+    public void RecordMessage(string type)
+    {
+        _messagesTotal.Add(1, new TagList { { "type", type } });
+    }
+
+    public void RecordUserJoin()
+    {
+        _userJoinsTotal.Add(1);
+    }
+
+    public void RecordUserLeave()
+    {
+        _userLeavesTotal.Add(1);
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Metrics/PipelineMetrics.cs
+++ b/TelegramGroupsAdmin.Telegram/Metrics/PipelineMetrics.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace TelegramGroupsAdmin.Telegram.Metrics;
+
+/// <summary>
+/// Metrics for message processing pipeline, moderation actions, command handling,
+/// and profile scanning.
+/// </summary>
+public sealed class PipelineMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Pipeline");
+
+    private readonly Counter<long> _messagesProcessedTotal;
+    private readonly Counter<long> _moderationActionsTotal;
+    private readonly Counter<long> _commandsHandledTotal;
+    private readonly Counter<long> _profileScansTotal;
+    private readonly Counter<long> _profileScanTimeoutsTotal;
+    private readonly Counter<long> _profileScanSkippedTotal;
+
+    private readonly Histogram<double> _processingDuration;
+    private readonly Histogram<double> _profileScanDuration;
+
+    public PipelineMetrics()
+    {
+        _messagesProcessedTotal = _meter.CreateCounter<long>(
+            "tga.pipeline.messages_processed_total",
+            description: "Messages processed by source and result");
+
+        _moderationActionsTotal = _meter.CreateCounter<long>(
+            "tga.pipeline.moderation_actions_total",
+            description: "Moderation actions by action type and trigger");
+
+        _commandsHandledTotal = _meter.CreateCounter<long>(
+            "tga.pipeline.commands_handled_total",
+            description: "Bot commands handled by command name");
+
+        _profileScansTotal = _meter.CreateCounter<long>(
+            "tga.pipeline.profile_scans_total",
+            description: "Profile scans by outcome and source");
+
+        _profileScanTimeoutsTotal = _meter.CreateCounter<long>(
+            "tga.pipeline.profile_scan.timeouts_total",
+            description: "Profile scan timeouts");
+
+        _profileScanSkippedTotal = _meter.CreateCounter<long>(
+            "tga.pipeline.profile_scan.skipped_total",
+            description: "Profile scans skipped by reason");
+
+        _processingDuration = _meter.CreateHistogram<double>(
+            "tga.pipeline.processing.duration",
+            unit: "ms",
+            description: "Message processing duration by source");
+
+        _profileScanDuration = _meter.CreateHistogram<double>(
+            "tga.pipeline.profile_scan.duration",
+            unit: "ms",
+            description: "Profile scan duration by source");
+    }
+
+    public void RecordMessageProcessed(string source, string result, double durationMs)
+    {
+        _messagesProcessedTotal.Add(1, new TagList
+        {
+            { "source", source },
+            { "result", result }
+        });
+        _processingDuration.Record(durationMs, new TagList { { "source", source } });
+    }
+
+    public void RecordModerationAction(string action, string trigger)
+    {
+        _moderationActionsTotal.Add(1, new TagList
+        {
+            { "action", action },
+            { "trigger", trigger }
+        });
+    }
+
+    public void RecordCommandHandled(string command)
+    {
+        _commandsHandledTotal.Add(1, new TagList { { "command", command } });
+    }
+
+    public void RecordProfileScan(string outcome, string source, double durationMs)
+    {
+        _profileScansTotal.Add(1, new TagList
+        {
+            { "outcome", outcome },
+            { "source", source }
+        });
+        _profileScanDuration.Record(durationMs, new TagList { { "source", source } });
+    }
+
+    public void RecordProfileScanTimeout()
+    {
+        _profileScanTimeoutsTotal.Add(1);
+    }
+
+    public void RecordProfileScanSkipped(string reason)
+    {
+        _profileScanSkippedTotal.Add(1, new TagList { { "reason", reason } });
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs
+++ b/TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs
@@ -11,7 +11,6 @@ public sealed class ReportMetrics
 {
     private readonly Counter<long> _createdTotal;
     private readonly Counter<long> _resolvedTotal;
-    private readonly Histogram<double> _resolutionDuration;
 
     private long _pendingCount;
 
@@ -27,11 +26,6 @@ public sealed class ReportMetrics
             "tga.reports.resolved_total",
             description: "Reports resolved by type and action");
 
-        _resolutionDuration = meter.CreateHistogram<double>(
-            "tga.reports.resolution.duration",
-            unit: "ms",
-            description: "Report resolution duration by type");
-
         meter.CreateObservableGauge(
             "tga.reports.pending_count",
             () => Interlocked.Read(ref _pendingCount),
@@ -44,10 +38,9 @@ public sealed class ReportMetrics
         Interlocked.Increment(ref _pendingCount);
     }
 
-    public void RecordReportResolved(string type, string action, double durationMs)
+    public void RecordReportResolved(string type, string action)
     {
         _resolvedTotal.Add(1, new TagList { { "type", type }, { "action", action } });
-        _resolutionDuration.Record(durationMs, new TagList { { "type", type } });
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs
+++ b/TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs
@@ -48,6 +48,14 @@ public sealed class ReportMetrics
     {
         _resolvedTotal.Add(1, new TagList { { "type", type }, { "action", action } });
         _resolutionDuration.Record(durationMs, new TagList { { "type", type } });
+    }
+
+    /// <summary>
+    /// Decrement the pending report count. Call when a report resolution is attempted
+    /// (regardless of success/failure) since the report is no longer awaiting a decision.
+    /// </summary>
+    public void DecrementPending()
+    {
         Interlocked.Decrement(ref _pendingCount);
     }
 }

--- a/TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs
+++ b/TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace TelegramGroupsAdmin.Telegram.Metrics;
+
+/// <summary>
+/// Metrics for report creation, resolution, and pending count.
+/// Pending count is eventually consistent — resets to 0 on app restart.
+/// </summary>
+public sealed class ReportMetrics
+{
+    private readonly Counter<long> _createdTotal;
+    private readonly Counter<long> _resolvedTotal;
+    private readonly Histogram<double> _resolutionDuration;
+
+    private long _pendingCount;
+
+    public ReportMetrics()
+    {
+        var meter = new Meter("TelegramGroupsAdmin.Reports");
+
+        _createdTotal = meter.CreateCounter<long>(
+            "tga.reports.created_total",
+            description: "Reports created by type and source");
+
+        _resolvedTotal = meter.CreateCounter<long>(
+            "tga.reports.resolved_total",
+            description: "Reports resolved by type and action");
+
+        _resolutionDuration = meter.CreateHistogram<double>(
+            "tga.reports.resolution.duration",
+            unit: "ms",
+            description: "Report resolution duration by type");
+
+        meter.CreateObservableGauge(
+            "tga.reports.pending_count",
+            () => Interlocked.Read(ref _pendingCount),
+            description: "Current total pending reports");
+    }
+
+    public void RecordReportCreated(string type, string source)
+    {
+        _createdTotal.Add(1, new TagList { { "type", type }, { "source", source } });
+        Interlocked.Increment(ref _pendingCount);
+    }
+
+    public void RecordReportResolved(string type, string action, double durationMs)
+    {
+        _resolvedTotal.Add(1, new TagList { { "type", type }, { "action", action } });
+        _resolutionDuration.Record(durationMs, new TagList { { "type", type } });
+        Interlocked.Decrement(ref _pendingCount);
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Metrics/WelcomeMetrics.cs
+++ b/TelegramGroupsAdmin.Telegram/Metrics/WelcomeMetrics.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace TelegramGroupsAdmin.Telegram.Metrics;
+
+/// <summary>
+/// Metrics for welcome flow outcomes, security checks, bot joins, timeouts, and user departures.
+/// </summary>
+public sealed class WelcomeMetrics
+{
+    private readonly Counter<long> _joinsTotal;
+    private readonly Counter<long> _securityChecksTotal;
+    private readonly Counter<long> _botJoinsTotal;
+    private readonly Counter<long> _timeoutsTotal;
+    private readonly Counter<long> _leavesTotal;
+    private readonly Histogram<double> _duration;
+
+    public WelcomeMetrics()
+    {
+        var meter = new Meter("TelegramGroupsAdmin.Welcome");
+
+        _joinsTotal = meter.CreateCounter<long>(
+            "tga.welcome.joins_total",
+            description: "Welcome flow outcomes by result");
+
+        _securityChecksTotal = meter.CreateCounter<long>(
+            "tga.welcome.security_checks_total",
+            description: "Security checks by check type and result");
+
+        _botJoinsTotal = meter.CreateCounter<long>(
+            "tga.welcome.bot_joins_total",
+            description: "Bot join outcomes by result");
+
+        _timeoutsTotal = meter.CreateCounter<long>(
+            "tga.welcome.timeouts_total",
+            description: "Welcome timeouts");
+
+        _leavesTotal = meter.CreateCounter<long>(
+            "tga.welcome.leaves_total",
+            description: "Users who left during welcome flow");
+
+        _duration = meter.CreateHistogram<double>(
+            "tga.welcome.duration",
+            unit: "ms",
+            description: "Welcome flow duration by result");
+    }
+
+    public void RecordWelcomeOutcome(string result, double durationMs)
+    {
+        _joinsTotal.Add(1, new TagList { { "result", result } });
+        _duration.Record(durationMs, new TagList { { "result", result } });
+    }
+
+    public void RecordSecurityCheck(string check, string result)
+    {
+        _securityChecksTotal.Add(1, new TagList
+        {
+            { "check", check },
+            { "result", result }
+        });
+    }
+
+    public void RecordBotJoin(string result)
+    {
+        _botJoinsTotal.Add(1, new TagList { { "result", result } });
+    }
+
+    public void RecordWelcomeTimeout()
+    {
+        _timeoutsTotal.Add(1);
+    }
+
+    public void RecordUserLeft()
+    {
+        _leavesTotal.Add(1);
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs
@@ -8,6 +8,7 @@ using TelegramGroupsAdmin.ContentDetection.Constants;
 using TelegramGroupsAdmin.ContentDetection.Models;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Telegram.Extensions;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
 
@@ -22,6 +23,7 @@ namespace TelegramGroupsAdmin.Telegram.Services.BackgroundServices;
 /// </summary>
 public class DetectionActionService(
     IServiceProvider serviceProvider,
+    PipelineMetrics pipelineMetrics,
     ILogger<DetectionActionService> logger)
 {
     /// <summary>
@@ -99,6 +101,7 @@ public class DetectionActionService(
                         TelegramMessage = message
                     },
                     cancellationToken);
+                pipelineMetrics.RecordModerationAction("ban", "auto");
 
                 return;
             }
@@ -129,6 +132,7 @@ public class DetectionActionService(
                         TelegramMessage = message
                     },
                     cancellationToken);
+                pipelineMetrics.RecordModerationAction("ban", "auto");
             }
             else if (spamResult.TotalScore > config.ReviewQueueThreshold)
             {
@@ -148,6 +152,7 @@ public class DetectionActionService(
                     message,
                     isAutomated: true,
                     cancellationToken);
+                pipelineMetrics.RecordModerationAction("report", "auto");
 
                 logger.LogInformation(
                     "Created admin review report for message {MessageId} in {Chat}: {Reason}",

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
@@ -34,6 +34,7 @@ public partial class MessageProcessingService(
     IChatCache chatCache,
     IServiceProvider serviceProvider,
     PipelineMetrics pipelineMetrics,
+    ChatMetrics chatMetrics,
     ILogger<MessageProcessingService> logger) : IMessageProcessingService
 {
     // REFACTOR-1: Specialized handlers injected via scoped services (created per request)
@@ -154,6 +155,19 @@ public partial class MessageProcessingService(
 
         // Keep SDK Chat cache warm (used by NotificationHandler and other services)
         chatCache.UpdateChat(message.Chat);
+
+        // Record message type metric for group messages
+        var messageType = message switch
+        {
+            { Photo: not null } => "photo",
+            { Video: not null } => "video",
+            { Animation: not null } => "animation",
+            { Document: not null } => "document",
+            { Sticker: not null } => "sticker",
+            _ when !string.IsNullOrEmpty(message.Text) => "text",
+            _ => "other"
+        };
+        chatMetrics.RecordMessage(messageType);
 
         // Detect Group → Supergroup migration
         // When a Group is upgraded to Supergroup (e.g., when granting admin), Telegram:

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -14,6 +15,7 @@ using TelegramGroupsAdmin.Telegram.Extensions;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Helpers;
 using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.Telegram.Services.BotCommands;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
@@ -31,6 +33,7 @@ public partial class MessageProcessingService(
     CommandRouter commandRouter,
     IChatCache chatCache,
     IServiceProvider serviceProvider,
+    PipelineMetrics pipelineMetrics,
     ILogger<MessageProcessingService> logger) : IMessageProcessingService
 {
     // REFACTOR-1: Specialized handlers injected via scoped services (created per request)
@@ -61,6 +64,8 @@ public partial class MessageProcessingService(
         activity?.SetTag("message.message_id", message.MessageId);
         activity?.SetTag("message.chat_type", message.Chat.Type.ToString());
         activity?.SetTag("message.has_text", !string.IsNullOrWhiteSpace(message.Text ?? message.Caption));
+
+        var startTimestamp = Stopwatch.GetTimestamp();
 
         // Skip private chats - only process group messages for history/spam detection
         if (message.Chat.Type == ChatType.Private)
@@ -142,6 +147,8 @@ public partial class MessageProcessingService(
                 }
             }
 
+            pipelineMetrics.RecordMessageProcessed("new_message", "skipped",
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
             return; // Don't process private messages further
         }
 
@@ -166,6 +173,8 @@ public partial class MessageProcessingService(
             using var migrationScope = scopeFactory.CreateScope();
             var chatService = migrationScope.ServiceProvider.GetRequiredService<IBotChatService>();
             await chatService.HandleChatMigrationAsync(oldChatId, newChatId, cancellationToken);
+            pipelineMetrics.RecordMessageProcessed("new_message", "skipped",
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
             return; // Don't process migration message further
         }
 
@@ -274,6 +283,8 @@ public partial class MessageProcessingService(
                     message.Chat.ToLogDebug());
             }
 
+            pipelineMetrics.RecordMessageProcessed("new_message", "skipped",
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
             return; // Don't process service messages further
         }
 
@@ -747,9 +758,14 @@ public partial class MessageProcessingService(
                         cancellationToken);
                 }
             }
+
+            pipelineMetrics.RecordMessageProcessed("new_message", "processed",
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
         }
         catch (Exception ex)
         {
+            pipelineMetrics.RecordMessageProcessed("new_message", "error",
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
             logger.LogError(ex,
                 "Error caching message {MessageId} from {User} in {Chat}",
                 message.MessageId,
@@ -768,6 +784,8 @@ public partial class MessageProcessingService(
         activity?.SetTag("message.message_id", editedMessage.MessageId);
         activity?.SetTag("message.chat_type", editedMessage.Chat.Type.ToString());
 
+        var startTimestamp = Stopwatch.GetTimestamp();
+
         try
         {
             using var scope = scopeFactory.CreateScope();
@@ -780,9 +798,14 @@ public partial class MessageProcessingService(
             {
                 OnMessageEdited?.Invoke(editRecord);
             }
+
+            pipelineMetrics.RecordMessageProcessed("edit", "processed",
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
         }
         catch (Exception ex)
         {
+            pipelineMetrics.RecordMessageProcessed("edit", "error",
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
             logger.LogError(ex,
                 "Error handling edit for message {MessageId}",
                 editedMessage.MessageId);

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotChatService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotChatService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Telegram.Bot.Exceptions;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using TelegramGroupsAdmin.Configuration.Repositories;
@@ -98,6 +99,7 @@ public class BotChatService(
         catch (Exception ex)
         {
             apiMetrics.RecordTelegramApiCall("get_chat", success: false);
+            apiMetrics.RecordTelegramApiError(ex is ApiRequestException apiEx ? apiEx.ErrorCode.ToString() : ex.GetType().Name);
             logger.LogWarning(ex, "Health check failed for {Chat}", chat.ToLogDebug());
             return false;
         }
@@ -506,6 +508,7 @@ public class BotChatService(
         catch (Exception ex)
         {
             apiMetrics.RecordTelegramApiCall("get_chat_administrators", success: false);
+            apiMetrics.RecordTelegramApiError(ex is ApiRequestException apiEx ? apiEx.ErrorCode.ToString() : ex.GetType().Name);
             logger.LogWarning(ex, "Failed to refresh admins for {Chat}", chat.ToLogDebug());
             throw; // Re-throw so caller can track failures
         }

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotChatService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotChatService.cs
@@ -3,6 +3,7 @@ using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using TelegramGroupsAdmin.Configuration.Repositories;
 using TelegramGroupsAdmin.Core.Extensions;
+using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Telegram.Extensions;
@@ -27,11 +28,14 @@ public class BotChatService(
     ITelegramUserRepository userRepo,
     IUserActionsRepository userActionsRepo,
     INotificationService notificationService,
+    ApiMetrics apiMetrics,
     ILogger<BotChatService> logger) : IBotChatService
 {
     public async Task<ChatFullInfo> GetChatAsync(long chatId, CancellationToken ct = default)
     {
-        return await chatHandler.GetChatAsync(chatId, ct);
+        var chat = await chatHandler.GetChatAsync(chatId, ct);
+        apiMetrics.RecordTelegramApiCall("get_chat", success: true);
+        return chat;
     }
 
     public async Task<string?> GetInviteLinkAsync(long chatId, CancellationToken ct = default)
@@ -79,6 +83,7 @@ public class BotChatService(
     public async Task LeaveChatAsync(long chatId, CancellationToken ct = default)
     {
         await chatHandler.LeaveChatAsync(chatId, ct);
+        apiMetrics.RecordTelegramApiCall("leave_chat", success: true);
     }
 
     public async Task<bool> CheckHealthAsync(ChatIdentity chat, CancellationToken ct = default)
@@ -87,10 +92,12 @@ public class BotChatService(
         {
             // Basic health check - can we get chat info?
             var chatInfo = await chatHandler.GetChatAsync(chat.Id, ct);
+            apiMetrics.RecordTelegramApiCall("get_chat", success: true);
             return chatInfo != null;
         }
         catch (Exception ex)
         {
+            apiMetrics.RecordTelegramApiCall("get_chat", success: false);
             logger.LogWarning(ex, "Health check failed for {Chat}", chat.ToLogDebug());
             return false;
         }
@@ -402,6 +409,7 @@ public class BotChatService(
         {
             // Check if this is a group chat (only groups/supergroups have administrators)
             var sdkChat = await chatHandler.GetChatAsync(chat.Id, ct);
+            apiMetrics.RecordTelegramApiCall("get_chat", success: true);
             if (sdkChat.Type != ChatType.Group && sdkChat.Type != ChatType.Supergroup)
             {
                 logger.LogDebug("Skipping admin refresh for non-group chat {Chat} (type: {Type})",
@@ -411,6 +419,7 @@ public class BotChatService(
 
             // Get all administrators from Telegram
             var admins = await chatHandler.GetChatAdministratorsAsync(chat.Id, ct);
+            apiMetrics.RecordTelegramApiCall("get_chat_administrators", success: true);
 
             // Get current admin IDs from Telegram
             var currentAdminIds = admins.Select(a => a.User.Id).ToHashSet();
@@ -496,6 +505,7 @@ public class BotChatService(
         }
         catch (Exception ex)
         {
+            apiMetrics.RecordTelegramApiCall("get_chat_administrators", success: false);
             logger.LogWarning(ex, "Failed to refresh admins for {Chat}", chat.ToLogDebug());
             throw; // Re-throw so caller can track failures
         }
@@ -543,6 +553,7 @@ public class BotChatService(
     private async Task<string?> FetchAndCacheInviteLinkAsync(long chatId, CancellationToken ct)
     {
         var chat = await chatHandler.GetChatAsync(chatId, ct);
+        apiMetrics.RecordTelegramApiCall("get_chat", success: true);
         string? currentLink;
 
         // Public group - use username link (e.g., https://t.me/groupname)
@@ -577,6 +588,7 @@ public class BotChatService(
         // No cached link - export the primary link (this WILL revoke any previous primary link)
         // This should only happen on first setup
         currentLink = await chatHandler.ExportChatInviteLinkAsync(chatId, ct);
+        apiMetrics.RecordTelegramApiCall("export_chat_invite_link", success: true);
         logger.LogWarning(
             "Exported PRIMARY invite link for private chat {ChatId} - this revokes previous primary link! Link: {Link}",
             chatId,

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotMessageService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotMessageService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
+using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Extensions;
@@ -24,6 +25,7 @@ public class BotMessageService(
     IMessageHistoryRepository messageRepo,
     IMessageEditService editService,
     ITelegramUserRepository userRepo,
+    ApiMetrics apiMetrics,
     ILogger<BotMessageService> logger) : IBotMessageService
 {
 
@@ -47,6 +49,7 @@ public class BotMessageService(
             replyParameters: replyParameters,
             replyMarkup: replyMarkup,
             ct: cancellationToken);
+        apiMetrics.RecordTelegramApiCall("send_message", success: true);
 
         // Get bot user info (cached in singleton IBotIdentityCache via IBotUserService)
         var botInfo = await userService.GetMeAsync(cancellationToken);
@@ -145,6 +148,7 @@ public class BotMessageService(
             parseMode: parseMode,
             replyMarkup: replyMarkup,
             ct: cancellationToken);
+        apiMetrics.RecordTelegramApiCall("edit_message", success: true);
 
         var editDate = editedMessage.EditDate.HasValue
             ? new DateTimeOffset(editedMessage.EditDate.Value, TimeSpan.Zero) // DateTime (UTC) → DateTimeOffset
@@ -204,6 +208,7 @@ public class BotMessageService(
         {
             // Delete from Telegram via handler
             await messageHandler.DeleteAsync(chatId, messageId, cancellationToken);
+            apiMetrics.RecordTelegramApiCall("delete_message", success: true);
 
             // Mark as deleted in database
             await messageRepo.MarkMessageAsDeletedAsync(messageId, chatId, deletionSource, cancellationToken);
@@ -216,6 +221,8 @@ public class BotMessageService(
         }
         catch (Exception ex)
         {
+            apiMetrics.RecordTelegramApiCall("delete_message", success: false);
+
             logger.LogWarning(ex,
                 "Failed to delete message {MessageId} from Telegram (chat: {ChatId}), marking as deleted in DB anyway",
                 messageId,
@@ -255,6 +262,7 @@ public class BotMessageService(
 
         // Get chat info for the name
         var chatInfo = await chatHandler.GetChatAsync(chatId, cancellationToken);
+        apiMetrics.RecordTelegramApiCall("get_chat", success: true);
 
         // Upsert bot to telegram_users table (ensures bot name is available for UI display)
         var now = DateTimeOffset.UtcNow;
@@ -332,6 +340,7 @@ public class BotMessageService(
             text: text,
             showAlert: showAlert,
             ct: cancellationToken);
+        apiMetrics.RecordTelegramApiCall("answer_callback_query", success: true);
     }
 
     /// <summary>
@@ -352,6 +361,7 @@ public class BotMessageService(
             caption: caption,
             parseMode: parseMode,
             ct: cancellationToken);
+        apiMetrics.RecordTelegramApiCall("send_animation", success: true);
 
         // Get bot user info (cached in singleton IBotIdentityCache via IBotUserService)
         var botInfo = await userService.GetMeAsync(cancellationToken);

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotMessageService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotMessageService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Telegram.Bot.Exceptions;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
@@ -222,6 +223,7 @@ public class BotMessageService(
         catch (Exception ex)
         {
             apiMetrics.RecordTelegramApiCall("delete_message", success: false);
+            apiMetrics.RecordTelegramApiError(ex is ApiRequestException apiEx ? apiEx.ErrorCode.ToString() : ex.GetType().Name);
 
             logger.LogWarning(ex,
                 "Failed to delete message {MessageId} from Telegram (chat: {ChatId}), marking as deleted in DB anyway",

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotUserService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotUserService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Telegram.Bot.Exceptions;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using TelegramGroupsAdmin.Core.Metrics;
@@ -53,6 +54,7 @@ public class BotUserService(
         catch (Exception ex)
         {
             apiMetrics.RecordTelegramApiCall("get_chat_member", success: false);
+            apiMetrics.RecordTelegramApiError(ex is ApiRequestException apiEx ? apiEx.ErrorCode.ToString() : ex.GetType().Name);
             logger.LogWarning(ex, "Failed to check admin status for user {UserId} in chat {ChatId}",
                 userId, chatId);
             return false;

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotUserService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotUserService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
+using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Bot.Handlers;
 
 namespace TelegramGroupsAdmin.Telegram.Services.Bot;
@@ -12,6 +13,7 @@ namespace TelegramGroupsAdmin.Telegram.Services.Bot;
 public class BotUserService(
     IBotUserHandler userHandler,
     IBotIdentityCache identityCache,
+    ApiMetrics apiMetrics,
     ILogger<BotUserService> logger) : IBotUserService
 {
     public async Task<User> GetMeAsync(CancellationToken ct = default)
@@ -25,6 +27,7 @@ public class BotUserService(
 
         // Fetch from API and cache
         var botUser = await userHandler.GetMeAsync(ct);
+        apiMetrics.RecordTelegramApiCall("get_me", success: true);
         identityCache.SetBotUser(botUser);
         logger.LogDebug("Cached bot user info: @{Username} ({Id})",
             botUser.Username, botUser.Id);
@@ -34,7 +37,9 @@ public class BotUserService(
 
     public async Task<ChatMember> GetChatMemberAsync(long chatId, long userId, CancellationToken ct = default)
     {
-        return await userHandler.GetChatMemberAsync(chatId, userId, ct);
+        var member = await userHandler.GetChatMemberAsync(chatId, userId, ct);
+        apiMetrics.RecordTelegramApiCall("get_chat_member", success: true);
+        return member;
     }
 
     public async Task<bool> IsAdminAsync(long chatId, long userId, CancellationToken ct = default)
@@ -42,10 +47,12 @@ public class BotUserService(
         try
         {
             var member = await userHandler.GetChatMemberAsync(chatId, userId, ct);
+            apiMetrics.RecordTelegramApiCall("get_chat_member", success: true);
             return member.Status is ChatMemberStatus.Administrator or ChatMemberStatus.Creator;
         }
         catch (Exception ex)
         {
+            apiMetrics.RecordTelegramApiCall("get_chat_member", success: false);
             logger.LogWarning(ex, "Failed to check admin status for user {UserId} in chat {ChatId}",
                 userId, chatId);
             return false;
@@ -54,6 +61,7 @@ public class BotUserService(
 
     public async Task<long> GetBotIdAsync(CancellationToken ct = default)
     {
+        // Delegates to GetMeAsync which already records metrics
         var botUser = await GetMeAsync(ct);
         return botUser.Id;
     }

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/ChatHealthCache.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/ChatHealthCache.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Telegram.Models;
 
@@ -10,7 +11,7 @@ namespace TelegramGroupsAdmin.Telegram.Services.Bot;
 /// Singleton service that maintains an in-memory cache of chat health statuses.
 /// No Telegram API calls - just stores and retrieves state.
 /// </summary>
-public class ChatHealthCache(ILogger<ChatHealthCache> logger) : IChatHealthCache
+public class ChatHealthCache(ILogger<ChatHealthCache> logger, CacheMetrics cacheMetrics) : IChatHealthCache
 {
     private readonly ConcurrentDictionary<long, ChatHealthStatus> _healthCache = new();
     private readonly ConcurrentDictionary<long, int> _failureCounts = new();
@@ -18,7 +19,16 @@ public class ChatHealthCache(ILogger<ChatHealthCache> logger) : IChatHealthCache
     public event Action<ChatHealthStatus>? OnHealthUpdate;
 
     public ChatHealthStatus? GetCachedHealth(long chatId)
-        => _healthCache.TryGetValue(chatId, out var health) ? health : null;
+    {
+        if (_healthCache.TryGetValue(chatId, out var health))
+        {
+            cacheMetrics.RecordHit("chat_health");
+            return health;
+        }
+
+        cacheMetrics.RecordMiss("chat_health");
+        return null;
+    }
 
     public IReadOnlyList<ChatIdentity> GetHealthyChatIdentities()
     {
@@ -59,7 +69,8 @@ public class ChatHealthCache(ILogger<ChatHealthCache> logger) : IChatHealthCache
 
     public void RemoveHealth(long chatId)
     {
-        _healthCache.TryRemove(chatId, out _);
+        if (_healthCache.TryRemove(chatId, out _))
+            cacheMetrics.RecordRemoval("chat_health");
     }
 
     public IReadOnlyDictionary<long, ChatHealthStatus> GetAllCachedHealth()

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs
@@ -5,6 +5,7 @@ using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Extensions;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Repositories;
 
 namespace TelegramGroupsAdmin.Telegram.Services.BotCommands;
@@ -21,16 +22,19 @@ public partial class CommandRouter
 {
     private readonly ILogger<CommandRouter> _logger;
     private readonly IServiceProvider _serviceProvider;
+    private readonly PipelineMetrics _pipelineMetrics;
 
     [GeneratedRegex(@"^/(\w+)(?:@\w+)?(?:\s+(.*))?$", RegexOptions.Compiled)]
     private static partial Regex CommandPattern();
 
     public CommandRouter(
         ILogger<CommandRouter> logger,
-        IServiceProvider serviceProvider)
+        IServiceProvider serviceProvider,
+        PipelineMetrics pipelineMetrics)
     {
         _logger = logger;
         _serviceProvider = serviceProvider;
+        _pipelineMetrics = pipelineMetrics;
     }
 
     /// <summary>
@@ -128,6 +132,7 @@ public partial class CommandRouter
                 string.Join(", ", args));
 
             var result = await command.ExecuteAsync(message, args, permissionLevel, cancellationToken);
+            _pipelineMetrics.RecordCommandHandled(commandName);
 
             // Commands can now return dynamic CommandResult or use defaults from interface properties
             return result;

--- a/TelegramGroupsAdmin.Telegram/Services/ChatCache.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ChatCache.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Metrics;
 
 namespace TelegramGroupsAdmin.Telegram.Services;
 
@@ -7,13 +8,20 @@ namespace TelegramGroupsAdmin.Telegram.Services;
 /// Thread-safe in-memory cache for SDK Chat objects.
 /// Singleton service - populated by health checks (startup + periodic) and message processing.
 /// </summary>
-public class ChatCache : IChatCache
+public class ChatCache(CacheMetrics cacheMetrics) : IChatCache
 {
     private readonly ConcurrentDictionary<long, Chat> _cache = new();
 
     /// <inheritdoc />
     public Chat? GetChat(long chatId)
-        => _cache.GetValueOrDefault(chatId);
+    {
+        var chat = _cache.GetValueOrDefault(chatId);
+        if (chat != null)
+            cacheMetrics.RecordHit("chat");
+        else
+            cacheMetrics.RecordMiss("chat");
+        return chat;
+    }
 
     /// <inheritdoc />
     public void UpdateChat(Chat chat)
@@ -21,7 +29,10 @@ public class ChatCache : IChatCache
 
     /// <inheritdoc />
     public void RemoveChat(long chatId)
-        => _cache.TryRemove(chatId, out _);
+    {
+        if (_cache.TryRemove(chatId, out _))
+            cacheMetrics.RecordRemoval("chat");
+    }
 
     /// <inheritdoc />
     public IReadOnlyCollection<Chat> GetAllChats()

--- a/TelegramGroupsAdmin.Telegram/Services/ChatHealthRefreshOrchestrator.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ChatHealthRefreshOrchestrator.cs
@@ -6,6 +6,7 @@ using TelegramGroupsAdmin.Core.Extensions;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Telegram.Extensions;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
@@ -31,6 +32,7 @@ public class ChatHealthRefreshOrchestrator(
     TelegramPhotoService photoService,
     IPhotoHashService photoHashService,
     INotificationService notificationService,
+    ChatMetrics chatMetrics,
     ILogger<ChatHealthRefreshOrchestrator> logger) : IChatHealthRefreshOrchestrator
 {
     /// <summary>
@@ -47,6 +49,7 @@ public class ChatHealthRefreshOrchestrator(
 
             if (!isReachable)
             {
+                chatMetrics.RecordHealthCheck("unreachable");
                 var failureCount = healthCache.IncrementFailureCount(chat.Id);
                 logger.LogDebug("Reachability check failed for {Chat}, consecutive failures: {Count}",
                     chat.ToLogDebug(), failureCount);
@@ -57,6 +60,7 @@ public class ChatHealthRefreshOrchestrator(
                         "Chat {Chat} unreachable after {Count} consecutive failures, marking inactive",
                         chat.ToLogDebug(), failureCount);
                     await managedChatsRepository.MarkInactiveAsync(chat, cancellationToken);
+                    chatMetrics.RecordChatMarkedInactive();
                     healthCache.ResetFailureCount(chat.Id);
                 }
 
@@ -76,6 +80,15 @@ public class ChatHealthRefreshOrchestrator(
 
             var health = await PerformHealthCheckAsync(chat, cancellationToken);
             healthCache.SetHealth(chat.Id, health);
+
+            // Record health check result as metric
+            var healthResult = health.Status switch
+            {
+                ChatHealthStatusType.Healthy or ChatHealthStatusType.NotApplicable => "healthy",
+                ChatHealthStatusType.Warning => "degraded",
+                _ => "unreachable"
+            };
+            chatMetrics.RecordHealthCheck(healthResult);
 
             // Update chat name in database if Telegram returned a fresher name
             var freshName = health.Chat.ChatName;

--- a/TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs
@@ -111,7 +111,7 @@ internal sealed class ReportActionsService(
             var result = await handler(scope);
 
             if (result.Success)
-                reportMetrics.RecordReportResolved(reportType, action, 0);
+                reportMetrics.RecordReportResolved(reportType, action);
 
             return result;
         }

--- a/TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs
@@ -122,6 +122,10 @@ internal sealed class ReportActionsService(
         }
         finally
         {
+            // Always decrement pending count — the report is no longer awaiting a decision
+            // regardless of whether the action succeeded or failed
+            reportMetrics.DecrementPending();
+
             if (acquired)
                 entry.Semaphore.Release();
             if (Interlocked.Decrement(ref entry.ReferenceCount) == 0)

--- a/TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Metrics;
 
 namespace TelegramGroupsAdmin.Telegram.Services.ReportActions;
 
@@ -11,6 +12,7 @@ namespace TelegramGroupsAdmin.Telegram.Services.ReportActions;
 /// </summary>
 internal sealed class ReportActionsService(
     IServiceScopeFactory scopeFactory,
+    ReportMetrics reportMetrics,
     ILogger<ReportActionsService> logger) : IReportActionsService
 {
     private sealed class ReportLock
@@ -23,76 +25,78 @@ internal sealed class ReportActionsService(
 
     // Content report actions
     public Task<ReviewActionResult> HandleContentSpamAsync(long reportId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(reportId, scope =>
+        => ExecuteWithLockAsync(reportId, "content", "spam", scope =>
             scope.ServiceProvider.GetRequiredService<IContentReportHandler>()
                 .SpamAsync(reportId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleContentBanAsync(long reportId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(reportId, scope =>
+        => ExecuteWithLockAsync(reportId, "content", "ban", scope =>
             scope.ServiceProvider.GetRequiredService<IContentReportHandler>()
                 .BanAsync(reportId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleContentWarnAsync(long reportId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(reportId, scope =>
+        => ExecuteWithLockAsync(reportId, "content", "warn", scope =>
             scope.ServiceProvider.GetRequiredService<IContentReportHandler>()
                 .WarnAsync(reportId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleContentDismissAsync(long reportId, Actor executor, string? reason, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(reportId, scope =>
+        => ExecuteWithLockAsync(reportId, "content", "dismiss", scope =>
             scope.ServiceProvider.GetRequiredService<IContentReportHandler>()
                 .DismissAsync(reportId, executor, reason, cancellationToken: cancellationToken), cancellationToken);
 
     // Profile scan actions
     public Task<ReviewActionResult> HandleProfileScanBanAsync(long alertId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(alertId, scope =>
+        => ExecuteWithLockAsync(alertId, "profile_scan", "ban", scope =>
             scope.ServiceProvider.GetRequiredService<IProfileScanHandler>()
                 .BanAsync(alertId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleProfileScanKickAsync(long alertId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(alertId, scope =>
+        => ExecuteWithLockAsync(alertId, "profile_scan", "kick", scope =>
             scope.ServiceProvider.GetRequiredService<IProfileScanHandler>()
                 .KickAsync(alertId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleProfileScanAllowAsync(long alertId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(alertId, scope =>
+        => ExecuteWithLockAsync(alertId, "profile_scan", "allow", scope =>
             scope.ServiceProvider.GetRequiredService<IProfileScanHandler>()
                 .AllowAsync(alertId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     // Impersonation actions
     public Task<ReviewActionResult> HandleImpersonationConfirmAsync(long alertId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(alertId, scope =>
+        => ExecuteWithLockAsync(alertId, "impersonation", "confirm", scope =>
             scope.ServiceProvider.GetRequiredService<IImpersonationHandler>()
                 .ConfirmAsync(alertId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleImpersonationDismissAsync(long alertId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(alertId, scope =>
+        => ExecuteWithLockAsync(alertId, "impersonation", "dismiss", scope =>
             scope.ServiceProvider.GetRequiredService<IImpersonationHandler>()
                 .DismissAsync(alertId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleImpersonationTrustAsync(long alertId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(alertId, scope =>
+        => ExecuteWithLockAsync(alertId, "impersonation", "trust", scope =>
             scope.ServiceProvider.GetRequiredService<IImpersonationHandler>()
                 .TrustAsync(alertId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     // Exam actions
     public Task<ReviewActionResult> HandleExamApproveAsync(long examId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(examId, scope =>
+        => ExecuteWithLockAsync(examId, "exam_failure", "approve", scope =>
             scope.ServiceProvider.GetRequiredService<IExamHandler>()
                 .ApproveAsync(examId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleExamDenyAsync(long examId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(examId, scope =>
+        => ExecuteWithLockAsync(examId, "exam_failure", "deny", scope =>
             scope.ServiceProvider.GetRequiredService<IExamHandler>()
                 .DenyAsync(examId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     public Task<ReviewActionResult> HandleExamDenyAndBanAsync(long examId, Actor executor, CancellationToken cancellationToken)
-        => ExecuteWithLockAsync(examId, scope =>
+        => ExecuteWithLockAsync(examId, "exam_failure", "deny_and_ban", scope =>
             scope.ServiceProvider.GetRequiredService<IExamHandler>()
                 .DenyAndBanAsync(examId, executor, cancellationToken: cancellationToken), cancellationToken);
 
     private async Task<ReviewActionResult> ExecuteWithLockAsync(
         long reportId,
-        Func<IServiceScope, Task<ReviewActionResult>> action,
+        string reportType,
+        string action,
+        Func<IServiceScope, Task<ReviewActionResult>> handler,
         CancellationToken cancellationToken)
     {
         var entry = _reportLocks.GetOrAdd(reportId, _ => new ReportLock());
@@ -104,7 +108,12 @@ internal sealed class ReportActionsService(
             acquired = true;
 
             await using var scope = scopeFactory.CreateAsyncScope();
-            return await action(scope);
+            var result = await handler(scope);
+
+            if (result.Success)
+                reportMetrics.RecordReportResolved(reportType, action, 0);
+
+            return result;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/TelegramGroupsAdmin.Telegram/Services/ReportService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportService.cs
@@ -5,6 +5,7 @@ using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Core.Repositories;
 using TelegramGroupsAdmin.Telegram.Extensions;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Repositories;
 
 namespace TelegramGroupsAdmin.Telegram.Services;
@@ -18,6 +19,7 @@ public class ReportService(
     INotificationService notificationService,
     IAuditService auditService,
     IMessageHistoryRepository messageHistoryRepository,
+    ReportMetrics reportMetrics,
     ILogger<ReportService> logger) : IReportService
 {
     public async Task<ReportCreationResult> CreateReportAsync(
@@ -36,6 +38,8 @@ public class ReportService(
 
         // 1. Insert report into database
         var reportId = await reportsRepository.InsertContentReportAsync(report, cancellationToken);
+
+        reportMetrics.RecordReportCreated("content", isAutomated ? "auto" : "user");
 
         logger.LogInformation(
             "Report {ReportId} created: ChatId={ChatId}, MessageId={MessageId}, IsAutomated={IsAutomated}, ReportedBy={ReportedBy}",

--- a/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs
@@ -12,6 +12,8 @@ using TelegramGroupsAdmin.Core.Services.AI;
 using TelegramGroupsAdmin.Telegram.Extensions;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
+using System.Diagnostics;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
 using TL;
@@ -26,6 +28,7 @@ namespace TelegramGroupsAdmin.Telegram.Services.UserApi;
 public sealed class ProfileScanService(
     ITelegramSessionManager sessionManager,
     IServiceScopeFactory scopeFactory,
+    PipelineMetrics pipelineMetrics,
     ILogger<ProfileScanService> logger) : IProfileScanService
 {
     /// <summary>
@@ -45,6 +48,9 @@ public sealed class ProfileScanService(
         ChatIdentity? triggeringChat,
         CancellationToken ct)
     {
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var scanSource = triggeringChat is not null ? "welcome" : "rescan";
+
         await using var scope = scopeFactory.CreateAsyncScope();
         var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
 
@@ -62,6 +68,7 @@ public sealed class ProfileScanService(
             logger.LogDebug("Profile scan for {User}: recently scanned ({LastScan}), reusing cached score {Score}",
                 user.ToLogDebug(), lastScan, existingUser.ProfileScanScore);
 
+            pipelineMetrics.RecordProfileScanSkipped("dedup");
             var cachedOutcome = await DetermineOutcomeAsync(existingUser.ProfileScanScore.Value, triggeringChat, scope.ServiceProvider, ct);
             return new ProfileScanResult(
                 user.Id,
@@ -79,6 +86,7 @@ public sealed class ProfileScanService(
         if (client == null)
         {
             logger.LogWarning("No User API client available for profile scan of {User}", user.ToLogDebug());
+            pipelineMetrics.RecordProfileScanSkipped("no_session");
             return EmptyResult(user.Id, "No User API session available. Connect a session in Settings.");
         }
 
@@ -110,10 +118,15 @@ public sealed class ProfileScanService(
                     TaskContinuationOptions.OnlyOnFaulted,
                     TaskScheduler.Default);
 
+                pipelineMetrics.RecordProfileScanTimeout();
                 return EmptyResult(user.Id, $"Scan timed out after {ScanTimeout.TotalSeconds}s");
             }
 
-            return await scanTask; // propagate result or exception
+            var result = await scanTask;
+            pipelineMetrics.RecordProfileScan(
+                OutcomeToTag(result.Outcome), scanSource,
+                Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
+            return result;
         }
         catch (TelegramFloodWaitException ex)
         {
@@ -156,6 +169,7 @@ public sealed class ProfileScanService(
         {
             logger.LogWarning("Could not resolve {User} — marking as excluded from future rescans", user.ToLogDebug());
             await userRepo.ExcludeFromProfileScanAsync(user.Id, ct);
+            pipelineMetrics.RecordProfileScanSkipped("excluded");
             return EmptyResult(user.Id, "User could not be resolved — they may have deleted their Telegram account.");
         }
 
@@ -813,4 +827,12 @@ public sealed class ProfileScanService(
     private static ProfileScanResult EmptyResult(long userId, string? skipReason = null) =>
         new(userId, null, null, null, null, false, null, false, false, false,
             0.0m, ProfileScanOutcome.Clean, null, null, ContainsNudity: false, skipReason);
+
+    private static string OutcomeToTag(ProfileScanOutcome outcome) => outcome switch
+    {
+        ProfileScanOutcome.Clean => "clean",
+        ProfileScanOutcome.HeldForReview => "held_for_review",
+        ProfileScanOutcome.Banned => "banned",
+        _ => outcome.ToString().ToLowerInvariant()
+    };
 }

--- a/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
@@ -10,6 +11,7 @@ using static TelegramGroupsAdmin.Core.BackgroundJobs.DeduplicationKeys;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Extensions;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
@@ -42,6 +44,8 @@ public class WelcomeService(
     IProfileScanService profileScanService,
     ITelegramSessionManager sessionManager,
     IWelcomeAdmissionHandler admissionHandler,
+    WelcomeMetrics welcomeMetrics,
+    ChatMetrics chatMetrics,
     ILogger<WelcomeService> logger) : IWelcomeService
 {
     // Deletion source constants for audit tracking
@@ -64,6 +68,8 @@ public class WelcomeService(
         ChatMemberUpdated chatMemberUpdate,
         CancellationToken cancellationToken)
     {
+        var startTimestamp = Stopwatch.GetTimestamp();
+
         // Detect new user joins (status changed to Member)
         var oldStatus = chatMemberUpdate.OldChatMember.Status;
         var newStatus = chatMemberUpdate.NewChatMember.Status;
@@ -100,13 +106,18 @@ public class WelcomeService(
                     user,
                     "Not whitelisted and not invited by admin",
                     cancellationToken);
+                welcomeMetrics.RecordBotJoin("banned");
                 return;
             }
 
             // Bot is allowed (whitelisted or admin-invited) - skip welcome message
             logger.LogDebug("Skipping welcome for allowed bot {User}", user.ToLogDebug());
+            welcomeMetrics.RecordBotJoin("allowed");
             return;
         }
+
+        // Human user join — record once before any security check
+        chatMetrics.RecordUserJoin();
 
         logger.LogInformation(
             "New user joined: {User} in {Chat}",
@@ -130,6 +141,7 @@ public class WelcomeService(
                     "Skipping welcome for admin/owner: {User} in {Chat}",
                     user.ToLogInfo(),
                     chatMemberUpdate.Chat.ToLogInfo());
+                welcomeMetrics.RecordWelcomeOutcome("skipped_admin", Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
                 return;
             }
 
@@ -153,6 +165,7 @@ public class WelcomeService(
                         Reason = "Lazy ban sync: User was globally banned before joining this chat",
                     },
                     cancellationToken);
+                welcomeMetrics.RecordWelcomeOutcome("pre_banned", Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
                 return;
             }
 
@@ -206,12 +219,17 @@ public class WelcomeService(
                     logger.LogInformation(
                         "{User} auto-banned (username blacklist), skipping welcome flow",
                         user.ToLogInfo());
+                    welcomeMetrics.RecordSecurityCheck("username_blacklist", "fail");
+                    welcomeMetrics.RecordWelcomeOutcome("banned", Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
                     return;
                 }
+
+                welcomeMetrics.RecordSecurityCheck("username_blacklist", "pass");
             }
             else
             {
                 logger.LogDebug("Username blacklist check skipped for {User}", user.ToLogDebug());
+                welcomeMetrics.RecordSecurityCheck("username_blacklist", "skipped");
             }
 
             // Step 6: CAS (Combot Anti-Spam) check - auto-ban known spammers FIRST (fail fast)
@@ -245,12 +263,17 @@ public class WelcomeService(
                     logger.LogInformation(
                         "{User} auto-banned (CAS), skipping welcome flow",
                         user.ToLogInfo());
+                    welcomeMetrics.RecordSecurityCheck("cas", "fail");
+                    welcomeMetrics.RecordWelcomeOutcome("banned", Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
                     return;
                 }
+
+                welcomeMetrics.RecordSecurityCheck("cas", "pass");
             }
             else
             {
                 logger.LogDebug("CAS check disabled, skipping for {User}", user.ToLogDebug());
+                welcomeMetrics.RecordSecurityCheck("cas", "skipped");
             }
 
             // Step 7: Photo fetch (sync, ~1.8s) - enables full impersonation detection
@@ -316,6 +339,9 @@ public class WelcomeService(
                             logger.LogInformation(
                                 "{User} auto-banned for impersonation, skipping welcome flow",
                                 user.ToLogInfo());
+                            welcomeMetrics.RecordSecurityCheck("impersonation", "fail");
+                            welcomeMetrics.RecordSecurityCheck("photo_match", "fail");
+                            welcomeMetrics.RecordWelcomeOutcome("banned", Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
                             return;
                         }
 
@@ -324,12 +350,26 @@ public class WelcomeService(
                             "{User} flagged for impersonation review (score: {Score}), continuing with welcome flow",
                             user.ToLogInfo(),
                             impersonationResult.TotalScore);
+                        welcomeMetrics.RecordSecurityCheck("impersonation", "pass");
+                        welcomeMetrics.RecordSecurityCheck("photo_match", "pass");
                     }
+                    else
+                    {
+                        welcomeMetrics.RecordSecurityCheck("impersonation", "pass");
+                        welcomeMetrics.RecordSecurityCheck("photo_match", "pass");
+                    }
+                }
+                else
+                {
+                    welcomeMetrics.RecordSecurityCheck("impersonation", "skipped");
+                    welcomeMetrics.RecordSecurityCheck("photo_match", "skipped");
                 }
             }
             else
             {
                 logger.LogDebug("Impersonation detection disabled, skipping for {User}", user.ToLogDebug());
+                welcomeMetrics.RecordSecurityCheck("impersonation", "skipped");
+                welcomeMetrics.RecordSecurityCheck("photo_match", "skipped");
             }
 
             // Step 9: Profile scan via User API (skip trusted users)
@@ -351,6 +391,8 @@ public class WelcomeService(
                         logger.LogInformation(
                             "{User} auto-banned by profile scan (score {Score}), skipping welcome flow",
                             user.ToLogInfo(), scanResult.Score);
+                        welcomeMetrics.RecordSecurityCheck("profile_scan", "fail");
+                        welcomeMetrics.RecordWelcomeOutcome("banned", Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
                         return; // User already banned by ProfileScanService
                     }
 
@@ -367,12 +409,19 @@ public class WelcomeService(
                             user.ToLogInfo(), scanResult.Score);
                         // Fall through — exam will run below if configured (dual-gate: both must pass)
                     }
+
+                    welcomeMetrics.RecordSecurityCheck("profile_scan", "pass");
                 }
                 else
                 {
                     logger.LogDebug("No User API session available, skipping profile scan for {User}",
                         user.ToLogDebug());
+                    welcomeMetrics.RecordSecurityCheck("profile_scan", "skipped");
                 }
+            }
+            else
+            {
+                welcomeMetrics.RecordSecurityCheck("profile_scan", "skipped");
             }
 
             // ═══════════════════════════════════════════════════════════════════
@@ -416,6 +465,7 @@ public class WelcomeService(
                         user.ToLogInfo(),
                         chatMemberUpdate.Chat.ToLogInfo());
                 }
+                welcomeMetrics.RecordWelcomeOutcome("admitted", Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds);
                 return;
             }
 
@@ -926,10 +976,15 @@ public class WelcomeService(
             ReasonCompletedWelcome,
             cancellationToken);
 
+        var durationMs = existingResponse != null
+            ? (DateTimeOffset.UtcNow - existingResponse.CreatedAt).TotalMilliseconds
+            : 0;
+
         if (admissionResult == AdmissionResult.Admitted)
         {
             await telegramUserRepository.ActivateAsync(user.Id, cancellationToken);
             await TryDeleteMessageAsync(chat.Id, welcomeMessageId, cancellationToken);
+            welcomeMetrics.RecordWelcomeOutcome("admitted", durationMs);
         }
         else
         {
@@ -993,6 +1048,11 @@ public class WelcomeService(
             );
             await welcomeResponsesRepository.InsertAsync(newResponse, cancellationToken);
         }
+
+        var durationMs = existingResponse != null
+            ? (DateTimeOffset.UtcNow - existingResponse.CreatedAt).TotalMilliseconds
+            : 0;
+        welcomeMetrics.RecordWelcomeOutcome("denied_rules", durationMs);
     }
 
     private async Task HandleDmAcceptAsync(
@@ -1064,10 +1124,13 @@ public class WelcomeService(
             ReasonCompletedWelcomeDm,
             cancellationToken);
 
+        var durationMs = (DateTimeOffset.UtcNow - welcomeResponse.CreatedAt).TotalMilliseconds;
+
         if (admissionResult == AdmissionResult.Admitted)
         {
             await telegramUserRepository.ActivateAsync(user.Id, cancellationToken);
             await TryDeleteMessageAsync(groupChatId, welcomeResponse.WelcomeMessageId, cancellationToken);
+            welcomeMetrics.RecordWelcomeOutcome("admitted", durationMs);
         }
         else
         {
@@ -1167,6 +1230,9 @@ public class WelcomeService(
 
     private async Task HandleUserLeftAsync(Chat chat, User user, CancellationToken cancellationToken = default)
     {
+        welcomeMetrics.RecordUserLeft();
+        chatMetrics.RecordUserLeave();
+
         logger.LogDebug(
             "{User} left {Chat}, recording welcome response if pending",
             user.ToLogDebug(),

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs
@@ -12,6 +12,7 @@ using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
 using TelegramGroupsAdmin.Core.Repositories;
 using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Telegram.Repositories;
 
 namespace TelegramGroupsAdmin.UnitTests.BackgroundJobs.Jobs;
@@ -68,7 +69,7 @@ public class DataCleanupJobTests
         _jobContext = Substitute.For<IJobExecutionContext>();
         _jobContext.CancellationToken.Returns(CancellationToken.None);
 
-        _sut = new DataCleanupJob(_scopeFactory, appOptions, logger);
+        _sut = new DataCleanupJob(_scopeFactory, appOptions, logger, new JobMetrics());
     }
 
     [TearDown]

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/ScheduledBackupJobTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/ScheduledBackupJobTests.cs
@@ -11,6 +11,7 @@ using TelegramGroupsAdmin.BackgroundJobs.Services.Backup;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
 using TelegramGroupsAdmin.Core.JobPayloads;
 using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
 using TelegramGroupsAdmin.Core.Models.BackgroundJobSettings;
 
 namespace TelegramGroupsAdmin.UnitTests.BackgroundJobs.Jobs;
@@ -78,7 +79,7 @@ public class ScheduledBackupJobTests
         // Arrange — DB config has custom directory and retention
         SetupDbConfig(backupDir: "/custom/path", hourly: 48);
 
-        var job = new ScheduledBackupJob(_logger, _scopeFactory);
+        var job = new ScheduledBackupJob(_logger, _scopeFactory, new JobMetrics());
 
         // Act
         await job.Execute(_jobContext);
@@ -100,7 +101,7 @@ public class ScheduledBackupJobTests
         // Arrange — DB config has null BackupDirectory
         SetupDbConfig(backupDir: null);
 
-        var job = new ScheduledBackupJob(_logger, _scopeFactory);
+        var job = new ScheduledBackupJob(_logger, _scopeFactory, new JobMetrics());
 
         // Act
         await job.Execute(_jobContext);
@@ -118,7 +119,7 @@ public class ScheduledBackupJobTests
         // Arrange — DB config has non-default retention values
         SetupDbConfig(hourly: 10, daily: 3, weekly: 2, monthly: 6, yearly: 1);
 
-        var job = new ScheduledBackupJob(_logger, _scopeFactory);
+        var job = new ScheduledBackupJob(_logger, _scopeFactory, new JobMetrics());
 
         // Act
         await job.Execute(_jobContext);
@@ -154,7 +155,7 @@ public class ScheduledBackupJobTests
             { JobDataKeys.PayloadJson, payloadJson }
         });
 
-        var job = new ScheduledBackupJob(_logger, _scopeFactory);
+        var job = new ScheduledBackupJob(_logger, _scopeFactory, new JobMetrics());
 
         // Act
         await job.Execute(_jobContext);
@@ -179,7 +180,7 @@ public class ScheduledBackupJobTests
         _configService.GetJobConfigAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("DB connection failed"));
 
-        var job = new ScheduledBackupJob(_logger, _scopeFactory);
+        var job = new ScheduledBackupJob(_logger, _scopeFactory, new JobMetrics());
 
         // Act — should NOT throw (graceful fallback)
         await job.Execute(_jobContext);
@@ -203,7 +204,7 @@ public class ScheduledBackupJobTests
         _configService.GetJobConfigAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((BackgroundJobConfig?)null);
 
-        var job = new ScheduledBackupJob(_logger, _scopeFactory);
+        var job = new ScheduledBackupJob(_logger, _scopeFactory, new JobMetrics());
 
         // Act
         await job.Execute(_jobContext);

--- a/TelegramGroupsAdmin.UnitTests/ContentDetection/ClamAVScannerServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/ContentDetection/ClamAVScannerServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using TelegramGroupsAdmin.Configuration.Models;
 using TelegramGroupsAdmin.Configuration.Repositories;
+using TelegramGroupsAdmin.ContentDetection.Metrics;
 using TelegramGroupsAdmin.ContentDetection.Services;
 
 namespace TelegramGroupsAdmin.UnitTests.ContentDetection;
@@ -49,7 +50,7 @@ public class ClamAVScannerServiceTests
         _mockConfigRepository.GetAsync(chatId: null, Arg.Any<CancellationToken>())
             .Returns(DbConfig);
 
-        _service = new ClamAVScannerService(_mockLogger, _mockConfigRepository);
+        _service = new ClamAVScannerService(_mockLogger, _mockConfigRepository, new DetectionMetrics());
 
         ResetHasLoggedOverride();
     }

--- a/TelegramGroupsAdmin.UnitTests/ContentDetection/ContentDetectionEngineV2Tests.cs
+++ b/TelegramGroupsAdmin.UnitTests/ContentDetection/ContentDetectionEngineV2Tests.cs
@@ -7,6 +7,7 @@ using TelegramGroupsAdmin.Configuration.Models.ContentDetection;
 using TelegramGroupsAdmin.Configuration.Repositories;
 using TelegramGroupsAdmin.ContentDetection.Abstractions;
 using TelegramGroupsAdmin.ContentDetection.Constants;
+using TelegramGroupsAdmin.ContentDetection.Metrics;
 using TelegramGroupsAdmin.ContentDetection.Models;
 using TelegramGroupsAdmin.ContentDetection.Repositories;
 using TelegramGroupsAdmin.ContentDetection.Services;
@@ -970,7 +971,8 @@ public class ContentDetectionEngineV2Tests
             _promptVersionRepo,
             checks,
             _preFilterService,
-            _options);
+            _options,
+            new DetectionMetrics());
     }
 
     private static ContentCheckRequest BuildRequest(

--- a/TelegramGroupsAdmin.UnitTests/Services/ReportActions/ReportActionsServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/ReportActions/ReportActionsServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Services;
 using TelegramGroupsAdmin.Telegram.Services.ReportActions;
 
@@ -46,6 +47,7 @@ public class ReportActionsServiceTests
 
         _service = new ReportActionsService(
             _mockScopeFactory,
+            new ReportMetrics(),
             NullLogger<ReportActionsService>.Instance);
     }
 

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/Bot/BotUserServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/Bot/BotUserServiceTests.cs
@@ -3,6 +3,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
+using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.Telegram.Services.Bot.Handlers;
 
@@ -22,6 +23,7 @@ public class BotUserServiceTests
 {
     private IBotUserHandler _mockUserHandler = null!;
     private IBotIdentityCache _mockIdentityCache = null!;
+    private ApiMetrics _apiMetrics = null!;
     private ILogger<BotUserService> _mockLogger = null!;
     private BotUserService _service = null!;
 
@@ -38,11 +40,13 @@ public class BotUserServiceTests
     {
         _mockUserHandler = Substitute.For<IBotUserHandler>();
         _mockIdentityCache = Substitute.For<IBotIdentityCache>();
+        _apiMetrics = new ApiMetrics();
         _mockLogger = Substitute.For<ILogger<BotUserService>>();
 
         _service = new BotUserService(
             _mockUserHandler,
             _mockIdentityCache,
+            _apiMetrics,
             _mockLogger);
     }
 

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/ChatHealthRefreshOrchestratorTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/ChatHealthRefreshOrchestratorTests.cs
@@ -3,6 +3,7 @@ using NSubstitute;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using TelegramGroupsAdmin.Configuration;
+using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Services;
 using TelegramGroupsAdmin.Telegram.Models;
@@ -216,7 +217,7 @@ public class ChatHealthRefreshOrchestratorTests
     {
         // Arrange: use real health cache to track state: fail, fail, success, fail, fail
         // Pattern: max 2 consecutive failures — should NOT trigger MarkInactive
-        var realHealthCache = new ChatHealthCache(Substitute.For<ILogger<ChatHealthCache>>());
+        var realHealthCache = new ChatHealthCache(Substitute.For<ILogger<ChatHealthCache>>(), new CacheMetrics());
 
         var orchestrator = new ChatHealthRefreshOrchestrator(
             _configLoader,
@@ -269,7 +270,7 @@ public class ChatHealthRefreshOrchestratorTests
     public async Task RefreshHealthForChatAsync_FailureCounters_ArePerChat()
     {
         // Arrange: use real health cache to verify independent counters
-        var realHealthCache = new ChatHealthCache(Substitute.For<ILogger<ChatHealthCache>>());
+        var realHealthCache = new ChatHealthCache(Substitute.For<ILogger<ChatHealthCache>>(), new CacheMetrics());
 
         var orchestrator = new ChatHealthRefreshOrchestrator(
             _configLoader,
@@ -304,7 +305,7 @@ public class ChatHealthRefreshOrchestratorTests
     public async Task RefreshHealthForChatAsync_ChatAAt3Failures_DoesNotAffectChatB()
     {
         // Arrange: use real health cache for true counter isolation
-        var realHealthCache = new ChatHealthCache(Substitute.For<ILogger<ChatHealthCache>>());
+        var realHealthCache = new ChatHealthCache(Substitute.For<ILogger<ChatHealthCache>>(), new CacheMetrics());
 
         var orchestrator = new ChatHealthRefreshOrchestrator(
             _configLoader,
@@ -345,7 +346,7 @@ public class ChatHealthRefreshOrchestratorTests
     public async Task RefreshHealthForChatAsync_After4thConsecutiveFailure_StartsNewCount()
     {
         // Arrange: use real health cache — counter must reset after MarkInactive
-        var realHealthCache = new ChatHealthCache(Substitute.For<ILogger<ChatHealthCache>>());
+        var realHealthCache = new ChatHealthCache(Substitute.For<ILogger<ChatHealthCache>>(), new CacheMetrics());
 
         var orchestrator = new ChatHealthRefreshOrchestrator(
             _configLoader,

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/ChatHealthRefreshOrchestratorTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/ChatHealthRefreshOrchestratorTests.cs
@@ -6,6 +6,7 @@ using TelegramGroupsAdmin.Configuration;
 using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Services;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.Telegram.Services;
@@ -37,6 +38,7 @@ public class ChatHealthRefreshOrchestratorTests
     private TelegramPhotoService _photoService = null!;
     private IPhotoHashService _photoHashService = null!;
     private INotificationService _notificationService = null!;
+    private ChatMetrics _chatMetrics = null!;
     private ILogger<ChatHealthRefreshOrchestrator> _logger = null!;
 
     private ChatHealthRefreshOrchestrator _orchestrator = null!;
@@ -63,6 +65,7 @@ public class ChatHealthRefreshOrchestratorTests
             Microsoft.Extensions.Options.Options.Create(new AppOptions { DataPath = Path.GetTempPath() }));
         _photoHashService = Substitute.For<IPhotoHashService>();
         _notificationService = Substitute.For<INotificationService>();
+        _chatMetrics = new ChatMetrics(_chatCache);
         _logger = Substitute.For<ILogger<ChatHealthRefreshOrchestrator>>();
 
         _orchestrator = new ChatHealthRefreshOrchestrator(
@@ -78,6 +81,7 @@ public class ChatHealthRefreshOrchestratorTests
             _photoService,
             _photoHashService,
             _notificationService,
+            _chatMetrics,
             _logger);
     }
 
@@ -232,6 +236,7 @@ public class ChatHealthRefreshOrchestratorTests
             _photoService,
             _photoHashService,
             _notificationService,
+            _chatMetrics,
             _logger);
 
         var sdkChat = MakeSupergroup(ChatAId);
@@ -285,6 +290,7 @@ public class ChatHealthRefreshOrchestratorTests
             _photoService,
             _photoHashService,
             _notificationService,
+            _chatMetrics,
             _logger);
 
         _chatService.CheckHealthAsync(ChatA, Arg.Any<CancellationToken>()).Returns(false);
@@ -320,6 +326,7 @@ public class ChatHealthRefreshOrchestratorTests
             _photoService,
             _photoHashService,
             _notificationService,
+            _chatMetrics,
             _logger);
 
         _chatService.CheckHealthAsync(ChatA, Arg.Any<CancellationToken>()).Returns(false);
@@ -361,6 +368,7 @@ public class ChatHealthRefreshOrchestratorTests
             _photoService,
             _photoHashService,
             _notificationService,
+            _chatMetrics,
             _logger);
 
         _chatService.CheckHealthAsync(ChatA, Arg.Any<CancellationToken>()).Returns(false);

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceBlacklistTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceBlacklistTests.cs
@@ -14,6 +14,7 @@ using TelegramGroupsAdmin.Telegram.Services;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
 using TelegramGroupsAdmin.Telegram.Services.UserApi;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Welcome;
 
 namespace TelegramGroupsAdmin.UnitTests.Telegram.Services;
@@ -205,6 +206,8 @@ public class WelcomeServiceBlacklistTests
             _profileScanService,
             _sessionManager,
             _admissionHandler,
+            new WelcomeMetrics(),
+            new ChatMetrics(Substitute.For<IChatCache>()),
             NullLogger<WelcomeService>.Instance);
     }
 

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/WelcomeServiceTests.cs
@@ -14,6 +14,7 @@ using TelegramGroupsAdmin.Telegram.Services;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 using TelegramGroupsAdmin.Telegram.Services.Moderation;
 using TelegramGroupsAdmin.Telegram.Services.UserApi;
+using TelegramGroupsAdmin.Telegram.Metrics;
 using TelegramGroupsAdmin.Telegram.Services.Welcome;
 
 namespace TelegramGroupsAdmin.UnitTests.Telegram.Services;
@@ -191,6 +192,8 @@ public class WelcomeServiceTests
             _profileScanService,
             _sessionManager,
             _admissionHandler,
+            new WelcomeMetrics(),
+            new ChatMetrics(Substitute.For<IChatCache>()),
             NullLogger<WelcomeService>.Instance);
     }
 

--- a/TelegramGroupsAdmin/Program.cs
+++ b/TelegramGroupsAdmin/Program.cs
@@ -355,9 +355,9 @@ app.MapApiEndpoints();
 // Map Prometheus metrics endpoint (if metrics pipeline is enabled)
 if (metricsEnabled)
 {
-    // Force-resolve MemoryInstrumentation to register ObservableGauges on stateful singletons.
+    // Force-resolve MemoryMetrics to register ObservableGauges on stateful singletons.
     // Without this, DI never instantiates it since nothing injects it.
-    app.Services.GetRequiredService<MemoryInstrumentation>();
+    app.Services.GetRequiredService<MemoryMetrics>();
 
     app.MapPrometheusScrapingEndpoint();
     var activatedBy = !string.IsNullOrEmpty(otlpEndpoint)

--- a/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
@@ -165,8 +165,8 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<Services.Docs.IDocumentationService, Services.Docs.DocumentationService>();
             services.AddHostedService<Services.Docs.DocumentationStartupService>();
 
-            // Memory instrumentation — ObservableGauges on all stateful singletons for Prometheus/Grafana
-            services.AddSingleton<MemoryInstrumentation>();
+            // Memory metrics — ObservableGauges on all stateful singletons for Prometheus/Grafana
+            services.AddSingleton<MemoryMetrics>();
 
             return services;
         }

--- a/TelegramGroupsAdmin/Services/Email/SendGridEmailService.cs
+++ b/TelegramGroupsAdmin/Services/Email/SendGridEmailService.cs
@@ -1,6 +1,7 @@
 using SendGrid;
 using SendGrid.Helpers.Mail;
 using TelegramGroupsAdmin.Configuration.Repositories;
+using TelegramGroupsAdmin.Core.Metrics;
 using TelegramGroupsAdmin.Models;
 
 namespace TelegramGroupsAdmin.Services.Email;
@@ -13,13 +14,16 @@ public class SendGridEmailService : IEmailService
 {
     private readonly ISystemConfigRepository _configRepo;
     private readonly ILogger<SendGridEmailService> _logger;
+    private readonly ApiMetrics _apiMetrics;
 
     public SendGridEmailService(
         ISystemConfigRepository configRepo,
-        ILogger<SendGridEmailService> logger)
+        ILogger<SendGridEmailService> logger,
+        ApiMetrics apiMetrics)
     {
         _configRepo = configRepo;
         _logger = logger;
+        _apiMetrics = apiMetrics;
     }
 
     public async Task SendEmailAsync(string to, string subject, string body, CancellationToken cancellationToken = default)
@@ -73,6 +77,7 @@ public class SendGridEmailService : IEmailService
 
             _logger.LogDebug("Sending email via SendGrid API...");
             var response = await client.SendEmailAsync(msg, cancellationToken);
+            _apiMetrics.RecordSendGridSend("raw", response.IsSuccessStatusCode);
 
             if (response.IsSuccessStatusCode)
             {

--- a/TelegramGroupsAdmin/Services/MemoryMetrics.cs
+++ b/TelegramGroupsAdmin/Services/MemoryMetrics.cs
@@ -1,6 +1,6 @@
+using System.Diagnostics.Metrics;
 using TelegramGroupsAdmin.ContentDetection.ML;
 using TelegramGroupsAdmin.Core.Services.AI;
-using TelegramGroupsAdmin.Core.Telemetry;
 using TelegramGroupsAdmin.Services.Auth;
 using TelegramGroupsAdmin.Services.Docs;
 using TelegramGroupsAdmin.Telegram.Services;
@@ -15,9 +15,9 @@ namespace TelegramGroupsAdmin.Services;
 /// per-component memory attribution in Prometheus/Grafana.
 /// Gauges are pull-based — callbacks only fire on /metrics scrape, zero overhead between scrapes.
 /// </summary>
-public sealed class MemoryInstrumentation
+public sealed class MemoryMetrics
 {
-    public MemoryInstrumentation(
+    public MemoryMetrics(
         IChatCache chatCache,
         IChatHealthCache chatHealthCache,
         ITelegramSessionManager sessionManager,
@@ -29,7 +29,7 @@ public sealed class MemoryInstrumentation
         IMLTextClassifierService mlClassifier,
         IBayesClassifierService bayesClassifier)
     {
-        var meter = TelemetryConstants.Memory;
+        var meter = new Meter("TelegramGroupsAdmin.Memory");
 
         // --- Telegram caches ---
         meter.CreateObservableGauge(

--- a/TelegramGroupsAdmin/Services/MemoryMetrics.cs
+++ b/TelegramGroupsAdmin/Services/MemoryMetrics.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using TelegramGroupsAdmin.ContentDetection.ML;
 using TelegramGroupsAdmin.Core.Services.AI;
@@ -102,5 +103,19 @@ public sealed class MemoryMetrics
             "tga.cache.kernel.count",
             () => SemanticKernelChatService.CachedKernelCount,
             description: "Number of cached Semantic Kernel instances");
+
+        // --- Native memory gap (RSS minus GC committed) ---
+        // Stable gap = WTelegram + ML.NET + Kestrel SSL baseline.
+        // Growing gap = native memory leak. See context-keep: tga_perf_ml_retraining_loh
+        meter.CreateObservableGauge(
+            "tga.memory.native_gap",
+            () =>
+            {
+                var rss = Process.GetCurrentProcess().WorkingSet64;
+                var gcCommitted = GC.GetGCMemoryInfo().TotalCommittedBytes;
+                return (rss - gcCommitted) / (1024.0 * 1024.0);
+            },
+            unit: "MiB",
+            description: "Native memory gap: RSS minus GC committed bytes");
     }
 }

--- a/docs/superpowers/plans/2026-03-26-metrics-expansion.md
+++ b/docs/superpowers/plans/2026-03-26-metrics-expansion.md
@@ -1,0 +1,1114 @@
+# Metrics Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand `/metrics` instrumentation from ~19 to ~58 custom instruments using domain-scoped metrics classes with consistent `tga.*` naming.
+
+**Architecture:** 9 singleton metrics classes distributed across their respective projects, each owning a `Meter` and exposing wrapper methods that enforce consistent tagging. Existing flat metrics in `TelemetryConstants` are migrated to the new classes, then removed.
+
+**Tech Stack:** System.Diagnostics.Metrics, OpenTelemetry with Prometheus exporter, .NET 10
+
+**Spec:** `docs/superpowers/specs/2026-03-26-metrics-expansion-design.md`
+
+**Branch:** `feat/metrics-expansion` (already created, branched from `develop`)
+
+**Important:** This project has NO unit tests for metrics classes (spec decision — they're thin wrappers around SDK primitives). Validation is done by running `dotnet build` and verifying the `/metrics` endpoint on prod after deployment. Run `dotnet run --migrate-only` to validate the app boots without errors after DI changes.
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Project | Responsibility |
+|---|---|---|
+| `TelegramGroupsAdmin.Core/Metrics/ApiMetrics.cs` | Core | OpenAI, VirusTotal, SendGrid, Telegram API metrics |
+| `TelegramGroupsAdmin.Core/Metrics/CacheMetrics.cs` | Core | Cache hit/miss/removal counters |
+| `TelegramGroupsAdmin.ContentDetection/Metrics/DetectionMetrics.cs` | ContentDetection | Spam detection, file scan, veto metrics |
+| `TelegramGroupsAdmin.Telegram/Metrics/PipelineMetrics.cs` | Telegram | Message processing, moderation, profile scan metrics |
+| `TelegramGroupsAdmin.Telegram/Metrics/ChatMetrics.cs` | Telegram | Managed chats, health checks, joins/leaves |
+| `TelegramGroupsAdmin.Telegram/Metrics/WelcomeMetrics.cs` | Telegram | Welcome flow outcomes, security checks |
+| `TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs` | Telegram | Report creation, resolution, pending count |
+| `TelegramGroupsAdmin.BackgroundJobs/Metrics/JobMetrics.cs` | BackgroundJobs | Job execution counts, duration, rows affected |
+
+### Renamed Files
+
+| From | To |
+|---|---|
+| `TelegramGroupsAdmin/Services/MemoryInstrumentation.cs` | `TelegramGroupsAdmin/Services/MemoryMetrics.cs` |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `TelegramGroupsAdmin.Core/TelemetryConstants.cs` | Remove counters/histograms/meters, keep ActivitySources only |
+| `TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs` | Register `ApiMetrics`, `CacheMetrics` |
+| `TelegramGroupsAdmin.ContentDetection/Extensions/ServiceCollectionExtensions.cs` | Register `DetectionMetrics` |
+| `TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs` | Register `PipelineMetrics`, `ChatMetrics`, `WelcomeMetrics`, `ReportMetrics` |
+| `TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs` | Register `JobMetrics` |
+| `TelegramGroupsAdmin/ServiceCollectionExtensions.cs` | Replace `MemoryInstrumentation` with `MemoryMetrics` |
+| `TelegramGroupsAdmin.ContentDetection/Services/ContentDetectionEngineV2.cs` | Switch to `DetectionMetrics` |
+| `TelegramGroupsAdmin.ContentDetection/Services/ClamAVScannerService.cs` | Switch to `DetectionMetrics` |
+| `TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs` | Add `DetectionMetrics` + `ApiMetrics` |
+| `TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs` | Add `ApiMetrics` |
+| `TelegramGroupsAdmin/Services/Email/SendGridEmailService.cs` | Add `ApiMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/ChatCache.cs` | Add `CacheMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/Bot/ChatHealthCache.cs` | Add `CacheMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs` | Add `PipelineMetrics`, `ChatMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs` | Add `PipelineMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs` | Add `PipelineMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs` | Add `PipelineMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/ChatHealthRefreshOrchestrator.cs` | Add `ChatMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs` | Add `WelcomeMetrics`, `ChatMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/ReportService.cs` | Add `ReportMetrics` |
+| `TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs` | Add `ReportMetrics` |
+| `TelegramGroupsAdmin.BackgroundJobs/Jobs/WelcomeTimeoutJob.cs` | Add `WelcomeMetrics` |
+| All 17 `*Job.cs` files in BackgroundJobs/Jobs/ | Switch to `JobMetrics` |
+
+---
+
+## Task 1: DetectionMetrics — Create Class and Migrate Existing Metrics
+
+This is the best starting task because it replaces existing metrics (proving the pattern works) with minimal risk.
+
+**Files:**
+- Create: `TelegramGroupsAdmin.ContentDetection/Metrics/DetectionMetrics.cs`
+- Modify: `TelegramGroupsAdmin.ContentDetection/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `TelegramGroupsAdmin.ContentDetection/Services/ContentDetectionEngineV2.cs`
+- Modify: `TelegramGroupsAdmin.ContentDetection/Services/ClamAVScannerService.cs`
+- Modify: `TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs`
+
+- [ ] **Step 1: Create `DetectionMetrics.cs`**
+
+Create `TelegramGroupsAdmin.ContentDetection/Metrics/DetectionMetrics.cs`:
+
+```csharp
+using System.Diagnostics.Metrics;
+using System.Diagnostics;
+
+namespace TelegramGroupsAdmin.ContentDetection.Metrics;
+
+/// <summary>
+/// Metrics for spam detection, file scanning, and OpenAI veto tracking.
+/// Replaces flat counters/histograms from TelemetryConstants.
+/// </summary>
+public sealed class DetectionMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Detection");
+
+    private readonly Counter<long> _spamTotal;
+    private readonly Histogram<double> _algorithmDuration;
+    private readonly Counter<long> _fileScanTotal;
+    private readonly Histogram<double> _fileScanDuration;
+    private readonly Counter<long> _vetoTotal;
+
+    public DetectionMetrics()
+    {
+        _spamTotal = _meter.CreateCounter<long>(
+            "tga.detection.spam_total",
+            description: "Per-algorithm spam detection counts");
+
+        _algorithmDuration = _meter.CreateHistogram<double>(
+            "tga.detection.algorithm.duration",
+            unit: "ms",
+            description: "Per-algorithm execution time");
+
+        _fileScanTotal = _meter.CreateCounter<long>(
+            "tga.detection.file_scan_total",
+            description: "File scan results by tier and outcome");
+
+        _fileScanDuration = _meter.CreateHistogram<double>(
+            "tga.detection.file_scan.duration",
+            unit: "ms",
+            description: "File scan latency by tier");
+
+        _vetoTotal = _meter.CreateCounter<long>(
+            "tga.detection.veto_total",
+            description: "OpenAI veto count per algorithm");
+    }
+
+    public void RecordSpamDetection(string algorithm, string result, double durationMs)
+    {
+        var tags = new TagList
+        {
+            { "algorithm", algorithm },
+            { "result", result }
+        };
+        _spamTotal.Add(1, tags);
+        _algorithmDuration.Record(durationMs, new TagList { { "algorithm", algorithm } });
+    }
+
+    public void RecordFileScan(string tier, bool isMalicious, double durationMs)
+    {
+        var tags = new TagList
+        {
+            { "tier", tier },
+            { "result", isMalicious ? "malicious" : "clean" }
+        };
+        _fileScanTotal.Add(1, tags);
+        _fileScanDuration.Record(durationMs, new TagList { { "tier", tier } });
+    }
+
+    public void RecordVeto(string algorithm)
+    {
+        _vetoTotal.Add(1, new TagList { { "algorithm", algorithm } });
+    }
+}
+```
+
+- [ ] **Step 2: Register in DI**
+
+In `TelegramGroupsAdmin.ContentDetection/Extensions/ServiceCollectionExtensions.cs`, add after the existing singleton registrations (after line ~35):
+
+```csharp
+using TelegramGroupsAdmin.ContentDetection.Metrics;
+// ...
+services.AddSingleton<DetectionMetrics>();
+```
+
+- [ ] **Step 3: Migrate ContentDetectionEngineV2**
+
+In `TelegramGroupsAdmin.ContentDetection/Services/ContentDetectionEngineV2.cs`:
+- Add `DetectionMetrics` to the constructor parameters
+- In `RecordDetectionMetrics()` (lines 493-514), replace `TelemetryConstants.SpamDetections.Add(...)` and `TelemetryConstants.SpamDetectionDuration.Record(...)` with calls to `_detectionMetrics.RecordSpamDetection(algorithm, result, durationMs)`
+- Drop the `version` tag (intentionally removed per spec)
+- Change `result` tag: collapse `"low_confidence"` into `"clean"`
+
+- [ ] **Step 4: Migrate ClamAVScannerService**
+
+In `TelegramGroupsAdmin.ContentDetection/Services/ClamAVScannerService.cs`:
+- Add `DetectionMetrics` to the constructor parameters
+- In `RecordScanMetrics()` (lines 320-345), replace `TelemetryConstants.FileScanResults.Add(...)` and `TelemetryConstants.FileScanDuration.Record(...)` with calls to `_detectionMetrics.RecordFileScan("clamav", isMalicious, durationMs)`
+
+- [ ] **Step 5: Add Tier 2 metrics to VirusTotalScannerService**
+
+In `TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs`:
+- Add `DetectionMetrics` to the constructor parameters
+- After hash lookup completes (around lines 80-100), add `_detectionMetrics.RecordFileScan("virustotal", isMalicious, durationMs)`
+- After file upload completes (around lines 220-240), add `_detectionMetrics.RecordFileScan("virustotal", isMalicious, durationMs)`
+
+- [ ] **Step 6: Build and verify**
+
+```bash
+dotnet build TelegramGroupsAdmin.ContentDetection
+dotnet build  # Full solution
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin.ContentDetection/Metrics/DetectionMetrics.cs \
+       TelegramGroupsAdmin.ContentDetection/Extensions/ServiceCollectionExtensions.cs \
+       TelegramGroupsAdmin.ContentDetection/Services/ContentDetectionEngineV2.cs \
+       TelegramGroupsAdmin.ContentDetection/Services/ClamAVScannerService.cs \
+       TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs
+git commit -m "feat: add DetectionMetrics and migrate spam/file scan instrumentation
+
+Replaces flat TelemetryConstants counters with domain-scoped
+DetectionMetrics class. Adds VirusTotal Tier 2 scan metrics.
+Drops version tag, collapses low_confidence into clean."
+```
+
+---
+
+## Task 2: JobMetrics — Create Class and Migrate All 17 Jobs
+
+**Files:**
+- Create: `TelegramGroupsAdmin.BackgroundJobs/Metrics/JobMetrics.cs`
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs`
+- Modify: All 17 `*Job.cs` files in `TelegramGroupsAdmin.BackgroundJobs/Jobs/`
+
+- [ ] **Step 1: Create `JobMetrics.cs`**
+
+Create `TelegramGroupsAdmin.BackgroundJobs/Metrics/JobMetrics.cs`:
+
+```csharp
+using System.Diagnostics.Metrics;
+using System.Diagnostics;
+
+namespace TelegramGroupsAdmin.BackgroundJobs.Metrics;
+
+/// <summary>
+/// Metrics for Quartz.NET background job execution.
+/// Replaces flat counters from TelemetryConstants.
+/// </summary>
+public sealed class JobMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Jobs");
+
+    private readonly Counter<long> _executionsTotal;
+    private readonly Histogram<double> _duration;
+    private readonly Counter<long> _rowsAffectedTotal;
+
+    public JobMetrics()
+    {
+        _executionsTotal = _meter.CreateCounter<long>(
+            "tga.jobs.executions_total",
+            description: "Job execution counts by name and status");
+
+        _duration = _meter.CreateHistogram<double>(
+            "tga.jobs.duration",
+            unit: "ms",
+            description: "Job execution time by name");
+
+        _rowsAffectedTotal = _meter.CreateCounter<long>(
+            "tga.jobs.rows_affected_total",
+            description: "Rows deleted or processed by cleanup jobs");
+    }
+
+    public void RecordJobExecution(string jobName, bool success, double durationMs)
+    {
+        var tags = new TagList
+        {
+            { "job_name", jobName },
+            { "status", success ? "success" : "failure" }
+        };
+        _executionsTotal.Add(1, tags);
+        _duration.Record(durationMs, new TagList { { "job_name", jobName } });
+    }
+
+    public void RecordRowsAffected(string jobName, long count)
+    {
+        if (count > 0)
+            _rowsAffectedTotal.Add(count, new TagList { { "job_name", jobName } });
+    }
+}
+```
+
+- [ ] **Step 2: Register in DI**
+
+In `TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs`, add after existing singleton registrations (after line ~32):
+
+```csharp
+using TelegramGroupsAdmin.BackgroundJobs.Metrics;
+// ...
+services.AddSingleton<JobMetrics>();
+```
+
+- [ ] **Step 3: Migrate all 17 job files**
+
+For each job file in `TelegramGroupsAdmin.BackgroundJobs/Jobs/`:
+
+1. Add `JobMetrics jobMetrics` to the constructor (primary constructor or injected field)
+2. Replace the `finally` block pattern:
+
+**Before:**
+```csharp
+finally
+{
+    var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+    var tags = new TagList
+    {
+        { "job_name", jobName },
+        { "status", success ? "success" : "failure" }
+    };
+    TelemetryConstants.JobExecutions.Add(1, tags);
+    TelemetryConstants.JobDuration.Record(elapsedMs, new TagList { { "job_name", jobName } });
+}
+```
+
+**After:**
+```csharp
+finally
+{
+    var elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+    jobMetrics.RecordJobExecution(jobName, success, elapsedMs);
+}
+```
+
+3. Remove `using TelegramGroupsAdmin.Core.Telemetry;` if no other TelemetryConstants references remain
+
+The 17 job files to update:
+- `BayesClassifierRetrainingJob.cs`
+- `BlocklistSyncJob.cs`
+- `ChatHealthCheckJob.cs`
+- `DatabaseMaintenanceJob.cs`
+- `DataCleanupJob.cs`
+- `DeleteMessageJob.cs`
+- `DeleteUserMessagesJob.cs`
+- `FetchUserPhotoJob.cs`
+- `FileScanJob.cs`
+- `ProfileRescanJob.cs`
+- `ProfileScanJob.cs`
+- `RefreshUserPhotosJob.cs`
+- `RotateBackupPassphraseJob.cs`
+- `ScheduledBackupJob.cs`
+- `TempbanExpiryJob.cs`
+- `TextClassifierRetrainingJob.cs`
+- `WelcomeTimeoutJob.cs`
+
+For cleanup jobs (`DataCleanupJob`, `DatabaseMaintenanceJob`, `DeleteMessageJob`, `DeleteUserMessagesJob`), also add `jobMetrics.RecordRowsAffected(jobName, rowCount)` where row counts are available.
+
+- [ ] **Step 4: Build and verify**
+
+```bash
+dotnet build TelegramGroupsAdmin.BackgroundJobs
+dotnet build
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.BackgroundJobs/
+git commit -m "feat: add JobMetrics and migrate all 17 background jobs
+
+Replaces TelemetryConstants.JobExecutions/JobDuration with
+domain-scoped JobMetrics class. Adds rows_affected tracking
+for cleanup jobs."
+```
+
+---
+
+## Task 3: Clean Up TelemetryConstants and Rename MemoryInstrumentation
+
+Now that DetectionMetrics and JobMetrics have migrated all call sites, clean up the old definitions.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Core/TelemetryConstants.cs`
+- Rename: `TelegramGroupsAdmin/Services/MemoryInstrumentation.cs` → `TelegramGroupsAdmin/Services/MemoryMetrics.cs`
+- Modify: `TelegramGroupsAdmin/ServiceCollectionExtensions.cs`
+
+- [ ] **Step 1: Strip TelemetryConstants down to ActivitySources only**
+
+In `TelegramGroupsAdmin.Core/TelemetryConstants.cs`, remove:
+- Lines 42-113: The `Metrics` meter, `Memory` meter, all 3 counters, all 3 histograms
+- Keep lines 1-38: The 4 ActivitySource fields (`SpamDetection`, `FileScanning`, `MessageProcessing`, `BackgroundJobs`)
+- Remove `using System.Diagnostics.Metrics;` if no longer needed
+
+After cleanup, file should contain only:
+```csharp
+using System.Diagnostics;
+
+namespace TelegramGroupsAdmin.Core.Telemetry;
+
+public static class TelemetryConstants
+{
+    public static readonly ActivitySource SpamDetection = new("TelegramGroupsAdmin.SpamDetection");
+    public static readonly ActivitySource FileScanning = new("TelegramGroupsAdmin.FileScanning");
+    public static readonly ActivitySource MessageProcessing = new("TelegramGroupsAdmin.MessageProcessing");
+    public static readonly ActivitySource BackgroundJobs = new("TelegramGroupsAdmin.BackgroundJobs");
+}
+```
+
+- [ ] **Step 2: Rename MemoryInstrumentation to MemoryMetrics**
+
+Rename file `TelegramGroupsAdmin/Services/MemoryInstrumentation.cs` → `TelegramGroupsAdmin/Services/MemoryMetrics.cs`
+
+Update the class:
+- Rename class from `MemoryInstrumentation` to `MemoryMetrics`
+- Replace `var meter = TelemetryConstants.Memory;` with `var meter = new Meter("TelegramGroupsAdmin.Memory");`
+- Add `using System.Diagnostics.Metrics;`
+- Remove the `TelemetryConstants` import if no longer needed
+
+- [ ] **Step 3: Update DI registration**
+
+In `TelegramGroupsAdmin/ServiceCollectionExtensions.cs`, change:
+```csharp
+services.AddSingleton<MemoryInstrumentation>();
+```
+to:
+```csharp
+services.AddSingleton<MemoryMetrics>();
+```
+
+- [ ] **Step 4: Build and verify**
+
+```bash
+dotnet build
+dotnet run --migrate-only  # Verify DI wiring
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Core/TelemetryConstants.cs \
+       TelegramGroupsAdmin/Services/MemoryMetrics.cs \
+       TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+git rm TelegramGroupsAdmin/Services/MemoryInstrumentation.cs
+git commit -m "refactor: strip TelemetryConstants to ActivitySources, rename MemoryInstrumentation
+
+TelemetryConstants now contains only ActivitySource fields.
+MemoryInstrumentation renamed to MemoryMetrics with its own Meter."
+```
+
+---
+
+## Task 4: ApiMetrics — Create Class and Instrument External APIs
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Core/Metrics/ApiMetrics.cs`
+- Modify: `TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs`
+- Modify: `TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs`
+- Modify: `TelegramGroupsAdmin/Services/Email/SendGridEmailService.cs`
+
+- [ ] **Step 1: Create `ApiMetrics.cs`**
+
+Create `TelegramGroupsAdmin.Core/Metrics/ApiMetrics.cs`:
+
+```csharp
+using System.Diagnostics.Metrics;
+using System.Diagnostics;
+
+namespace TelegramGroupsAdmin.Core.Metrics;
+
+/// <summary>
+/// Metrics for external API calls: OpenAI, VirusTotal, SendGrid, Telegram Bot API.
+/// Per-feature attribution via required tags on recording methods.
+/// </summary>
+public sealed class ApiMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Api");
+
+    private readonly Counter<long> _openAiCallsTotal;
+    private readonly Histogram<double> _openAiLatency;
+    private readonly Counter<long> _openAiTokensTotal;
+    private readonly Counter<long> _virusTotalCallsTotal;
+    private readonly Histogram<double> _virusTotalLatency;
+    private readonly Counter<long> _virusTotalQuotaExhaustedTotal;
+    private readonly Counter<long> _sendGridSendsTotal;
+    private readonly Counter<long> _telegramCallsTotal;
+    private readonly Counter<long> _telegramErrorsTotal;
+
+    public ApiMetrics()
+    {
+        _openAiCallsTotal = _meter.CreateCounter<long>(
+            "tga.api.openai.calls_total",
+            description: "OpenAI API call count per feature");
+
+        _openAiLatency = _meter.CreateHistogram<double>(
+            "tga.api.openai.latency",
+            unit: "ms",
+            description: "OpenAI API latency distribution");
+
+        _openAiTokensTotal = _meter.CreateCounter<long>(
+            "tga.api.openai.tokens_total",
+            description: "OpenAI token consumption per feature");
+
+        _virusTotalCallsTotal = _meter.CreateCounter<long>(
+            "tga.api.virustotal.calls_total",
+            description: "VirusTotal API calls by operation");
+
+        _virusTotalLatency = _meter.CreateHistogram<double>(
+            "tga.api.virustotal.latency",
+            unit: "ms",
+            description: "VirusTotal API latency per operation");
+
+        _virusTotalQuotaExhaustedTotal = _meter.CreateCounter<long>(
+            "tga.api.virustotal.quota_exhausted_total",
+            description: "VirusTotal daily quota exhaustion events");
+
+        _sendGridSendsTotal = _meter.CreateCounter<long>(
+            "tga.api.sendgrid.sends_total",
+            description: "SendGrid email sends by template and status");
+
+        _telegramCallsTotal = _meter.CreateCounter<long>(
+            "tga.api.telegram.calls_total",
+            description: "Telegram Bot API calls by operation");
+
+        _telegramErrorsTotal = _meter.CreateCounter<long>(
+            "tga.api.telegram.errors_total",
+            description: "Telegram Bot API error breakdown");
+    }
+
+    public void RecordOpenAiCall(string feature, string model, int promptTokens, int completionTokens, double durationMs, bool success)
+    {
+        _openAiCallsTotal.Add(1, new TagList
+        {
+            { "feature", feature },
+            { "model", model },
+            { "status", success ? "success" : "failure" }
+        });
+
+        _openAiLatency.Record(durationMs, new TagList
+        {
+            { "feature", feature },
+            { "model", model }
+        });
+
+        if (promptTokens > 0)
+            _openAiTokensTotal.Add(promptTokens, new TagList
+            {
+                { "feature", feature },
+                { "model", model },
+                { "type", "prompt" }
+            });
+
+        if (completionTokens > 0)
+            _openAiTokensTotal.Add(completionTokens, new TagList
+            {
+                { "feature", feature },
+                { "model", model },
+                { "type", "completion" }
+            });
+    }
+
+    public void RecordVirusTotalCall(string operation, double durationMs, bool success)
+    {
+        _virusTotalCallsTotal.Add(1, new TagList
+        {
+            { "operation", operation },
+            { "status", success ? "success" : "failure" }
+        });
+        _virusTotalLatency.Record(durationMs, new TagList { { "operation", operation } });
+    }
+
+    public void RecordVirusTotalQuotaExhausted()
+    {
+        _virusTotalQuotaExhaustedTotal.Add(1);
+    }
+
+    public void RecordSendGridSend(string template, bool success)
+    {
+        _sendGridSendsTotal.Add(1, new TagList
+        {
+            { "template", template },
+            { "status", success ? "success" : "failure" }
+        });
+    }
+
+    public void RecordTelegramApiCall(string operation, bool success)
+    {
+        _telegramCallsTotal.Add(1, new TagList
+        {
+            { "operation", operation },
+            { "status", success ? "success" : "failure" }
+        });
+    }
+
+    public void RecordTelegramApiError(string errorType)
+    {
+        _telegramErrorsTotal.Add(1, new TagList { { "error_type", errorType } });
+    }
+}
+```
+
+- [ ] **Step 2: Register in DI**
+
+In `TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs`, add:
+
+```csharp
+using TelegramGroupsAdmin.Core.Metrics;
+// ...
+services.AddSingleton<ApiMetrics>();
+```
+
+- [ ] **Step 3: Instrument SemanticKernelChatService**
+
+In `TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs`:
+- Add `ApiMetrics` to the constructor parameters
+- In `GetCompletionAsync()` (line ~72), after `CreateResult()`, add a `Stopwatch` around the completion call and record:
+  ```csharp
+  apiMetrics.RecordOpenAiCall(feature, modelId, promptTokens, completionTokens, durationMs, success: true);
+  ```
+- The `feature` parameter needs to be passed through from callers — add a `string feature` parameter to the method or use a constant based on the call context
+- Same for `GetVisionCompletionAsync()` methods (lines ~122, ~176)
+- In catch blocks, record `success: false`
+
+**Note:** Check how `feature` context flows from callers (e.g., `AIContentCheckV2`, `ImageContentCheckV2`). The feature string should identify the spam detection subsystem calling OpenAI. If callers don't pass this, add a `string feature` parameter to the public API.
+
+- [ ] **Step 4: Instrument VirusTotalScannerService**
+
+In `TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs`:
+- Add `ApiMetrics` to the constructor parameters
+- At quota exhaustion points (lines 62, 247), add `apiMetrics.RecordVirusTotalQuotaExhausted()`
+- Wrap hash lookup calls with stopwatch, add `apiMetrics.RecordVirusTotalCall("hash_lookup", durationMs, success)`
+- Wrap file upload calls with stopwatch, add `apiMetrics.RecordVirusTotalCall("file_upload", durationMs, success)`
+
+- [ ] **Step 5: Instrument SendGridEmailService**
+
+In `TelegramGroupsAdmin/Services/Email/SendGridEmailService.cs`:
+- Add `ApiMetrics` to the constructor parameters
+- After `client.SendEmailAsync()` (line ~75), add:
+  ```csharp
+  apiMetrics.RecordSendGridSend("raw", response.IsSuccessStatusCode);
+  ```
+- In `SendTemplatedEmailAsync()` if it exists, use the template name instead of `"raw"`
+
+- [ ] **Step 6: Build and verify**
+
+```bash
+dotnet build
+dotnet run --migrate-only
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Core/Metrics/ApiMetrics.cs \
+       TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs \
+       TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs \
+       TelegramGroupsAdmin.ContentDetection/Services/VirusTotalScannerService.cs \
+       TelegramGroupsAdmin/Services/Email/SendGridEmailService.cs
+git commit -m "feat: add ApiMetrics for OpenAI, VirusTotal, and SendGrid instrumentation
+
+Per-feature attribution for all external API calls including
+token consumption, latency histograms, and quota exhaustion."
+```
+
+---
+
+## Task 5: CacheMetrics — Create Class and Instrument Caches
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Core/Metrics/CacheMetrics.cs`
+- Modify: `TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ChatCache.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/Bot/ChatHealthCache.cs`
+- Modify: `TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs`
+
+- [ ] **Step 1: Create `CacheMetrics.cs`**
+
+Create `TelegramGroupsAdmin.Core/Metrics/CacheMetrics.cs`:
+
+```csharp
+using System.Diagnostics.Metrics;
+using System.Diagnostics;
+
+namespace TelegramGroupsAdmin.Core.Metrics;
+
+/// <summary>
+/// Metrics for in-memory cache hit/miss/removal tracking.
+/// </summary>
+public sealed class CacheMetrics
+{
+    private readonly Meter _meter = new("TelegramGroupsAdmin.Cache");
+
+    private readonly Counter<long> _hitsTotal;
+    private readonly Counter<long> _missesTotal;
+    private readonly Counter<long> _removalsTotal;
+
+    public CacheMetrics()
+    {
+        _hitsTotal = _meter.CreateCounter<long>(
+            "tga.cache.hits_total",
+            description: "Cache hits by cache name");
+
+        _missesTotal = _meter.CreateCounter<long>(
+            "tga.cache.misses_total",
+            description: "Cache misses by cache name");
+
+        _removalsTotal = _meter.CreateCounter<long>(
+            "tga.cache.removals_total",
+            description: "Explicit cache removals by cache name");
+    }
+
+    public void RecordHit(string cacheName)
+    {
+        _hitsTotal.Add(1, new TagList { { "cache_name", cacheName } });
+    }
+
+    public void RecordMiss(string cacheName)
+    {
+        _missesTotal.Add(1, new TagList { { "cache_name", cacheName } });
+    }
+
+    public void RecordRemoval(string cacheName)
+    {
+        _removalsTotal.Add(1, new TagList { { "cache_name", cacheName } });
+    }
+}
+```
+
+- [ ] **Step 2: Register in DI**
+
+In `TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs`, add `services.AddSingleton<CacheMetrics>();`
+
+- [ ] **Step 3: Instrument ChatCache**
+
+In `TelegramGroupsAdmin.Telegram/Services/ChatCache.cs`:
+- Add `CacheMetrics` to the constructor parameters
+- In `GetChat()` (line ~15): record hit if found, miss if not
+- In `RemoveChat()` (line ~23): record removal
+
+- [ ] **Step 4: Instrument ChatHealthCache**
+
+In `TelegramGroupsAdmin.Telegram/Services/Bot/ChatHealthCache.cs`:
+- Add `CacheMetrics` to the constructor parameters
+- In `GetCachedHealth()` (line ~20): record hit/miss
+- In `RemoveHealth()` (line ~60): record removal
+
+- [ ] **Step 5: Instrument SemanticKernelChatService kernel cache**
+
+In `TelegramGroupsAdmin.Core/Services/AI/SemanticKernelChatService.cs` (already modified in Task 4 for `ApiMetrics`):
+- Add `CacheMetrics` to the constructor parameters (alongside `ApiMetrics` from Task 4)
+- Wrap Semantic Kernel cache lookups with `cacheMetrics.RecordHit("kernel")` / `cacheMetrics.RecordMiss("kernel")`
+
+- [ ] **Step 6: Build, verify, commit**
+
+```bash
+dotnet build && dotnet run --migrate-only
+git add TelegramGroupsAdmin.Core/Metrics/CacheMetrics.cs \
+       TelegramGroupsAdmin.Core/Extensions/ServiceCollectionExtensions.cs \
+       TelegramGroupsAdmin.Telegram/Services/ChatCache.cs \
+       TelegramGroupsAdmin.Telegram/Services/Bot/ChatHealthCache.cs
+git commit -m "feat: add CacheMetrics for hit/miss/removal tracking on ChatCache and ChatHealthCache"
+```
+
+---
+
+## Task 6: PipelineMetrics — Message Processing, Moderation, Profile Scans
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Telegram/Metrics/PipelineMetrics.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs`
+
+- [ ] **Step 1: Create `PipelineMetrics.cs`**
+
+Create `TelegramGroupsAdmin.Telegram/Metrics/PipelineMetrics.cs` with:
+- 6 counters: `messages_processed_total`, `moderation_actions_total`, `commands_handled_total`, `profile_scans_total`, `profile_scan.timeouts_total`, `profile_scan.skipped_total`
+- 2 histograms: `processing.duration`, `profile_scan.duration`
+- Recording methods: `RecordMessageProcessed()`, `RecordModerationAction()`, `RecordCommandHandled()`, `RecordProfileScan()`, `RecordProfileScanTimeout()`, `RecordProfileScanSkipped()`
+
+Follow the same pattern as `DetectionMetrics` — sealed class, private meter `TelegramGroupsAdmin.Pipeline`, TagList in recording methods.
+
+- [ ] **Step 2: Register in DI**
+
+In `TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs`, add `services.AddSingleton<PipelineMetrics>();` in the singleton registration block (after line ~204).
+
+- [ ] **Step 3: Instrument MessageProcessingService**
+
+In `MessageProcessingService.cs`:
+- Add `PipelineMetrics` to the constructor
+- In `HandleNewMessageAsync()` (line ~57): add `Stopwatch.GetTimestamp()` at start, call `pipelineMetrics.RecordMessageProcessed("new_message", result, durationMs)` at each exit path
+- In `HandleEditAsync()` if it exists: same pattern with `"edit"` source
+
+- [ ] **Step 4: Instrument DetectionActionService**
+
+In `DetectionActionService.cs`:
+- Add `PipelineMetrics` to the constructor
+- After `MarkAsSpamAndBanAsync()` calls (lines ~98, ~127): `pipelineMetrics.RecordModerationAction("ban", "auto")`
+- After `CreateReportAsync()` (line ~146): `pipelineMetrics.RecordModerationAction("report", "auto")`
+- For hard block path: `pipelineMetrics.RecordModerationAction("ban", "auto")` with hard_block context
+
+- [ ] **Step 5: Instrument ProfileScanService**
+
+In `ProfileScanService.cs`:
+- Add `PipelineMetrics` to the constructor
+- In `ScanUserProfileAsync()` (line ~43): add stopwatch at start
+- At dedup return (line ~62-72): `pipelineMetrics.RecordProfileScanSkipped("dedup")`
+- At no-session return (line ~81): `pipelineMetrics.RecordProfileScanSkipped("no_session")`
+- At timeout (line ~99-113): `pipelineMetrics.RecordProfileScanTimeout()`
+- At excluded return (line ~159): `pipelineMetrics.RecordProfileScanSkipped("excluded")`
+- At successful completion: `pipelineMetrics.RecordProfileScan(outcome, source, durationMs)`
+
+Determine `source` from context: `"welcome"` when `triggeringChat` is provided, `"rescan"` for ProfileRescanJob, `"manual"` for UI-triggered scans.
+
+- [ ] **Step 6: Instrument CommandRouter**
+
+In `CommandRouter.cs`:
+- Add `PipelineMetrics` to the constructor
+- After successful command execution (line ~130): `pipelineMetrics.RecordCommandHandled(commandName)`
+
+- [ ] **Step 7: Build, verify, commit**
+
+```bash
+dotnet build && dotnet run --migrate-only
+git add TelegramGroupsAdmin.Telegram/Metrics/PipelineMetrics.cs \
+       TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs \
+       TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs \
+       TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs \
+       TelegramGroupsAdmin.Telegram/Services/UserApi/ProfileScanService.cs \
+       TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs
+git commit -m "feat: add PipelineMetrics for message processing, moderation, and profile scans"
+```
+
+---
+
+## Task 7: ChatMetrics — Managed Chats, Health Checks, Joins/Leaves
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Telegram/Metrics/ChatMetrics.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ChatHealthRefreshOrchestrator.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs`
+
+- [ ] **Step 1: Create `ChatMetrics.cs`**
+
+Create `TelegramGroupsAdmin.Telegram/Metrics/ChatMetrics.cs` with:
+- 1 ObservableGauge: `tga.chats.managed_count` — callback reads `IChatCache.Count`
+- 5 counters: `health_check_total`, `marked_inactive_total`, `messages_total`, `user_joins_total`, `user_leaves_total`
+
+**Note:** `RecordUserJoin()` and `RecordUserLeave()` call sites are added in Task 8 when WelcomeService is instrumented.
+- Constructor takes `IChatCache` for the gauge callback
+- Recording methods: `RecordHealthCheck()`, `RecordChatMarkedInactive()`, `RecordMessage()`, `RecordUserJoin()`, `RecordUserLeave()`
+
+**Important:** The `IChatCache` dependency must be injected via constructor for the ObservableGauge callback.
+
+- [ ] **Step 2: Register in DI**
+
+Add `services.AddSingleton<ChatMetrics>();` — ensure it's registered AFTER `IChatCache`.
+
+- [ ] **Step 3: Instrument ChatHealthRefreshOrchestrator**
+
+In `ChatHealthRefreshOrchestrator.cs`:
+- Add `ChatMetrics` to the constructor
+- After health check result determination (lines ~46-77): `chatMetrics.RecordHealthCheck(result)` where result is `"healthy"`, `"degraded"`, or `"unreachable"`
+- At `MarkInactiveAsync()` call (line ~59): `chatMetrics.RecordChatMarkedInactive()`
+
+- [ ] **Step 4: Instrument MessageProcessingService for message types**
+
+In `MessageProcessingService.cs` (already modified in Task 6):
+- Add `ChatMetrics` to the constructor (if not already added)
+- Near the start of `HandleNewMessageAsync()`, determine message type from the Telegram `Message` object and call `chatMetrics.RecordMessage(type)` where type is `"text"`, `"photo"`, `"video"`, `"document"`, `"animation"`, `"sticker"`, or `"other"`
+
+- [ ] **Step 5: Build, verify, commit**
+
+```bash
+dotnet build && dotnet run --migrate-only
+git add TelegramGroupsAdmin.Telegram/Metrics/ChatMetrics.cs \
+       TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs \
+       TelegramGroupsAdmin.Telegram/Services/ChatHealthRefreshOrchestrator.cs \
+       TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+git commit -m "feat: add ChatMetrics for managed chats, health checks, and message type tracking"
+```
+
+---
+
+## Task 8: WelcomeMetrics — Welcome Flow Outcomes and Security Checks
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Telegram/Metrics/WelcomeMetrics.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs`
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Jobs/WelcomeTimeoutJob.cs`
+
+- [ ] **Step 1: Create `WelcomeMetrics.cs`**
+
+Create `TelegramGroupsAdmin.Telegram/Metrics/WelcomeMetrics.cs` with:
+- 5 counters: `joins_total`, `security_checks_total`, `bot_joins_total`, `timeouts_total`, `leaves_total`
+- 1 histogram: `duration` (unit: ms)
+- Recording methods per spec
+
+- [ ] **Step 2: Register in DI**
+
+Add `services.AddSingleton<WelcomeMetrics>();`
+
+- [ ] **Step 3: Instrument WelcomeService**
+
+In `WelcomeService.cs`:
+- Add `WelcomeMetrics` and `ChatMetrics` to the constructor
+- Add `Stopwatch.GetTimestamp()` at the start of `HandleChatMemberUpdateAsync()`
+- At each exit path (see exploration map — ~18 exit paths), record the appropriate outcome:
+  - Bot banned → `welcomeMetrics.RecordBotJoin("banned")`
+  - Bot allowed → `welcomeMetrics.RecordBotJoin("allowed")`
+  - Admin skip → `welcomeMetrics.RecordWelcomeOutcome("skipped_admin", durationMs)`
+  - Pre-banned → `welcomeMetrics.RecordWelcomeOutcome("pre_banned", durationMs)`
+  - Username blacklist → `welcomeMetrics.RecordSecurityCheck("username_blacklist", "fail")` + `RecordWelcomeOutcome("banned", durationMs)`
+  - CAS banned → `welcomeMetrics.RecordSecurityCheck("cas", "fail")` + `RecordWelcomeOutcome("banned", durationMs)`
+  - Impersonation → `welcomeMetrics.RecordSecurityCheck("impersonation", "fail")` + `RecordWelcomeOutcome("banned", durationMs)`
+  - Profile scan auto-ban → `welcomeMetrics.RecordSecurityCheck("profile_scan", "fail")` + `RecordWelcomeOutcome("banned", durationMs)`
+  - Photo match detection → `welcomeMetrics.RecordSecurityCheck("photo_match", "fail")` + appropriate outcome
+  - Normal admission → `welcomeMetrics.RecordWelcomeOutcome("admitted", durationMs)`
+  - Denied rules → `welcomeMetrics.RecordWelcomeOutcome("denied_rules", durationMs)`
+- For each security check that passes: `welcomeMetrics.RecordSecurityCheck(checkName, "pass")`
+- For skipped checks: `welcomeMetrics.RecordSecurityCheck(checkName, "skipped")`
+- At `HandleUserLeftAsync()`: `welcomeMetrics.RecordUserLeft()` + `chatMetrics.RecordUserLeave()`
+- At new user join: `chatMetrics.RecordUserJoin()`
+
+**This is the most complex instrumentation point.** Take care to record at every exit path. The stopwatch should be started early and duration recorded at the outcome point.
+
+- [ ] **Step 4: Instrument WelcomeTimeoutJob**
+
+In `WelcomeTimeoutJob.cs`:
+- Add `WelcomeMetrics` to the constructor
+- When a timeout kicks a user (around line ~100): `welcomeMetrics.RecordWelcomeTimeout()` + `welcomeMetrics.RecordWelcomeOutcome("timed_out", durationMs)`
+
+- [ ] **Step 5: Build, verify, commit**
+
+```bash
+dotnet build && dotnet run --migrate-only
+git add TelegramGroupsAdmin.Telegram/Metrics/WelcomeMetrics.cs \
+       TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs \
+       TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs \
+       TelegramGroupsAdmin.BackgroundJobs/Jobs/WelcomeTimeoutJob.cs
+git commit -m "feat: add WelcomeMetrics for welcome flow outcomes and security check tracking"
+```
+
+---
+
+## Task 9: ReportMetrics — Report Creation, Resolution, Pending Count
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ReportService.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs`
+
+- [ ] **Step 1: Create `ReportMetrics.cs`**
+
+Create `TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs` with:
+- 2 counters: `created_total`, `resolved_total`
+- 1 histogram: `resolution.duration` (unit: ms)
+- 1 ObservableGauge: `pending_count` — reads from internal `_pendingCount` field
+- Internal `_pendingCount` (`long`) managed via `Interlocked.Increment` / `Interlocked.Decrement`
+
+```csharp
+private long _pendingCount;
+
+public ReportMetrics()
+{
+    // ... other instruments ...
+
+    _meter.CreateObservableGauge(
+        "tga.reports.pending_count",
+        () => Interlocked.Read(ref _pendingCount),
+        description: "Current total pending reports");
+}
+
+public void RecordReportCreated(string type, string source)
+{
+    _createdTotal.Add(1, new TagList { { "type", type }, { "source", source } });
+    Interlocked.Increment(ref _pendingCount);
+}
+
+public void RecordReportResolved(string type, string action, double durationMs)
+{
+    _resolvedTotal.Add(1, new TagList { { "type", type }, { "action", action } });
+    _resolutionDuration.Record(durationMs, new TagList { { "type", type } });
+    Interlocked.Decrement(ref _pendingCount);
+}
+```
+
+**Eventual consistency note:** `_pendingCount` resets to 0 on app restart. Resolving pre-existing reports will decrement below zero. This is expected and accepted — the gauge self-corrects as new reports are created/resolved. Do not add a database query or floor check.
+
+- [ ] **Step 2: Register in DI**
+
+Add `services.AddSingleton<ReportMetrics>();`
+
+- [ ] **Step 3: Instrument ReportService**
+
+In `ReportService.cs`:
+- Add `ReportMetrics` to the constructor
+- After `InsertContentReportAsync()` (line ~38): `reportMetrics.RecordReportCreated(type, source)` where `type` maps from the report's type and `source` is `isAutomated ? "auto" : "user"`
+
+- [ ] **Step 4: Instrument ReportActionsService**
+
+In `ReportActionsService.cs`:
+- Add `ReportMetrics` to the constructor
+- In `ExecuteWithLockAsync()` (lines ~93-121) or in each `Handle*Async` wrapper method:
+  - After the delegate completes, if successful: `reportMetrics.RecordReportResolved(type, action, durationMs)`
+  - Map each handler method to its type and action:
+    - `HandleContentSpamAsync` → `("content", "spam")`
+    - `HandleContentBanAsync` → `("content", "ban")`
+    - `HandleContentWarnAsync` → `("content", "warn")`
+    - `HandleContentDismissAsync` → `("content", "dismiss")`
+    - `HandleProfileScanBanAsync` → `("profile_scan", "ban")`
+    - `HandleProfileScanKickAsync` → `("profile_scan", "kick")`
+    - `HandleProfileScanAllowAsync` → `("profile_scan", "allow")`
+    - `HandleImpersonationConfirmAsync` → `("impersonation", "confirm")`
+    - `HandleImpersonationDismissAsync` → `("impersonation", "dismiss")`
+    - `HandleImpersonationTrustAsync` → `("impersonation", "trust")`
+    - `HandleExamApproveAsync` → `("exam_failure", "approve")`
+    - `HandleExamDenyAsync` → `("exam_failure", "deny")`
+    - `HandleExamDenyAndBanAsync` → `("exam_failure", "deny_and_ban")`
+
+- [ ] **Step 5: Build, verify, commit**
+
+```bash
+dotnet build && dotnet run --migrate-only
+git add TelegramGroupsAdmin.Telegram/Metrics/ReportMetrics.cs \
+       TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs \
+       TelegramGroupsAdmin.Telegram/Services/ReportService.cs \
+       TelegramGroupsAdmin.Telegram/Services/ReportActions/ReportActionsService.cs
+git commit -m "feat: add ReportMetrics for report creation, resolution, and pending count tracking"
+```
+
+---
+
+## Task 10: Telegram Bot API Metrics — Instrument Bot Services
+
+This is separate from Task 4 (ApiMetrics class creation) because the Bot services are in the Telegram project and have many methods to instrument.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/Bot/BotMessageService.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/Bot/BotUserService.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/Bot/BotChatService.cs`
+
+- [ ] **Step 1: Instrument BotMessageService**
+
+- Add `ApiMetrics` to the constructor
+- In each method that calls the Telegram Bot API (send, edit, delete), add:
+  ```csharp
+  apiMetrics.RecordTelegramApiCall("send_message", success: true);
+  ```
+- In catch blocks for `ApiRequestException`, add:
+  ```csharp
+  apiMetrics.RecordTelegramApiError(ex.ErrorCode.ToString());
+  ```
+
+- [ ] **Step 2: Instrument BotUserService**
+
+- Add `ApiMetrics` to the constructor
+- Instrument `GetChatMemberAsync`, `BanChatMemberAsync`, `UnbanChatMemberAsync`, `RestrictChatMemberAsync`, etc.
+
+- [ ] **Step 3: Instrument BotChatService**
+
+- Add `ApiMetrics` to the constructor
+- Instrument `GetChatAsync`, `CheckHealthAsync`, `CreateChatInviteLinkAsync`, etc.
+
+- [ ] **Step 4: Build, verify, commit**
+
+```bash
+dotnet build && dotnet run --migrate-only
+git add TelegramGroupsAdmin.Telegram/Services/Bot/BotMessageService.cs \
+       TelegramGroupsAdmin.Telegram/Services/Bot/BotUserService.cs \
+       TelegramGroupsAdmin.Telegram/Services/Bot/BotChatService.cs
+git commit -m "feat: add Telegram Bot API operation metrics to BotMessageService, BotUserService, BotChatService"
+```
+
+---
+
+## Task 11: Final Verification and Cleanup
+
+- [ ] **Step 1: Full solution build**
+
+```bash
+dotnet build
+```
+
+Fix any compilation errors.
+
+- [ ] **Step 2: Run existing tests**
+
+```bash
+dotnet test --filter "Category!=E2E" --no-build 2>&1 | tee /tmp/metrics-test-results.txt
+```
+
+Review output for failures. Since metrics classes are singletons with no side effects, failures would indicate a DI wiring issue (missing registration or constructor parameter mismatch).
+
+- [ ] **Step 3: Verify app boots**
+
+```bash
+dotnet run --migrate-only
+```
+
+This validates all DI registrations resolve correctly.
+
+- [ ] **Step 4: Verify no dangling TelemetryConstants references**
+
+```bash
+# Should return zero results for counter/histogram usage
+grep -r "TelemetryConstants\.\(SpamDetections\|FileScanResults\|JobExecutions\|SpamDetectionDuration\|FileScanDuration\|JobDuration\)" --include="*.cs" .
+```
+
+If any results, update those call sites to use the appropriate metrics class.
+
+- [ ] **Step 5: Verify no remaining MemoryInstrumentation references**
+
+```bash
+grep -r "MemoryInstrumentation" --include="*.cs" .
+```
+
+If any results, update to `MemoryMetrics`.
+
+- [ ] **Step 6: Commit any cleanup**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup for metrics expansion"
+```

--- a/docs/superpowers/specs/2026-03-26-metrics-expansion-design.md
+++ b/docs/superpowers/specs/2026-03-26-metrics-expansion-design.md
@@ -16,6 +16,7 @@ Expand `/metrics` endpoint instrumentation from ~22 instruments to ~58, standard
 - Grafana dashboard creation (handled separately on prod machine)
 - Alert rule definitions (configured in Prometheus/Grafana, not in app code)
 - Distributed tracing expansion (ActivitySources are already well-covered)
+- Blazor/web UI metrics (page load times, auth events) — deferred to a future iteration
 
 ## Architecture: Domain-Scoped Metrics Classes
 
@@ -25,7 +26,7 @@ Each class is a **singleton** registered in DI, owns a `Meter` instance, and exp
 ┌─────────────────────────────────────────────────────────┐
 │ TelegramGroupsAdmin.Core                                │
 │   ApiMetrics         (OpenAI, VirusTotal, SendGrid, TG) │
-│   CacheMetrics       (hit/miss/eviction counters)       │
+│   CacheMetrics       (hit/miss/removal counters)        │
 ├─────────────────────────────────────────────────────────┤
 │ TelegramGroupsAdmin.ContentDetection                    │
 │   DetectionMetrics   (spam, file scan, veto)            │
@@ -52,20 +53,30 @@ Recording methods like `RecordOpenAiCall(feature, model, tokens, duration, succe
 
 All metrics use: `tga.<domain>.<subject>.<metric_type>`
 
+### Prometheus Export Behavior (Verified Against Prod)
+
+- **Dots become underscores**: `tga.cache.chat.count` → `tga_cache_chat_count`
+- **`_total` suffix**: The Prometheus exporter detects existing `_total` suffixes and does NOT double-append. `spam_detections_total` exports as `spam_detections_total`, not `spam_detections_total_total`. Safe to include `_total` in counter names.
+- **Unit suffix**: The exporter appends the unit as a suffix. A histogram named `job_duration_ms` with `unit: "ms"` exports as `job_duration_ms_milliseconds_bucket` — redundant. **Fix: drop `_ms` from histogram names and keep the `unit: "ms"` parameter.** E.g., `tga.detection.algorithm.duration` with `unit: "ms"` → `tga_detection_algorithm_duration_milliseconds_bucket`.
+
 ### Renames (Existing Flat Metrics)
 
-| Current Name | New Name |
-|---|---|
-| `spam_detections_total` | `tga.detection.spam_total` |
-| `spam_detection_duration_ms` | `tga.detection.algorithm.duration_ms` |
-| `file_scan_results_total` | `tga.detection.file_scan_total` |
-| `file_scan_duration_ms` | `tga.detection.file_scan.duration_ms` |
-| `job_executions_total` | `tga.jobs.executions_total` |
-| `job_duration_ms` | `tga.jobs.duration_ms` |
+| Current Name | New Name | Notes |
+|---|---|---|
+| `spam_detections_total` | `tga.detection.spam_total` | |
+| `spam_detection_duration_ms` | `tga.detection.algorithm.duration` | Drop `_ms`, keep `unit: "ms"` |
+| `file_scan_results_total` | `tga.detection.file_scan_total` | |
+| `file_scan_duration_ms` | `tga.detection.file_scan.duration` | Drop `_ms`, keep `unit: "ms"` |
+| `job_executions_total` | `tga.jobs.executions_total` | |
+| `job_duration_ms` | `tga.jobs.duration` | Drop `_ms`, keep `unit: "ms"` |
 
 Existing `tga.cache.*`, `tga.ml.*`, `tga.sessions.*`, `tga.queue.*` gauges are already correctly named — no changes needed.
 
-**Grafana impact:** All 6 renamed metrics require dashboard query updates on the prod machine.
+**Grafana impact:** All 6 renamed metrics require dashboard query updates on the prod machine. The histogram renames also change the exported suffix from `_ms_milliseconds` to `_milliseconds`.
+
+### Tag Value Migration
+
+The existing `result` tag on `spam_detections_total` currently uses values: `"spam"`, `"clean"`, `"abstained"`, `"low_confidence"`. The new `tga.detection.spam_total` will use `result` values: `spam`, `clean`, `abstained`. The `low_confidence` value is collapsed into `clean` since the per-algorithm level already provides confidence granularity. The `version` tag (`"v2"`) is intentionally dropped — only one engine version exists at a time, and the tag adds no diagnostic value.
 
 ## Metrics Classes — Full Instrument Catalog
 
@@ -73,31 +84,33 @@ Existing `tga.cache.*`, `tga.ml.*`, `tga.sessions.*`, `tga.queue.*` gauges are a
 
 Meter: `TelegramGroupsAdmin.Api`
 
-| Metric | Type | Tags | Purpose |
-|---|---|---|---|
-| `tga.api.openai.calls_total` | Counter | `feature`, `model`, `status` | Call count per feature |
-| `tga.api.openai.latency_ms` | Histogram | `feature`, `model` | Latency distribution |
-| `tga.api.openai.tokens_total` | Counter | `feature`, `model`, `type` (prompt\|completion) | Token consumption |
-| `tga.api.virustotal.calls_total` | Counter | `operation` (hash_lookup\|file_upload), `status` | Calls by operation |
-| `tga.api.virustotal.latency_ms` | Histogram | `operation` | Latency per operation |
-| `tga.api.virustotal.quota_exhausted_total` | Counter | — | Daily quota exhaustion events |
-| `tga.api.sendgrid.sends_total` | Counter | `template`, `status` | Email sends |
-| `tga.api.telegram.calls_total` | Counter | `operation`, `status` | Bot API calls by operation |
-| `tga.api.telegram.errors_total` | Counter | `error_type` | Error breakdown |
+| Metric | Type | Unit | Tags | Purpose |
+|---|---|---|---|---|
+| `tga.api.openai.calls_total` | Counter | — | `feature`, `model`, `status` | Call count per feature |
+| `tga.api.openai.latency` | Histogram | ms | `feature`, `model` | Latency distribution |
+| `tga.api.openai.tokens_total` | Counter | — | `feature`, `model`, `type` (prompt\|completion) | Token consumption |
+| `tga.api.virustotal.calls_total` | Counter | — | `operation` (hash_lookup\|file_upload), `status` | Calls by operation |
+| `tga.api.virustotal.latency` | Histogram | ms | `operation` | Latency per operation |
+| `tga.api.virustotal.quota_exhausted_total` | Counter | — | — | Daily quota exhaustion events |
+| `tga.api.sendgrid.sends_total` | Counter | — | `template`, `status` | Email sends |
+| `tga.api.telegram.calls_total` | Counter | — | `operation`, `status` | Bot API calls by operation |
+| `tga.api.telegram.errors_total` | Counter | — | `error_type` | Error breakdown |
 
 **Recording methods:**
 - `RecordOpenAiCall(string feature, string model, int promptTokens, int completionTokens, double durationMs, bool success)`
 - `RecordVirusTotalCall(string operation, double durationMs, bool success)`
 - `RecordVirusTotalQuotaExhausted()`
-- `RecordSendGridSend(string template, bool success)`
+- `RecordSendGridSend(string template, bool success)` — use `"raw"` for non-templated sends
 - `RecordTelegramApiCall(string operation, bool success)`
 - `RecordTelegramApiError(string errorType)`
 
 **Instrumentation points:**
-- `SemanticKernelChatService` — already extracts `ChatTokenUsage`, add metrics after each completion
-- `VirusTotalScannerService` — wrap hash lookup and file upload calls
-- `SendGridEmailService` (or equivalent) — wrap send calls
-- `BotMessageService`, `BotUserService`, `BotChatService` — wrap Telegram Bot API calls
+- `SemanticKernelChatService` (Core) — already extracts `ChatTokenUsage`, add metrics after each completion
+- `VirusTotalScannerService` (ContentDetection) — wrap hash lookup and file upload calls
+- `SendGridEmailService` (main app, `Services/Email/`) — wrap send calls; use `"raw"` template tag for non-templated sends
+- `BotMessageService`, `BotUserService`, `BotChatService` (Telegram) — wrap Telegram Bot API calls
+
+**Cardinality note:** The `operation` tag for Telegram API calls has ~15-20 values (send_message, delete_message, ban_chat_member, get_chat_member, restrict_chat_member, get_chat, get_chat_administrators, create_chat_invite_link, get_user_profile_photos, get_file, edit_message_text, edit_message_reply_markup, approve_chat_join_request, decline_chat_join_request, etc.). All bounded.
 
 ### 2. `DetectionMetrics` (TelegramGroupsAdmin.ContentDetection)
 
@@ -105,16 +118,16 @@ Meter: `TelegramGroupsAdmin.Detection`
 
 Replaces existing flat counters in `TelemetryConstants`.
 
-| Metric | Type | Tags | Purpose |
-|---|---|---|---|
-| `tga.detection.spam_total` | Counter | `algorithm`, `result` (spam\|ham) | Per-algorithm detection counts |
-| `tga.detection.algorithm.duration_ms` | Histogram | `algorithm` | Per-algorithm execution time |
-| `tga.detection.file_scan_total` | Counter | `tier` (clamav\|virustotal), `result` (malicious\|clean) | File scan results |
-| `tga.detection.file_scan.duration_ms` | Histogram | `tier` | File scan latency |
-| `tga.detection.veto_total` | Counter | `algorithm` | OpenAI veto count per algorithm |
+| Metric | Type | Unit | Tags | Purpose |
+|---|---|---|---|---|
+| `tga.detection.spam_total` | Counter | — | `algorithm`, `result` (spam\|clean\|abstained) | Per-algorithm detection counts |
+| `tga.detection.algorithm.duration` | Histogram | ms | `algorithm` | Per-algorithm execution time |
+| `tga.detection.file_scan_total` | Counter | — | `tier` (clamav\|virustotal), `result` (malicious\|clean) | File scan results |
+| `tga.detection.file_scan.duration` | Histogram | ms | `tier` | File scan latency |
+| `tga.detection.veto_total` | Counter | — | `algorithm` | OpenAI veto count per algorithm |
 
 **Recording methods:**
-- `RecordSpamDetection(string algorithm, bool isSpam, double durationMs)`
+- `RecordSpamDetection(string algorithm, string result, double durationMs)` — accepts explicit result string to preserve abstained/clean distinction
 - `RecordFileScan(string tier, bool isMalicious, double durationMs)`
 - `RecordVeto(string algorithm)`
 
@@ -127,22 +140,22 @@ Replaces existing flat counters in `TelemetryConstants`.
 
 Meter: `TelegramGroupsAdmin.Pipeline`
 
-| Metric | Type | Tags | Purpose |
-|---|---|---|---|
-| `tga.pipeline.messages_processed_total` | Counter | `source` (new_message\|edit), `result` (processed\|skipped\|error) | Messages through pipeline |
-| `tga.pipeline.processing.duration_ms` | Histogram | `source` | End-to-end pipeline latency |
-| `tga.pipeline.moderation_actions_total` | Counter | `action` (ban\|warn\|report\|delete\|malware_alert), `trigger` (auto\|admin) | All moderation actions |
-| `tga.pipeline.reports_created_total` | Counter | `reason` (borderline\|admin_review) | Reports queued for review |
-| `tga.pipeline.commands_handled_total` | Counter | `command` | Bot command usage |
-| `tga.pipeline.profile_scans_total` | Counter | `outcome` (clean\|held_for_review\|banned), `source` (welcome\|rescan\|manual) | Scan outcomes |
-| `tga.pipeline.profile_scan.duration_ms` | Histogram | `source` | Scan latency |
-| `tga.pipeline.profile_scan.timeouts_total` | Counter | — | 45s timeout hits |
-| `tga.pipeline.profile_scan.skipped_total` | Counter | `reason` (dedup\|no_session\|excluded) | Skipped scans |
+| Metric | Type | Unit | Tags | Purpose |
+|---|---|---|---|---|
+| `tga.pipeline.messages_processed_total` | Counter | — | `source` (new_message\|edit), `result` (processed\|skipped\|error) | Messages through pipeline |
+| `tga.pipeline.processing.duration` | Histogram | ms | `source` | End-to-end pipeline latency |
+| `tga.pipeline.moderation_actions_total` | Counter | — | `action` (ban\|warn\|report\|delete\|malware_alert), `trigger` (auto\|admin) | All moderation actions |
+| `tga.pipeline.commands_handled_total` | Counter | — | `command` | Bot command usage |
+| `tga.pipeline.profile_scans_total` | Counter | — | `outcome` (clean\|held_for_review\|banned), `source` (welcome\|rescan\|manual) | Scan outcomes |
+| `tga.pipeline.profile_scan.duration` | Histogram | ms | `source` | Scan latency |
+| `tga.pipeline.profile_scan.timeouts_total` | Counter | — | — | 45s timeout hits |
+| `tga.pipeline.profile_scan.skipped_total` | Counter | — | `reason` (dedup\|no_session\|excluded) | Skipped scans |
+
+**Note:** `reports_created_total` was removed from PipelineMetrics to avoid overlap with `ReportMetrics.tga.reports.created_total`, which has richer tagging (`type` + `source`).
 
 **Recording methods:**
 - `RecordMessageProcessed(string source, string result, double durationMs)`
 - `RecordModerationAction(string action, string trigger)`
-- `RecordReportCreated(string reason)`
 - `RecordCommandHandled(string command)`
 - `RecordProfileScan(string outcome, string source, double durationMs)`
 - `RecordProfileScanTimeout()`
@@ -158,14 +171,18 @@ Meter: `TelegramGroupsAdmin.Pipeline`
 
 Meter: `TelegramGroupsAdmin.Chats`
 
-| Metric | Type | Tags | Purpose |
-|---|---|---|---|
-| `tga.chats.managed_total` | ObservableGauge | — | Active managed chats count |
-| `tga.chats.health_check_total` | Counter | `result` (healthy\|degraded\|unreachable) | Health check outcomes |
-| `tga.chats.marked_inactive_total` | Counter | — | Chats marked inactive (3 failures) |
-| `tga.chats.messages_total` | Counter | `type` (text\|photo\|video\|document\|sticker\|other) | Messages by content type |
-| `tga.chats.user_joins_total` | Counter | — | User joins across all chats |
-| `tga.chats.user_leaves_total` | Counter | — | User departures |
+| Metric | Type | Unit | Tags | Purpose |
+|---|---|---|---|---|
+| `tga.chats.managed_count` | ObservableGauge | — | — | Active managed chats count |
+| `tga.chats.health_check_total` | Counter | — | `result` (healthy\|degraded\|unreachable) | Health check outcomes |
+| `tga.chats.marked_inactive_total` | Counter | — | — | Chats marked inactive (3 failures) |
+| `tga.chats.messages_total` | Counter | — | `type` (text\|photo\|video\|document\|animation\|sticker\|other) | Messages by content type |
+| `tga.chats.user_joins_total` | Counter | — | — | Raw user join events |
+| `tga.chats.user_leaves_total` | Counter | — | — | Raw user departure events |
+
+**Observable gauge implementation:** `tga.chats.managed_count` reads from `IChatCache.Count` (in-memory singleton), NOT from a database query. `ObservableGauge` callbacks must be synchronous (`Func<T>`); async DB calls are not permitted. The `ChatCache` already maintains the count of active managed chats in memory.
+
+**Semantic distinction from WelcomeMetrics:** `tga.chats.user_joins_total` / `user_leaves_total` count raw join/leave events. `WelcomeMetrics` counts welcome *flow outcomes* (admitted, banned, timed_out, etc.). A single join event becomes one `tga.chats.user_joins_total` increment AND one `tga.welcome.joins_total` increment with a `result` tag. Both are recorded in `WelcomeService.HandleChatMemberUpdateAsync`.
 
 **Recording methods:**
 - `RecordHealthCheck(string result)`
@@ -178,20 +195,20 @@ Meter: `TelegramGroupsAdmin.Chats`
 - `ChatHealthRefreshOrchestrator.RefreshHealthForChatAsync` — record health check results
 - `MessageProcessingService.HandleNewMessageAsync` — record message type
 - `WelcomeService.HandleChatMemberUpdateAsync` — record joins/leaves
-- Observable gauge callback queries `IManagedChatsRepository` for active count
+- Observable gauge callback reads `IChatCache.Count`
 
 ### 5. `WelcomeMetrics` (TelegramGroupsAdmin.Telegram)
 
 Meter: `TelegramGroupsAdmin.Welcome`
 
-| Metric | Type | Tags | Purpose |
-|---|---|---|---|
-| `tga.welcome.joins_total` | Counter | `result` (admitted\|banned\|timed_out\|denied_rules\|pre_banned\|skipped_admin) | Welcome flow outcomes |
-| `tga.welcome.security_checks_total` | Counter | `check` (username_blacklist\|cas\|impersonation\|profile_scan\|photo_match), `result` (pass\|fail\|skipped) | Per-check pass/fail |
-| `tga.welcome.duration_ms` | Histogram | `result` | End-to-end welcome flow time |
-| `tga.welcome.bot_joins_total` | Counter | `result` (allowed\|banned) | Bot join attempts |
-| `tga.welcome.timeouts_total` | Counter | — | Welcome timeout expirations |
-| `tga.welcome.leaves_total` | Counter | — | Users left before completing |
+| Metric | Type | Unit | Tags | Purpose |
+|---|---|---|---|---|
+| `tga.welcome.joins_total` | Counter | — | `result` (admitted\|banned\|timed_out\|denied_rules\|pre_banned\|skipped_admin) | Welcome flow outcomes |
+| `tga.welcome.security_checks_total` | Counter | — | `check` (username_blacklist\|cas\|impersonation\|profile_scan\|photo_match), `result` (pass\|fail\|skipped) | Per-check pass/fail |
+| `tga.welcome.duration` | Histogram | ms | `result` | End-to-end welcome flow time |
+| `tga.welcome.bot_joins_total` | Counter | — | `result` (allowed\|banned) | Bot join attempts |
+| `tga.welcome.timeouts_total` | Counter | — | — | Welcome timeout expirations |
+| `tga.welcome.leaves_total` | Counter | — | — | Users left before completing |
 
 **Recording methods:**
 - `RecordWelcomeOutcome(string result, double durationMs)`
@@ -210,12 +227,14 @@ Meter: `TelegramGroupsAdmin.Welcome`
 
 Meter: `TelegramGroupsAdmin.Reports`
 
-| Metric | Type | Tags | Purpose |
-|---|---|---|---|
-| `tga.reports.created_total` | Counter | `type` (content\|profile_scan\|impersonation), `source` (auto\|user) | Reports created |
-| `tga.reports.resolved_total` | Counter | `type`, `action` (spam\|ban\|warn\|dismiss\|kick\|allow\|confirm\|trust) | Resolution actions |
-| `tga.reports.resolution.duration_ms` | Histogram | `type` | Time from creation to resolution |
-| `tga.reports.pending` | ObservableGauge | `type` | Current pending count |
+| Metric | Type | Unit | Tags | Purpose |
+|---|---|---|---|---|
+| `tga.reports.created_total` | Counter | — | `type` (content\|profile_scan\|impersonation\|exam_failure), `source` (auto\|user) | Reports created |
+| `tga.reports.resolved_total` | Counter | — | `type`, `action` (spam\|ban\|warn\|dismiss\|kick\|allow\|confirm\|trust\|approve\|reject) | Resolution actions |
+| `tga.reports.resolution.duration` | Histogram | ms | `type` | Time from creation to resolution |
+| `tga.reports.pending_count` | ObservableGauge | — | — | Current total pending reports |
+
+**Observable gauge implementation:** `tga.reports.pending_count` uses a cached counter maintained by `ReportMetrics` itself. Incremented on `RecordReportCreated()`, decremented on `RecordReportResolved()`. This avoids async DB calls in the synchronous `ObservableGauge` callback. The count is eventually consistent — it resets on app restart but self-corrects as reports are created/resolved. A per-`type` tag is not used on the gauge to keep the caching simple; the `created_total` and `resolved_total` counters provide per-type breakdown.
 
 **Recording methods:**
 - `RecordReportCreated(string type, string source)`
@@ -224,7 +243,7 @@ Meter: `TelegramGroupsAdmin.Reports`
 **Instrumentation points:**
 - `ReportService.CreateReportAsync` — record creation
 - `ReportActionsService` — each `Handle*Async` method records resolution
-- Observable gauge callback queries `IReportsRepository` for pending counts
+- Observable gauge reads internal `_pendingCount` field (Interlocked increment/decrement)
 
 ### 7. `JobMetrics` (TelegramGroupsAdmin.BackgroundJobs)
 
@@ -232,45 +251,47 @@ Meter: `TelegramGroupsAdmin.Jobs`
 
 Replaces existing flat counters in `TelemetryConstants`.
 
-| Metric | Type | Tags | Purpose |
-|---|---|---|---|
-| `tga.jobs.executions_total` | Counter | `job_name`, `status` (success\|failure) | Job execution counts |
-| `tga.jobs.duration_ms` | Histogram | `job_name` | Job execution time |
-| `tga.jobs.rows_affected_total` | Counter | `job_name` | Rows deleted/processed (cleanup jobs) |
+| Metric | Type | Unit | Tags | Purpose |
+|---|---|---|---|---|
+| `tga.jobs.executions_total` | Counter | — | `job_name`, `status` (success\|failure) | Job execution counts |
+| `tga.jobs.duration` | Histogram | ms | `job_name` | Job execution time |
+| `tga.jobs.rows_affected_total` | Counter | — | `job_name` | Rows deleted/processed (cleanup jobs) |
 
 **Recording methods:**
 - `RecordJobExecution(string jobName, bool success, double durationMs)`
 - `RecordRowsAffected(string jobName, long count)`
 
 **Instrumentation points:**
-- All 16 `*Job.cs` files — replace direct `TelemetryConstants.JobExecutions` / `JobDuration` calls
+- All 17 `*Job.cs` files — replace direct `TelemetryConstants.JobExecutions` / `JobDuration` calls
 - `DataCleanupJob`, `DatabaseMaintenanceJob`, `DeleteMessageJob`, `DeleteUserMessagesJob` — add rows affected
 
 ### 8. `CacheMetrics` (TelegramGroupsAdmin.Core)
 
 Meter: `TelegramGroupsAdmin.Cache`
 
-| Metric | Type | Tags | Purpose |
-|---|---|---|---|
-| `tga.cache.hits_total` | Counter | `cache_name` | Cache hits |
-| `tga.cache.misses_total` | Counter | `cache_name` | Cache misses |
-| `tga.cache.evictions_total` | Counter | `cache_name` | Cache evictions |
+| Metric | Type | Unit | Tags | Purpose |
+|---|---|---|---|---|
+| `tga.cache.hits_total` | Counter | — | `cache_name` | Cache hits |
+| `tga.cache.misses_total` | Counter | — | `cache_name` | Cache misses |
+| `tga.cache.removals_total` | Counter | — | `cache_name` | Explicit cache removals |
+
+**Note:** Renamed from `evictions_total` to `removals_total`. The caches use `ConcurrentDictionary` with no automatic eviction policy — items are only removed explicitly via `RemoveChat()` / `RemoveHealth()`. This counter tracks those explicit removals.
 
 **Recording methods:**
 - `RecordHit(string cacheName)`
 - `RecordMiss(string cacheName)`
-- `RecordEviction(string cacheName)`
+- `RecordRemoval(string cacheName)`
 
 **Instrumentation points:**
-- `ChatCache` — wrap `TryGetValue` / `AddOrUpdate` / eviction callbacks
+- `ChatCache` — wrap `TryGetValue` / `AddOrUpdate` / `RemoveChat`
 - `ChatHealthCache` — same pattern
 - `SemanticKernelChatService` kernel cache — wrap cache lookups
 
 ### 9. `MemoryMetrics` (TelegramGroupsAdmin — main app)
 
-Renamed from `MemoryInstrumentation`. No instrument changes — keeps all 13 existing observable gauges.
+Renamed from `MemoryInstrumentation`. No instrument changes — keeps all 13 existing observable gauges. Owns its own `Meter` instance (no longer reads from `TelemetryConstants.Memory`).
 
-Meter: `TelegramGroupsAdmin.Memory` (unchanged)
+Meter: `TelegramGroupsAdmin.Memory`
 
 ## Migration Plan for Existing Metrics
 
@@ -278,12 +299,14 @@ Meter: `TelegramGroupsAdmin.Memory` (unchanged)
 
 1. **Remove** counter/histogram fields (`SpamDetections`, `FileScanResults`, `JobExecutions`, `SpamDetectionDuration`, `FileScanDuration`, `JobDuration`)
 2. **Remove** the `Metrics` meter (replaced by per-domain meters)
-3. **Keep** the `Memory` meter (used by `MemoryMetrics`)
+3. **Remove** the `Memory` meter (moved to `MemoryMetrics` class)
 4. **Keep** all four `ActivitySource` fields (tracing is unchanged)
+
+After migration, `TelemetryConstants` contains only `ActivitySource` fields. If no other code references it, it can be removed entirely with the sources moved to a `TelemetryActivitySources` class or kept as-is.
 
 ### Call Site Updates
 
-All files currently calling `TelemetryConstants.SpamDetections.Add(...)` etc. switch to injecting the appropriate metrics class and calling its wrapper method. The 16 background jobs switch from `TelemetryConstants.JobExecutions` / `JobDuration` to `JobMetrics.RecordJobExecution(...)`.
+All files currently calling `TelemetryConstants.SpamDetections.Add(...)` etc. switch to injecting the appropriate metrics class and calling its wrapper method. The 17 background jobs switch from `TelemetryConstants.JobExecutions` / `JobDuration` to `JobMetrics.RecordJobExecution(...)`.
 
 ## DI Registration
 
@@ -311,7 +334,8 @@ Tag cardinality is bounded:
 - `feature` tag: ~6 values (spam_check, image_classification, content_analysis, profile_scan, translation, impersonation)
 - `algorithm` tag: ~14 values (fixed set of content checks)
 - `command` tag: ~10 values (fixed set of bot commands)
-- `job_name` tag: 16 values (fixed set of Quartz jobs)
-- `operation` tag: ~8 values per API (fixed set of operations)
+- `job_name` tag: 17 values (fixed set of Quartz jobs)
+- `operation` tag (Telegram API): ~15-20 values (fixed set of Bot API operations)
+- `operation` tag (VirusTotal): 2 values (hash_lookup, file_upload)
 
 No unbounded cardinality (no user IDs, chat IDs, or message IDs as tags).

--- a/docs/superpowers/specs/2026-03-26-metrics-expansion-design.md
+++ b/docs/superpowers/specs/2026-03-26-metrics-expansion-design.md
@@ -1,0 +1,317 @@
+# Metrics Expansion Design
+
+## Summary
+
+Expand `/metrics` endpoint instrumentation from ~22 instruments to ~58, standardize naming on `tga.*` dotted prefix, and organize metrics into domain-scoped singleton classes with wrapper methods that enforce consistent tagging.
+
+## Goals
+
+- **Full observability from Grafana** — independent of the Blazor analytics pages
+- **Alerting capability** — real-time rate-based alerts on external API failures, pipeline stalls, quota exhaustion
+- **Per-feature attribution** — every external API call tagged with *why* it happened
+- **Consistent naming** — all metrics under `tga.<domain>.<subject>.<metric_type>`
+
+## Non-Goals
+
+- Grafana dashboard creation (handled separately on prod machine)
+- Alert rule definitions (configured in Prometheus/Grafana, not in app code)
+- Distributed tracing expansion (ActivitySources are already well-covered)
+
+## Architecture: Domain-Scoped Metrics Classes
+
+Each class is a **singleton** registered in DI, owns a `Meter` instance, and exposes recording methods that enforce consistent tag construction. Services inject only the metrics class they need.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ TelegramGroupsAdmin.Core                                │
+│   ApiMetrics         (OpenAI, VirusTotal, SendGrid, TG) │
+│   CacheMetrics       (hit/miss/eviction counters)       │
+├─────────────────────────────────────────────────────────┤
+│ TelegramGroupsAdmin.ContentDetection                    │
+│   DetectionMetrics   (spam, file scan, veto)            │
+├─────────────────────────────────────────────────────────┤
+│ TelegramGroupsAdmin.Telegram                            │
+│   PipelineMetrics    (messages, moderation, profile)    │
+│   ChatMetrics        (managed chats, health, joins)     │
+│   WelcomeMetrics     (welcome flow, security checks)    │
+│   ReportMetrics      (created, resolved, pending)       │
+├─────────────────────────────────────────────────────────┤
+│ TelegramGroupsAdmin.BackgroundJobs                      │
+│   JobMetrics         (executions, duration, rows)       │
+├─────────────────────────────────────────────────────────┤
+│ TelegramGroupsAdmin (main app)                          │
+│   MemoryMetrics      (renamed MemoryInstrumentation)    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Why Wrapper Methods
+
+Recording methods like `RecordOpenAiCall(feature, model, tokens, duration, success)` enforce that callers always provide the required tags. This prevents inconsistent tagging (e.g., forgetting the `feature` tag on one call site) which would create confusing Grafana queries.
+
+## Naming Convention
+
+All metrics use: `tga.<domain>.<subject>.<metric_type>`
+
+### Renames (Existing Flat Metrics)
+
+| Current Name | New Name |
+|---|---|
+| `spam_detections_total` | `tga.detection.spam_total` |
+| `spam_detection_duration_ms` | `tga.detection.algorithm.duration_ms` |
+| `file_scan_results_total` | `tga.detection.file_scan_total` |
+| `file_scan_duration_ms` | `tga.detection.file_scan.duration_ms` |
+| `job_executions_total` | `tga.jobs.executions_total` |
+| `job_duration_ms` | `tga.jobs.duration_ms` |
+
+Existing `tga.cache.*`, `tga.ml.*`, `tga.sessions.*`, `tga.queue.*` gauges are already correctly named — no changes needed.
+
+**Grafana impact:** All 6 renamed metrics require dashboard query updates on the prod machine.
+
+## Metrics Classes — Full Instrument Catalog
+
+### 1. `ApiMetrics` (TelegramGroupsAdmin.Core)
+
+Meter: `TelegramGroupsAdmin.Api`
+
+| Metric | Type | Tags | Purpose |
+|---|---|---|---|
+| `tga.api.openai.calls_total` | Counter | `feature`, `model`, `status` | Call count per feature |
+| `tga.api.openai.latency_ms` | Histogram | `feature`, `model` | Latency distribution |
+| `tga.api.openai.tokens_total` | Counter | `feature`, `model`, `type` (prompt\|completion) | Token consumption |
+| `tga.api.virustotal.calls_total` | Counter | `operation` (hash_lookup\|file_upload), `status` | Calls by operation |
+| `tga.api.virustotal.latency_ms` | Histogram | `operation` | Latency per operation |
+| `tga.api.virustotal.quota_exhausted_total` | Counter | — | Daily quota exhaustion events |
+| `tga.api.sendgrid.sends_total` | Counter | `template`, `status` | Email sends |
+| `tga.api.telegram.calls_total` | Counter | `operation`, `status` | Bot API calls by operation |
+| `tga.api.telegram.errors_total` | Counter | `error_type` | Error breakdown |
+
+**Recording methods:**
+- `RecordOpenAiCall(string feature, string model, int promptTokens, int completionTokens, double durationMs, bool success)`
+- `RecordVirusTotalCall(string operation, double durationMs, bool success)`
+- `RecordVirusTotalQuotaExhausted()`
+- `RecordSendGridSend(string template, bool success)`
+- `RecordTelegramApiCall(string operation, bool success)`
+- `RecordTelegramApiError(string errorType)`
+
+**Instrumentation points:**
+- `SemanticKernelChatService` — already extracts `ChatTokenUsage`, add metrics after each completion
+- `VirusTotalScannerService` — wrap hash lookup and file upload calls
+- `SendGridEmailService` (or equivalent) — wrap send calls
+- `BotMessageService`, `BotUserService`, `BotChatService` — wrap Telegram Bot API calls
+
+### 2. `DetectionMetrics` (TelegramGroupsAdmin.ContentDetection)
+
+Meter: `TelegramGroupsAdmin.Detection`
+
+Replaces existing flat counters in `TelemetryConstants`.
+
+| Metric | Type | Tags | Purpose |
+|---|---|---|---|
+| `tga.detection.spam_total` | Counter | `algorithm`, `result` (spam\|ham) | Per-algorithm detection counts |
+| `tga.detection.algorithm.duration_ms` | Histogram | `algorithm` | Per-algorithm execution time |
+| `tga.detection.file_scan_total` | Counter | `tier` (clamav\|virustotal), `result` (malicious\|clean) | File scan results |
+| `tga.detection.file_scan.duration_ms` | Histogram | `tier` | File scan latency |
+| `tga.detection.veto_total` | Counter | `algorithm` | OpenAI veto count per algorithm |
+
+**Recording methods:**
+- `RecordSpamDetection(string algorithm, bool isSpam, double durationMs)`
+- `RecordFileScan(string tier, bool isMalicious, double durationMs)`
+- `RecordVeto(string algorithm)`
+
+**Instrumentation points:**
+- `ContentDetectionEngineV2` — replace direct `TelemetryConstants` calls
+- `ClamAVScannerService` — replace direct `TelemetryConstants` calls
+- `VirusTotalScannerService` — add Tier 2 recording (currently missing)
+
+### 3. `PipelineMetrics` (TelegramGroupsAdmin.Telegram)
+
+Meter: `TelegramGroupsAdmin.Pipeline`
+
+| Metric | Type | Tags | Purpose |
+|---|---|---|---|
+| `tga.pipeline.messages_processed_total` | Counter | `source` (new_message\|edit), `result` (processed\|skipped\|error) | Messages through pipeline |
+| `tga.pipeline.processing.duration_ms` | Histogram | `source` | End-to-end pipeline latency |
+| `tga.pipeline.moderation_actions_total` | Counter | `action` (ban\|warn\|report\|delete\|malware_alert), `trigger` (auto\|admin) | All moderation actions |
+| `tga.pipeline.reports_created_total` | Counter | `reason` (borderline\|admin_review) | Reports queued for review |
+| `tga.pipeline.commands_handled_total` | Counter | `command` | Bot command usage |
+| `tga.pipeline.profile_scans_total` | Counter | `outcome` (clean\|held_for_review\|banned), `source` (welcome\|rescan\|manual) | Scan outcomes |
+| `tga.pipeline.profile_scan.duration_ms` | Histogram | `source` | Scan latency |
+| `tga.pipeline.profile_scan.timeouts_total` | Counter | — | 45s timeout hits |
+| `tga.pipeline.profile_scan.skipped_total` | Counter | `reason` (dedup\|no_session\|excluded) | Skipped scans |
+
+**Recording methods:**
+- `RecordMessageProcessed(string source, string result, double durationMs)`
+- `RecordModerationAction(string action, string trigger)`
+- `RecordReportCreated(string reason)`
+- `RecordCommandHandled(string command)`
+- `RecordProfileScan(string outcome, string source, double durationMs)`
+- `RecordProfileScanTimeout()`
+- `RecordProfileScanSkipped(string reason)`
+
+**Instrumentation points:**
+- `MessageProcessingService.HandleNewMessageAsync` / `HandleEditAsync` — wrap with stopwatch
+- `DetectionActionService.HandleSpamDetectionActionsAsync` — record moderation actions
+- `ProfileScanService.ScanUserProfileAsync` — wrap with stopwatch, record outcome/timeout/skip
+- `CommandRouter` — record command usage
+
+### 4. `ChatMetrics` (TelegramGroupsAdmin.Telegram)
+
+Meter: `TelegramGroupsAdmin.Chats`
+
+| Metric | Type | Tags | Purpose |
+|---|---|---|---|
+| `tga.chats.managed_total` | ObservableGauge | — | Active managed chats count |
+| `tga.chats.health_check_total` | Counter | `result` (healthy\|degraded\|unreachable) | Health check outcomes |
+| `tga.chats.marked_inactive_total` | Counter | — | Chats marked inactive (3 failures) |
+| `tga.chats.messages_total` | Counter | `type` (text\|photo\|video\|document\|sticker\|other) | Messages by content type |
+| `tga.chats.user_joins_total` | Counter | — | User joins across all chats |
+| `tga.chats.user_leaves_total` | Counter | — | User departures |
+
+**Recording methods:**
+- `RecordHealthCheck(string result)`
+- `RecordChatMarkedInactive()`
+- `RecordMessage(string type)`
+- `RecordUserJoin()`
+- `RecordUserLeave()`
+
+**Instrumentation points:**
+- `ChatHealthRefreshOrchestrator.RefreshHealthForChatAsync` — record health check results
+- `MessageProcessingService.HandleNewMessageAsync` — record message type
+- `WelcomeService.HandleChatMemberUpdateAsync` — record joins/leaves
+- Observable gauge callback queries `IManagedChatsRepository` for active count
+
+### 5. `WelcomeMetrics` (TelegramGroupsAdmin.Telegram)
+
+Meter: `TelegramGroupsAdmin.Welcome`
+
+| Metric | Type | Tags | Purpose |
+|---|---|---|---|
+| `tga.welcome.joins_total` | Counter | `result` (admitted\|banned\|timed_out\|denied_rules\|pre_banned\|skipped_admin) | Welcome flow outcomes |
+| `tga.welcome.security_checks_total` | Counter | `check` (username_blacklist\|cas\|impersonation\|profile_scan\|photo_match), `result` (pass\|fail\|skipped) | Per-check pass/fail |
+| `tga.welcome.duration_ms` | Histogram | `result` | End-to-end welcome flow time |
+| `tga.welcome.bot_joins_total` | Counter | `result` (allowed\|banned) | Bot join attempts |
+| `tga.welcome.timeouts_total` | Counter | — | Welcome timeout expirations |
+| `tga.welcome.leaves_total` | Counter | — | Users left before completing |
+
+**Recording methods:**
+- `RecordWelcomeOutcome(string result, double durationMs)`
+- `RecordSecurityCheck(string check, string result)`
+- `RecordBotJoin(string result)`
+- `RecordWelcomeTimeout()`
+- `RecordUserLeft()`
+
+**Instrumentation points:**
+- `WelcomeService.HandleChatMemberUpdateAsync` — wrap with stopwatch, record outcome at each exit path
+- Each security check step — record pass/fail/skip
+- `WelcomeTimeoutJob` — record timeout
+- `WelcomeService.HandleUserLeftAsync` — record leave
+
+### 6. `ReportMetrics` (TelegramGroupsAdmin.Telegram)
+
+Meter: `TelegramGroupsAdmin.Reports`
+
+| Metric | Type | Tags | Purpose |
+|---|---|---|---|
+| `tga.reports.created_total` | Counter | `type` (content\|profile_scan\|impersonation), `source` (auto\|user) | Reports created |
+| `tga.reports.resolved_total` | Counter | `type`, `action` (spam\|ban\|warn\|dismiss\|kick\|allow\|confirm\|trust) | Resolution actions |
+| `tga.reports.resolution.duration_ms` | Histogram | `type` | Time from creation to resolution |
+| `tga.reports.pending` | ObservableGauge | `type` | Current pending count |
+
+**Recording methods:**
+- `RecordReportCreated(string type, string source)`
+- `RecordReportResolved(string type, string action, double durationMs)`
+
+**Instrumentation points:**
+- `ReportService.CreateReportAsync` — record creation
+- `ReportActionsService` — each `Handle*Async` method records resolution
+- Observable gauge callback queries `IReportsRepository` for pending counts
+
+### 7. `JobMetrics` (TelegramGroupsAdmin.BackgroundJobs)
+
+Meter: `TelegramGroupsAdmin.Jobs`
+
+Replaces existing flat counters in `TelemetryConstants`.
+
+| Metric | Type | Tags | Purpose |
+|---|---|---|---|
+| `tga.jobs.executions_total` | Counter | `job_name`, `status` (success\|failure) | Job execution counts |
+| `tga.jobs.duration_ms` | Histogram | `job_name` | Job execution time |
+| `tga.jobs.rows_affected_total` | Counter | `job_name` | Rows deleted/processed (cleanup jobs) |
+
+**Recording methods:**
+- `RecordJobExecution(string jobName, bool success, double durationMs)`
+- `RecordRowsAffected(string jobName, long count)`
+
+**Instrumentation points:**
+- All 16 `*Job.cs` files — replace direct `TelemetryConstants.JobExecutions` / `JobDuration` calls
+- `DataCleanupJob`, `DatabaseMaintenanceJob`, `DeleteMessageJob`, `DeleteUserMessagesJob` — add rows affected
+
+### 8. `CacheMetrics` (TelegramGroupsAdmin.Core)
+
+Meter: `TelegramGroupsAdmin.Cache`
+
+| Metric | Type | Tags | Purpose |
+|---|---|---|---|
+| `tga.cache.hits_total` | Counter | `cache_name` | Cache hits |
+| `tga.cache.misses_total` | Counter | `cache_name` | Cache misses |
+| `tga.cache.evictions_total` | Counter | `cache_name` | Cache evictions |
+
+**Recording methods:**
+- `RecordHit(string cacheName)`
+- `RecordMiss(string cacheName)`
+- `RecordEviction(string cacheName)`
+
+**Instrumentation points:**
+- `ChatCache` — wrap `TryGetValue` / `AddOrUpdate` / eviction callbacks
+- `ChatHealthCache` — same pattern
+- `SemanticKernelChatService` kernel cache — wrap cache lookups
+
+### 9. `MemoryMetrics` (TelegramGroupsAdmin — main app)
+
+Renamed from `MemoryInstrumentation`. No instrument changes — keeps all 13 existing observable gauges.
+
+Meter: `TelegramGroupsAdmin.Memory` (unchanged)
+
+## Migration Plan for Existing Metrics
+
+### TelemetryConstants Changes
+
+1. **Remove** counter/histogram fields (`SpamDetections`, `FileScanResults`, `JobExecutions`, `SpamDetectionDuration`, `FileScanDuration`, `JobDuration`)
+2. **Remove** the `Metrics` meter (replaced by per-domain meters)
+3. **Keep** the `Memory` meter (used by `MemoryMetrics`)
+4. **Keep** all four `ActivitySource` fields (tracing is unchanged)
+
+### Call Site Updates
+
+All files currently calling `TelemetryConstants.SpamDetections.Add(...)` etc. switch to injecting the appropriate metrics class and calling its wrapper method. The 16 background jobs switch from `TelemetryConstants.JobExecutions` / `JobDuration` to `JobMetrics.RecordJobExecution(...)`.
+
+## DI Registration
+
+Each metrics class registers as a singleton in its project's `ServiceCollectionExtensions`:
+
+- `TelegramGroupsAdmin.Core` → `services.AddSingleton<ApiMetrics>()`, `services.AddSingleton<CacheMetrics>()`
+- `TelegramGroupsAdmin.ContentDetection` → `services.AddSingleton<DetectionMetrics>()`
+- `TelegramGroupsAdmin.Telegram` → `services.AddSingleton<PipelineMetrics>()`, `services.AddSingleton<ChatMetrics>()`, `services.AddSingleton<WelcomeMetrics>()`, `services.AddSingleton<ReportMetrics>()`
+- `TelegramGroupsAdmin.BackgroundJobs` → `services.AddSingleton<JobMetrics>()`
+- `TelegramGroupsAdmin` (main app) → `services.AddSingleton<MemoryMetrics>()` (replaces `MemoryInstrumentation`)
+
+## OpenTelemetry Configuration Update
+
+In `Program.cs`, the existing `AddMeter("TelegramGroupsAdmin.*")` wildcard already covers all new meters since they all start with `TelegramGroupsAdmin.`. No changes needed to the OTel pipeline configuration.
+
+## Testing Strategy
+
+- **Unit tests not required for metrics classes** — they are thin wrappers around `System.Diagnostics.Metrics` primitives
+- **Verify via `/metrics` endpoint** — after implementation, scrape `/metrics` and confirm all new metric names appear with expected tags
+- **Existing tests unaffected** — metrics classes are singletons with no side effects; services that gain a new constructor parameter just need the DI registration
+
+## Cardinality Notes
+
+Tag cardinality is bounded:
+- `feature` tag: ~6 values (spam_check, image_classification, content_analysis, profile_scan, translation, impersonation)
+- `algorithm` tag: ~14 values (fixed set of content checks)
+- `command` tag: ~10 values (fixed set of bot commands)
+- `job_name` tag: 16 values (fixed set of Quartz jobs)
+- `operation` tag: ~8 values per API (fixed set of operations)
+
+No unbounded cardinality (no user IDs, chat IDs, or message IDs as tags).

--- a/docs/superpowers/specs/2026-03-26-metrics-expansion-design.md
+++ b/docs/superpowers/specs/2026-03-26-metrics-expansion-design.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Expand `/metrics` endpoint instrumentation from ~22 instruments to ~58, standardize naming on `tga.*` dotted prefix, and organize metrics into domain-scoped singleton classes with wrapper methods that enforce consistent tagging.
+Expand `/metrics` endpoint instrumentation from ~19 custom instruments to ~58, standardize naming on `tga.*` dotted prefix, and organize metrics into domain-scoped singleton classes with wrapper methods that enforce consistent tagging.
 
 ## Goals
 
@@ -229,8 +229,8 @@ Meter: `TelegramGroupsAdmin.Reports`
 
 | Metric | Type | Unit | Tags | Purpose |
 |---|---|---|---|---|
-| `tga.reports.created_total` | Counter | — | `type` (content\|profile_scan\|impersonation\|exam_failure), `source` (auto\|user) | Reports created |
-| `tga.reports.resolved_total` | Counter | — | `type`, `action` (spam\|ban\|warn\|dismiss\|kick\|allow\|confirm\|trust\|approve\|reject) | Resolution actions |
+| `tga.reports.created_total` | Counter | — | `type` (content\|profile_scan\|impersonation\|exam_failure), `source` (auto\|user) | Reports created. Type mapping: `ContentReport`→`content`, `ProfileScanAlert`→`profile_scan`, `ImpersonationAlert`→`impersonation`, `ExamFailure`→`exam_failure` |
+| `tga.reports.resolved_total` | Counter | — | `type`, `action` (spam\|ban\|warn\|dismiss\|kick\|allow\|confirm\|trust\|approve\|deny\|deny_and_ban) | Resolution actions |
 | `tga.reports.resolution.duration` | Histogram | ms | `type` | Time from creation to resolution |
 | `tga.reports.pending_count` | ObservableGauge | — | — | Current total pending reports |
 
@@ -333,7 +333,7 @@ In `Program.cs`, the existing `AddMeter("TelegramGroupsAdmin.*")` wildcard alrea
 Tag cardinality is bounded:
 - `feature` tag: ~6 values (spam_check, image_classification, content_analysis, profile_scan, translation, impersonation)
 - `algorithm` tag: ~14 values (fixed set of content checks)
-- `command` tag: ~10 values (fixed set of bot commands)
+- `command` tag: ~13 values (fixed set of bot commands)
 - `job_name` tag: 17 values (fixed set of Quartz jobs)
 - `operation` tag (Telegram API): ~15-20 values (fixed set of Bot API operations)
 - `operation` tag (VirusTotal): 2 values (hash_lookup, file_upload)


### PR DESCRIPTION
Closes #422

## Summary

- **9 new metrics classes** distributed across Core, ContentDetection, Telegram, BackgroundJobs, and main app projects — each a DI-registered singleton owning a `Meter` with domain-specific instruments
- **Migrated all existing flat metrics** from `TelemetryConstants` (now contains only ActivitySources) to the new domain-scoped classes
- **Standardized naming** on `tga.*` dotted prefix with correct histogram unit handling (no `_ms` suffix duplication)
- **Instrumented 30+ service files** including all 17 background jobs, external APIs (OpenAI, VirusTotal, SendGrid, Telegram Bot API), content detection pipeline, message processing, welcome flow, report system, and caches

### Metrics Classes

| Class | Project | Instruments |
|---|---|---|
| `ApiMetrics` | Core | 9 (OpenAI calls/latency/tokens, VirusTotal calls/latency/quota, SendGrid, Telegram API calls/errors) |
| `CacheMetrics` | Core | 3 (hits, misses, removals) |
| `DetectionMetrics` | ContentDetection | 5 (spam detection, algorithm duration, file scan, veto) |
| `PipelineMetrics` | Telegram | 8 (messages processed, moderation actions, commands, profile scans) |
| `ChatMetrics` | Telegram | 6 (managed count gauge, health checks, messages by type, joins/leaves) |
| `WelcomeMetrics` | Telegram | 6 (welcome outcomes, security checks, bot joins, timeouts, leaves) |
| `ReportMetrics` | Telegram | 4 (created, resolved, duration, pending count gauge) |
| `JobMetrics` | BackgroundJobs | 3 (executions, duration, rows affected) |
| `MemoryMetrics` | Main app | 13 existing ObservableGauges (renamed from MemoryInstrumentation) |

### Grafana Impact
- 6 existing metrics renamed (`spam_detections_total` → `tga.detection.spam_total`, etc.)
- Histogram suffix changes (`_ms_milliseconds` → `_milliseconds`)
- Dashboard queries need updating on prod

## Test plan
- [x] Full solution builds with 0 errors, 0 warnings
- [x] 3,454 tests pass (unit + component + integration)
- [x] App boots cleanly with `dotnet run --migrate-only`
- [x] No dangling `TelemetryConstants` counter/histogram references
- [ ] Deploy to prod and verify new metrics appear on `/metrics` endpoint (post-merge)
- [ ] Update Grafana dashboards for renamed metrics (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)