### PR TITLE
feat: track username and name history with audit trail

### DIFF
--- a/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using NSubstitute;
@@ -39,6 +40,10 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
 
         // Add WebUser cascading value (mirrors MainLayout where CascadingValue wraps MudDialogProvider)
         this.AddTestWebUser();
+
+        // Cascade TimeZoneInfo so LocalTimestamp renders formatted dates instead of mdash
+        RenderTree.TryAdd<CascadingValue<TimeZoneInfo?>>(p =>
+            p.Add(cv => cv.Value, TimeZoneInfo.Utc));
 
         // Create mocks for services used by the dialog
         _mockUserService = Substitute.For<ITelegramUserManagementService>();

--- a/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
@@ -98,6 +98,18 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
         return _dialogService.ShowAsync<UserDetailDialog>("User Details", parameters, options);
     }
 
+    [SetUp]
+    public async Task SetUp()
+    {
+        // Clear previously rendered components so each test starts with a fresh DOM.
+        // Without this, provider.Markup accumulates dialogs from prior tests in the fixture.
+        await DisposeComponentsAsync();
+
+        // Reset mock returns to defaults (NSubstitute retains overrides across tests)
+        _mockHistoryRepo.GetByUserIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
+    }
+
     #region Name History Panel Tests
 
     [Test]

--- a/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
@@ -1,0 +1,245 @@
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using NSubstitute;
+using TelegramGroupsAdmin.Components.Shared;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
+using TelegramGroupsAdmin.Telegram.Services.Bot;
+using TelegramGroupsAdmin.Telegram.Services.UserApi;
+
+namespace TelegramGroupsAdmin.ComponentTests.Components;
+
+/// <summary>
+/// Component tests for the name history panel in UserDetailDialog.razor.
+/// Verifies conditional rendering, collapsed state text, data display, and null username handling.
+/// </summary>
+[TestFixture]
+public class UserDetailDialogHistoryTests : MudBlazorTestContext
+{
+    private ITelegramUserManagementService _mockUserService = null!;
+    private IBotModerationService _mockModerationService = null!;
+    private IAdminNotesRepository _mockNotesRepo = null!;
+    private IUserTagsRepository _mockTagsRepo = null!;
+    private ITagDefinitionsRepository _mockTagDefinitionsRepo = null!;
+    private IUserActionsRepository _mockActionsRepo = null!;
+    private IUsernameHistoryRepository _mockHistoryRepo = null!;
+    private ISnackbar _mockSnackbar = null!;
+    private IDialogService _dialogService = null!;
+
+    private const long TestUserId = 123456789;
+
+    public UserDetailDialogHistoryTests()
+    {
+        // Additional JSInterop setup not in MudBlazorTestContext
+        JSInterop.SetupVoid("mudPopover.initialize", _ => true).SetVoidResult();
+        JSInterop.SetupVoid("mudPopover.connect", _ => true).SetVoidResult();
+        JSInterop.SetupVoid("mudPopover.disconnect", _ => true).SetVoidResult();
+
+        // Add WebUser cascading value (mirrors MainLayout where CascadingValue wraps MudDialogProvider)
+        this.AddTestWebUser();
+
+        // Create mocks for services used by the dialog
+        _mockUserService = Substitute.For<ITelegramUserManagementService>();
+        _mockModerationService = Substitute.For<IBotModerationService>();
+        _mockSnackbar = Substitute.For<ISnackbar>();
+        _mockTagDefinitionsRepo = Substitute.For<ITagDefinitionsRepository>();
+        _mockHistoryRepo = Substitute.For<IUsernameHistoryRepository>();
+
+        // These repositories satisfy constructor injection but are not directly called by the dialog
+        _mockNotesRepo = Substitute.For<IAdminNotesRepository>();
+        _mockTagsRepo = Substitute.For<IUserTagsRepository>();
+        _mockActionsRepo = Substitute.For<IUserActionsRepository>();
+
+        // Register services
+        Services.AddSingleton(_mockUserService);
+        Services.AddSingleton(_mockModerationService);
+        Services.AddSingleton(_mockNotesRepo);
+        Services.AddSingleton(_mockTagsRepo);
+        Services.AddSingleton(_mockTagDefinitionsRepo);
+        Services.AddSingleton(_mockActionsRepo);
+        Services.AddSingleton(_mockSnackbar);
+        Services.AddSingleton(_mockHistoryRepo);
+        Services.AddSingleton(Substitute.For<IProfileScanService>());
+        Services.AddSingleton(Substitute.For<ITelegramSessionManager>());
+        Services.AddSingleton(Substitute.For<ITelegramUserRepository>());
+
+        // Default setup for tag definitions
+        _mockTagDefinitionsRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<TagDefinition>()));
+
+        // Default: no history entries
+        _mockHistoryRepo.GetByUserIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
+    }
+
+    private IRenderedComponent<MudDialogProvider> RenderDialogProvider()
+    {
+        var provider = Render<MudDialogProvider>();
+        _dialogService = Services.GetRequiredService<IDialogService>();
+        return provider;
+    }
+
+    private Task<IDialogReference> OpenDialogAsync(long userId)
+    {
+        var parameters = new DialogParameters<UserDetailDialog>
+        {
+            { x => x.UserId, userId }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Large,
+            FullWidth = true
+        };
+
+        return _dialogService.ShowAsync<UserDetailDialog>("User Details", parameters, options);
+    }
+
+    #region Name History Panel Tests
+
+    [Test]
+    public void NameHistoryPanel_NotRendered_WhenNoHistory()
+    {
+        // Arrange — no history entries (default mock returns empty list)
+        var userDetail = CreateUserDetail();
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert — expansion panel should not appear when there is no history
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Not.Contain("Name History"));
+        });
+
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void NameHistoryPanel_RenderedCollapsed_WhenHistoryExists()
+    {
+        // Arrange — return two history records
+        var userDetail = CreateUserDetail();
+        var history = new List<UsernameHistoryRecord>
+        {
+            new(1, TestUserId, "olduser", "Old", "Name", DateTimeOffset.UtcNow.AddDays(-10)),
+            new(2, TestUserId, "newuser", "New", "Name", DateTimeOffset.UtcNow.AddDays(-1))
+        };
+
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(history));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert — panel text should include the count
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("Name History (2)"));
+        });
+
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void NameHistoryPanel_ShowsCorrectData_WhenExpanded()
+    {
+        // Arrange — a single history entry with known values
+        var userDetail = CreateUserDetail();
+        var recordedAt = new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var history = new List<UsernameHistoryRecord>
+        {
+            new(1, TestUserId, "prevuser", "Previous", "User", recordedAt)
+        };
+
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(history));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert — username, full name, and formatted date all appear in the markup
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("@prevuser"));
+            Assert.That(provider.Markup, Does.Contain("Previous User"));
+            // Date is rendered via entry.RecordedAt.LocalDateTime.ToString("MMM d, yyyy")
+            Assert.That(provider.Markup, Does.Contain("Jun"));
+        });
+
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    [Test]
+    public void NameHistoryPanel_HandlesNullUsername()
+    {
+        // Arrange — history entry with a null username
+        var userDetail = CreateUserDetail();
+        var history = new List<UsernameHistoryRecord>
+        {
+            new(1, TestUserId, null, "Some", "Person", DateTimeOffset.UtcNow.AddDays(-5))
+        };
+
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
+        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(history));
+
+        var provider = RenderDialogProvider();
+
+        // Act
+        var dialogTask = OpenDialogAsync(TestUserId);
+
+        // Assert — null username should render as "(no username)"
+        provider.WaitForAssertion(() =>
+        {
+            Assert.That(provider.Markup, Does.Contain("(no username)"));
+        });
+
+        Assert.That(dialogTask.Exception, Is.Null);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static TelegramUserDetail CreateUserDetail(
+        string? username = null,
+        bool isTrusted = false,
+        bool isBanned = false)
+    {
+        return new TelegramUserDetail
+        {
+            User = new UserIdentity(TestUserId, "Test", "User", username),
+            IsTrusted = isTrusted,
+            IsBanned = isBanned,
+            KickCount = 0,
+            BotDmEnabled = false,
+            FirstSeenAt = DateTimeOffset.UtcNow.AddDays(-30),
+            LastSeenAt = DateTimeOffset.UtcNow.AddHours(-1),
+            ChatMemberships = [],
+            Actions = [],
+            DetectionHistory = [],
+            Notes = [],
+            Tags = [],
+            Warnings = []
+        };
+    }
+
+    #endregion
+}

--- a/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
@@ -25,7 +25,6 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
     private IUserTagsRepository _mockTagsRepo = null!;
     private ITagDefinitionsRepository _mockTagDefinitionsRepo = null!;
     private IUserActionsRepository _mockActionsRepo = null!;
-    private IUsernameHistoryRepository _mockHistoryRepo = null!;
     private ISnackbar _mockSnackbar = null!;
     private IDialogService _dialogService = null!;
 
@@ -46,7 +45,6 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
         _mockModerationService = Substitute.For<IBotModerationService>();
         _mockSnackbar = Substitute.For<ISnackbar>();
         _mockTagDefinitionsRepo = Substitute.For<ITagDefinitionsRepository>();
-        _mockHistoryRepo = Substitute.For<IUsernameHistoryRepository>();
 
         // These repositories satisfy constructor injection but are not directly called by the dialog
         _mockNotesRepo = Substitute.For<IAdminNotesRepository>();
@@ -61,7 +59,6 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
         Services.AddSingleton(_mockTagDefinitionsRepo);
         Services.AddSingleton(_mockActionsRepo);
         Services.AddSingleton(_mockSnackbar);
-        Services.AddSingleton(_mockHistoryRepo);
         Services.AddSingleton(Substitute.For<IProfileScanService>());
         Services.AddSingleton(Substitute.For<ITelegramSessionManager>());
         Services.AddSingleton(Substitute.For<ITelegramUserRepository>());
@@ -71,7 +68,7 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
             .Returns(Task.FromResult(new List<TagDefinition>()));
 
         // Default: no history entries
-        _mockHistoryRepo.GetByUserIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+        _mockUserService.GetNameHistoryAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
     }
 
@@ -106,7 +103,7 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
         await DisposeComponentsAsync();
 
         // Reset mock returns to defaults (NSubstitute retains overrides across tests)
-        _mockHistoryRepo.GetByUserIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+        _mockUserService.GetNameHistoryAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
     }
 
@@ -147,7 +144,7 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
 
         _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
-        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+        _mockUserService.GetNameHistoryAsync(TestUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(history));
 
         var provider = RenderDialogProvider();
@@ -177,7 +174,7 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
 
         _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
-        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+        _mockUserService.GetNameHistoryAsync(TestUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(history));
 
         var provider = RenderDialogProvider();
@@ -209,7 +206,7 @@ public class UserDetailDialogHistoryTests : MudBlazorTestContext
 
         _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<TelegramUserDetail?>(userDetail));
-        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+        _mockUserService.GetNameHistoryAsync(TestUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(history));
 
         var provider = RenderDialogProvider();

--- a/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs
@@ -72,6 +72,10 @@ public class UserDetailDialogTests : MudBlazorTestContext
         Services.AddSingleton(Substitute.For<IProfileScanService>());
         Services.AddSingleton(Substitute.For<ITelegramSessionManager>());
         Services.AddSingleton(Substitute.For<ITelegramUserRepository>());
+        var mockHistoryRepo = Substitute.For<IUsernameHistoryRepository>();
+        mockHistoryRepo.GetByUserIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameHistoryRecord>());
+        Services.AddSingleton(mockHistoryRepo);
 
         // Default setup for tag definitions
         _mockTagDefinitionsRepo.GetAllAsync(Arg.Any<CancellationToken>())

--- a/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs
@@ -72,10 +72,10 @@ public class UserDetailDialogTests : MudBlazorTestContext
         Services.AddSingleton(Substitute.For<IProfileScanService>());
         Services.AddSingleton(Substitute.For<ITelegramSessionManager>());
         Services.AddSingleton(Substitute.For<ITelegramUserRepository>());
-        var mockHistoryRepo = Substitute.For<IUsernameHistoryRepository>();
-        mockHistoryRepo.GetByUserIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
-            .Returns(new List<UsernameHistoryRecord>());
-        Services.AddSingleton(mockHistoryRepo);
+
+        // Default: no history entries
+        _mockUserService.GetNameHistoryAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
 
         // Default setup for tag definitions
         _mockTagDefinitionsRepo.GetAllAsync(Arg.Any<CancellationToken>())

--- a/TelegramGroupsAdmin.Core/Models/Actor.cs
+++ b/TelegramGroupsAdmin.Core/Models/Actor.cs
@@ -113,6 +113,7 @@ public record Actor
             "profile_scan" => "Profile Scan",
             "username_blacklist" => "Username Blacklist",
             "bootstrap" => "CLI Bootstrap",
+            "profile_diff_detection" => "Profile Change Detection",
             _ => systemIdentifier
         };
 

--- a/TelegramGroupsAdmin.Core/Models/Actor.cs
+++ b/TelegramGroupsAdmin.Core/Models/Actor.cs
@@ -55,6 +55,7 @@ public record Actor
     public static readonly Actor ProfileScan = FromSystem("profile_scan");
     public static readonly Actor UsernameBlacklist = FromSystem("username_blacklist");
     public static readonly Actor Bootstrap = FromSystem("bootstrap");
+    public static readonly Actor ProfileDiffDetection = FromSystem("profile_diff_detection");
 
     /// <summary>
     /// Create actor from web user

--- a/TelegramGroupsAdmin.Data/AppDbContext.cs
+++ b/TelegramGroupsAdmin.Data/AppDbContext.cs
@@ -35,6 +35,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
 
     // Telegram integration tables
     public DbSet<TelegramUserDto> TelegramUsers => Set<TelegramUserDto>();
+    public DbSet<UsernameHistoryDto> UsernameHistory => Set<UsernameHistoryDto>();
     public DbSet<TelegramUserMappingRecordDto> TelegramUserMappings => Set<TelegramUserMappingRecordDto>();
     public DbSet<TelegramLinkTokenRecordDto> TelegramLinkTokens => Set<TelegramLinkTokenRecordDto>();
     public DbSet<ManagedChatRecordDto> ManagedChats => Set<ManagedChatRecordDto>();
@@ -254,6 +255,13 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
             .HasOne(ut => ut.TelegramUser)
             .WithMany()
             .HasForeignKey(ut => ut.TelegramUserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // UsernameHistory → TelegramUsers (cascade delete)
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasOne(h => h.User)
+            .WithMany()
+            .HasForeignKey(h => h.UserId)
             .OnDelete(DeleteBehavior.Cascade);
 
         // ============================================================================
@@ -635,6 +643,19 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<TelegramUserDto>()
             .HasIndex(tu => tu.ProfileScannedAt)
             .HasDatabaseName("ix_telegram_users_profile_scanned_at"); // Background re-scan job ordering
+
+        // UsernameHistory indexes
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => h.UserId)
+            .HasDatabaseName("IX_username_history_user_id");
+
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => h.Username)
+            .HasDatabaseName("IX_username_history_username_lower");
+
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => new { h.FirstName, h.LastName })
+            .HasDatabaseName("IX_username_history_name_lower");
 
         // TelegramUserMappings indexes
         modelBuilder.Entity<TelegramUserMappingRecordDto>()

--- a/TelegramGroupsAdmin.Data/AppDbContext.cs
+++ b/TelegramGroupsAdmin.Data/AppDbContext.cs
@@ -647,15 +647,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         // UsernameHistory indexes
         modelBuilder.Entity<UsernameHistoryDto>()
             .HasIndex(h => h.UserId)
-            .HasDatabaseName("IX_username_history_user_id");
-
-        modelBuilder.Entity<UsernameHistoryDto>()
-            .HasIndex(h => h.Username)
-            .HasDatabaseName("IX_username_history_username_lower");
-
-        modelBuilder.Entity<UsernameHistoryDto>()
-            .HasIndex(h => new { h.FirstName, h.LastName })
-            .HasDatabaseName("IX_username_history_name_lower");
+            .HasDatabaseName("ix_username_history_user_id");
 
         // TelegramUserMappings indexes
         modelBuilder.Entity<TelegramUserMappingRecordDto>()

--- a/TelegramGroupsAdmin.Data/Migrations/20260404024209_AddUsernameHistoryTable.Designer.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260404024209_AddUsernameHistoryTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TelegramGroupsAdmin.Data;
@@ -11,9 +12,11 @@ using TelegramGroupsAdmin.Data;
 namespace TelegramGroupsAdmin.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404024209_AddUsernameHistoryTable")]
+    partial class AddUsernameHistoryTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TelegramGroupsAdmin.Data/Migrations/20260404024209_AddUsernameHistoryTable.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260404024209_AddUsernameHistoryTable.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TelegramGroupsAdmin.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUsernameHistoryTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "username_history",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    user_id = table.Column<long>(type: "bigint", nullable: false),
+                    username = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    first_name = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    last_name = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    recorded_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_username_history", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_username_history_telegram_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "telegram_users",
+                        principalColumn: "telegram_user_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_username_history_name_lower",
+                table: "username_history",
+                columns: new[] { "first_name", "last_name" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_username_history_user_id",
+                table: "username_history",
+                column: "user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_username_history_username_lower",
+                table: "username_history",
+                column: "username");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "username_history");
+        }
+    }
+}

--- a/TelegramGroupsAdmin.Data/Migrations/20260404040738_RenameAndDropUsernameHistoryIndexes.Designer.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260404040738_RenameAndDropUsernameHistoryIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TelegramGroupsAdmin.Data;
@@ -11,9 +12,11 @@ using TelegramGroupsAdmin.Data;
 namespace TelegramGroupsAdmin.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404040738_RenameAndDropUsernameHistoryIndexes")]
+    partial class RenameAndDropUsernameHistoryIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TelegramGroupsAdmin.Data/Migrations/20260404040738_RenameAndDropUsernameHistoryIndexes.cs
+++ b/TelegramGroupsAdmin.Data/Migrations/20260404040738_RenameAndDropUsernameHistoryIndexes.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelegramGroupsAdmin.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameAndDropUsernameHistoryIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_username_history_name_lower",
+                table: "username_history");
+
+            migrationBuilder.DropIndex(
+                name: "IX_username_history_username_lower",
+                table: "username_history");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_username_history_user_id",
+                table: "username_history",
+                newName: "ix_username_history_user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameIndex(
+                name: "ix_username_history_user_id",
+                table: "username_history",
+                newName: "IX_username_history_user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_username_history_name_lower",
+                table: "username_history",
+                columns: new[] { "first_name", "last_name" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_username_history_username_lower",
+                table: "username_history",
+                column: "username");
+        }
+    }
+}

--- a/TelegramGroupsAdmin.Data/Models/UserActionType.cs
+++ b/TelegramGroupsAdmin.Data/Models/UserActionType.cs
@@ -24,5 +24,7 @@ public enum UserActionType
     /// <summary>Kick user from a specific chat (ban then immediate unban)</summary>
     Kick = 8,
     /// <summary>Restore user permissions to chat defaults (unmute)</summary>
-    RestorePermissions = 9
+    RestorePermissions = 9,
+    /// <summary>Profile change detected (username, first name, or last name changed)</summary>
+    ProfileChange = 10
 }

--- a/TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs
+++ b/TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TelegramGroupsAdmin.Data.Models;
+
+/// <summary>
+/// Tracks historical username/name values for a Telegram user.
+/// Each row captures the previous values at the moment a profile change is detected.
+/// </summary>
+[Table("username_history")]
+public class UsernameHistoryDto
+{
+    [Key]
+    [Column("id")]
+    public long Id { get; set; }
+
+    [Column("user_id")]
+    public long UserId { get; set; }
+
+    [Column("username")]
+    [MaxLength(32)]
+    public string? Username { get; set; }
+
+    [Column("first_name")]
+    [MaxLength(64)]
+    public string? FirstName { get; set; }
+
+    [Column("last_name")]
+    [MaxLength(64)]
+    public string? LastName { get; set; }
+
+    [Column("recorded_at")]
+    public DateTimeOffset RecordedAt { get; set; }
+
+    // Navigation
+    [ForeignKey(nameof(UserId))]
+    public virtual TelegramUserDto? User { get; set; }
+}

--- a/TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs
+++ b/TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs
@@ -33,6 +33,5 @@ public class UsernameHistoryDto
     public DateTimeOffset RecordedAt { get; set; }
 
     // Navigation
-    [ForeignKey(nameof(UserId))]
-    public virtual TelegramUserDto? User { get; set; }
+    public TelegramUserDto? User { get; set; }
 }

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
@@ -178,6 +178,91 @@ public class TelegramUserRepositoryTests
         Assert.That(counts.ActiveCount, Is.GreaterThanOrEqualTo(1));
     }
 
+    [Test]
+    public async Task SearchByNameAsync_MatchesPastUsername()
+    {
+        const long userId = 200010L;
+        await SeedActiveUserAsync(userId, username: "current_handle", firstName: "Search", lastName: "Test");
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userId, "legacy_handle", "Search", "Test");
+        }
+
+        var results = await _repository!.SearchByNameAsync("legacy_handle", limit: 10);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].TelegramUserId, Is.EqualTo(userId));
+    }
+
+    [Test]
+    public async Task SearchByNameAsync_MatchesPastFirstName()
+    {
+        const long userId = 200011L;
+        await SeedActiveUserAsync(userId, username: "name_search_user", firstName: "CurrentFirst", lastName: "Test");
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userId, "name_search_user", "FormerFirst", "Test");
+        }
+
+        var results = await _repository!.SearchByNameAsync("FormerFirst", limit: 10);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].TelegramUserId, Is.EqualTo(userId));
+    }
+
+    [Test]
+    public async Task GetPagedUsersAsync_SearchByPastName_DoesNotReturnDifferentUser()
+    {
+        const long userA = 200020L;
+        const long userB = 200021L;
+        await SeedActiveUserAsync(userA, username: "user_a", firstName: "Alice", lastName: "Smith");
+        await SeedActiveUserAsync(userB, username: "user_b", firstName: "Bob", lastName: "Jones");
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userA, "unique_old_handle", "Alice", "Smith");
+        }
+
+        var (items, totalCount) = await _repository!.GetPagedUsersAsync(
+            UiModels.UserListFilter.Active, skip: 0, take: 10,
+            searchText: "unique_old_handle", chatIds: null,
+            sortLabel: null, sortDescending: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(totalCount, Is.EqualTo(1));
+            Assert.That(items[0].TelegramUserId, Is.EqualTo(userA));
+        });
+    }
+
+    [Test]
+    public async Task SearchByNameAsync_DoesNotReturnUserWithoutMatchingHistory()
+    {
+        const long userA = 200030L;
+        const long userB = 200031L;
+        await SeedActiveUserAsync(userA, username: "iso_user_a", firstName: "Ava", lastName: "Test");
+        await SeedActiveUserAsync(userB, username: "iso_user_b", firstName: "Ben", lastName: "Test");
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userA, "distinctive_old_name", "Ava", "Test");
+        }
+
+        var results = await _repository!.SearchByNameAsync("distinctive_old_name", limit: 10);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(results, Has.Count.EqualTo(1));
+            Assert.That(results[0].TelegramUserId, Is.EqualTo(userA));
+        });
+    }
+
     #endregion
 
     #region GetOrCreateAsync Tests

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using TelegramGroupsAdmin.Core;
 using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
 using TelegramGroupsAdmin.IntegrationTests.TestData;
 using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
@@ -58,6 +59,7 @@ public class TelegramUserRepositoryTests
         });
 
         services.AddScoped<ITelegramUserRepository, TelegramUserRepository>();
+        services.AddScoped<IUsernameHistoryRepository, UsernameHistoryRepository>();
 
         _serviceProvider = services.BuildServiceProvider();
 
@@ -73,12 +75,110 @@ public class TelegramUserRepositoryTests
         _repository = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
     }
 
+    private async Task SeedActiveUserAsync(long userId, string? username = null, string? firstName = null, string? lastName = null)
+    {
+        await using var scope = _serviceProvider!.CreateAsyncScope();
+        var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
+        var now = DateTimeOffset.UtcNow;
+        await userRepo.UpsertAsync(new TelegramUser(
+            TelegramUserId: userId,
+            Username: username,
+            FirstName: firstName,
+            LastName: lastName,
+            UserPhotoPath: null,
+            PhotoHash: null,
+            PhotoFileUniqueId: null,
+            IsBot: false,
+            IsTrusted: false,
+            IsBanned: false,
+            KickCount: 0,
+            BotDmEnabled: false,
+            FirstSeenAt: now,
+            LastSeenAt: now,
+            CreatedAt: now,
+            UpdatedAt: now,
+            IsActive: true));
+    }
+
     [TearDown]
     public void TearDown()
     {
         _testHelper?.Dispose();
         (_serviceProvider as IDisposable)?.Dispose();
     }
+
+    #region Search with Username History Tests
+
+    [Test]
+    public async Task GetPagedUsersAsync_SearchMatchesPastUsername()
+    {
+        // Seed an active user with current username "new_name"
+        const long userId = 200001L;
+        await SeedActiveUserAsync(userId, username: "new_name", firstName: "Current", lastName: "User");
+
+        // Insert a history entry recording the old username
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userId, "old_name", "Current", "User");
+        }
+
+        // Search by old username — should find the user via username_history join
+        var (items, totalCount) = await _repository!.GetPagedUsersAsync(
+            UiModels.UserListFilter.Active, skip: 0, take: 10,
+            searchText: "old_name", chatIds: null,
+            sortLabel: null, sortDescending: false);
+
+        Assert.That(totalCount, Is.EqualTo(1));
+        Assert.That(items[0].TelegramUserId, Is.EqualTo(userId));
+    }
+
+    [Test]
+    public async Task GetPagedUsersAsync_SearchMatchesPastFirstName()
+    {
+        // Seed an active user with current first name "NewFirst"
+        const long userId = 200002L;
+        await SeedActiveUserAsync(userId, username: "history_user", firstName: "NewFirst", lastName: "User");
+
+        // Insert a history entry recording the old first name
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userId, "history_user", "OldFirst", "User");
+        }
+
+        // Search by old first name — should find the user via username_history join
+        var (items, totalCount) = await _repository!.GetPagedUsersAsync(
+            UiModels.UserListFilter.Active, skip: 0, take: 10,
+            searchText: "OldFirst", chatIds: null,
+            sortLabel: null, sortDescending: false);
+
+        Assert.That(totalCount, Is.EqualTo(1));
+        Assert.That(items[0].TelegramUserId, Is.EqualTo(userId));
+    }
+
+    [Test]
+    public async Task GetUserTabCountsAsync_IncludesUsersMatchedByPastNames()
+    {
+        // Seed an active user with a current username that won't match the search
+        const long userId = 200003L;
+        await SeedActiveUserAsync(userId, username: "current_handle", firstName: "Present", lastName: "User");
+
+        // Insert a history entry with a distinctive old username
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userId, "historic_handle", "Present", "User");
+        }
+
+        // Tab counts filtered by the old name must include the user in the active count
+        var counts = await _repository!.GetUserTabCountsAsync(
+            chatIds: null, searchText: "historic_handle");
+
+        Assert.That(counts.ActiveCount, Is.GreaterThanOrEqualTo(1));
+    }
+
+    #endregion
 
     #region GetOrCreateAsync Tests
 

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/UsernameHistoryRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/UsernameHistoryRepositoryTests.cs
@@ -1,0 +1,256 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+
+namespace TelegramGroupsAdmin.IntegrationTests.Repositories;
+
+/// <summary>
+/// Integration tests verifying UsernameHistoryRepository against a real PostgreSQL database.
+/// Covers insert/retrieve round-trips, ordering, cascade delete, user isolation, and null handling.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class UsernameHistoryRepositoryTests
+{
+    private MigrationTestHelper? _testHelper;
+    private IServiceProvider? _serviceProvider;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _testHelper = new MigrationTestHelper();
+        await _testHelper.CreateDatabaseAndApplyMigrationsAsync();
+
+        var services = new ServiceCollection();
+
+        services.AddDataProtection()
+            .SetApplicationName("TelegramGroupsAdmin.Tests")
+            .PersistKeysToFileSystem(new DirectoryInfo(Path.Combine(Path.GetTempPath(), $"test_keys_{Guid.NewGuid():N}")));
+
+        var dataSourceBuilder = new Npgsql.NpgsqlDataSourceBuilder(_testHelper.ConnectionString);
+        services.AddSingleton(dataSourceBuilder.Build());
+
+        services.AddDbContextFactory<AppDbContext>((_, options) =>
+        {
+            options.UseNpgsql(_testHelper.ConnectionString);
+        });
+
+        services.AddLogging(builder =>
+        {
+            builder.AddConsole().SetMinimumLevel(LogLevel.Warning);
+            builder.AddFilter("Microsoft.AspNetCore.DataProtection", LogLevel.Error);
+        });
+
+        services.AddScoped<ITelegramUserRepository, TelegramUserRepository>();
+        services.AddScoped<IUsernameHistoryRepository, UsernameHistoryRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        (_serviceProvider as IDisposable)?.Dispose();
+        _testHelper?.Dispose();
+    }
+
+    // ============================================================================
+    // Insert and Retrieve
+    // ============================================================================
+
+    [Test]
+    public async Task InsertAsync_And_GetByUserIdAsync_RoundTrips()
+    {
+        const long userId = 100001L;
+        await SeedUserAsync(userId);
+
+        await using var scope = _serviceProvider!.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+
+        await repo.InsertAsync(userId, "old_username", "OldFirst", "OldLast");
+
+        var results = await repo.GetByUserIdAsync(userId);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        var record = results[0];
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.UserId, Is.EqualTo(userId));
+            Assert.That(record.Username, Is.EqualTo("old_username"));
+            Assert.That(record.FirstName, Is.EqualTo("OldFirst"));
+            Assert.That(record.LastName, Is.EqualTo("OldLast"));
+            Assert.That(record.RecordedAt, Is.Not.EqualTo(default(DateTimeOffset)));
+        });
+    }
+
+    // ============================================================================
+    // Ordering
+    // ============================================================================
+
+    [Test]
+    public async Task GetByUserIdAsync_ReturnsDescendingByRecordedAt()
+    {
+        const long userId = 100002L;
+        await SeedUserAsync(userId);
+
+        // Seed rows directly with explicit, deterministic timestamps to avoid any timing dependency
+        var olderTs = "2024-01-01 10:00:00+00";
+        var newerTs = "2024-01-02 10:00:00+00";
+        await _testHelper!.ExecuteSqlAsync($"""
+            INSERT INTO username_history (user_id, username, first_name, last_name, recorded_at)
+            VALUES ({userId}, 'first_username', 'First', 'User', '{olderTs}'),
+                   ({userId}, 'second_username', 'Second', 'User', '{newerTs}')
+            """);
+
+        await using var scope = _serviceProvider!.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+
+        var results = await repo.GetByUserIdAsync(userId);
+
+        Assert.That(results, Has.Count.EqualTo(2));
+        Assert.That(results[0].Username, Is.EqualTo("second_username"),
+            "Most recently recorded entry must appear first (descending order)");
+        Assert.That(results[1].Username, Is.EqualTo("first_username"));
+        Assert.That(results[0].RecordedAt, Is.GreaterThan(results[1].RecordedAt));
+    }
+
+    // ============================================================================
+    // Cascade Delete
+    // ============================================================================
+
+    [Test]
+    public async Task CascadeDelete_RemovesHistoryWhenUserDeleted()
+    {
+        const long userId = 100003L;
+        await SeedUserAsync(userId);
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await repo.InsertAsync(userId, "username_to_delete", "ToDelete", "User");
+        }
+
+        // Verify history exists before delete
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            var before = await repo.GetByUserIdAsync(userId);
+            Assert.That(before, Has.Count.EqualTo(1), "History must exist before user deletion");
+        }
+
+        // Delete the parent user directly via SQL
+        await _testHelper!.ExecuteSqlAsync(
+            $"DELETE FROM telegram_users WHERE telegram_user_id = {userId}");
+
+        // History must be gone due to CASCADE DELETE
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            var after = await repo.GetByUserIdAsync(userId);
+            Assert.That(after, Is.Empty,
+                "Cascade delete must remove username_history rows when parent user is deleted");
+        }
+    }
+
+    // ============================================================================
+    // User Isolation
+    // ============================================================================
+
+    [Test]
+    public async Task GetByUserIdAsync_DoesNotReturnOtherUsersHistory()
+    {
+        const long userAId = 100004L;
+        const long userBId = 100005L;
+        await SeedUserAsync(userAId, username: "user_a");
+        await SeedUserAsync(userBId, username: "user_b");
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await repo.InsertAsync(userAId, "user_a_old", "UserA", "Old");
+            await repo.InsertAsync(userBId, "user_b_old", "UserB", "Old");
+        }
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+
+            var userAHistory = await repo.GetByUserIdAsync(userAId);
+            var userBHistory = await repo.GetByUserIdAsync(userBId);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(userAHistory, Has.Count.EqualTo(1));
+                Assert.That(userAHistory[0].UserId, Is.EqualTo(userAId));
+                Assert.That(userAHistory[0].Username, Is.EqualTo("user_a_old"));
+
+                Assert.That(userBHistory, Has.Count.EqualTo(1));
+                Assert.That(userBHistory[0].UserId, Is.EqualTo(userBId));
+                Assert.That(userBHistory[0].Username, Is.EqualTo("user_b_old"));
+            });
+        }
+    }
+
+    // ============================================================================
+    // Null Fields
+    // ============================================================================
+
+    [Test]
+    public async Task InsertAsync_HandlesNullFields()
+    {
+        const long userId = 100006L;
+        await SeedUserAsync(userId);
+
+        await using var scope = _serviceProvider!.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+
+        Assert.DoesNotThrowAsync(async () =>
+            await repo.InsertAsync(userId, username: null, firstName: null, lastName: null));
+
+        var results = await repo.GetByUserIdAsync(userId);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        var record = results[0];
+        Assert.Multiple(() =>
+        {
+            Assert.That(record.UserId, Is.EqualTo(userId));
+            Assert.That(record.Username, Is.Null);
+            Assert.That(record.FirstName, Is.Null);
+            Assert.That(record.LastName, Is.Null);
+        });
+    }
+
+    // ============================================================================
+    // Helper
+    // ============================================================================
+
+    private async Task SeedUserAsync(long userId, string? username = "testuser", string? firstName = "Test", string? lastName = "User")
+    {
+        await using var scope = _serviceProvider!.CreateAsyncScope();
+        var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
+        var now = DateTimeOffset.UtcNow;
+        await userRepo.UpsertAsync(new TelegramUser(
+            TelegramUserId: userId,
+            Username: username,
+            FirstName: firstName,
+            LastName: lastName,
+            UserPhotoPath: null,
+            PhotoHash: null,
+            PhotoFileUniqueId: null,
+            IsBot: false,
+            IsTrusted: false,
+            IsBanned: false,
+            KickCount: 0,
+            BotDmEnabled: false,
+            FirstSeenAt: now,
+            LastSeenAt: now,
+            CreatedAt: now,
+            UpdatedAt: now,
+            IsActive: false));
+    }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/TestData/GoldenDataset.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/TestData/GoldenDataset.cs
@@ -12,7 +12,7 @@ namespace TelegramGroupsAdmin.IntegrationTests.TestData;
 public static class GoldenDataset
 {
     // Tables with DTOs that BackupService can export (excludes: __EFMigrationsHistory, file_scan_quota, file_scan_results, ticker.*)
-    public const int TotalTableCount = 40; // Updated 2026-03-07: -threshold_recommendations (V1 remnant removed)
+    public const int TotalTableCount = 41; // Updated 2026-04-03: +username_history
 
     /// <summary>
     /// Web application users (ASP.NET Identity)

--- a/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
@@ -58,6 +58,7 @@ public static class ServiceCollectionExtensions
             services.AddScoped<IMessageTranslationService, MessageTranslationService>();
             services.AddScoped<IMessageEditService, MessageEditService>();
             services.AddScoped<ITelegramUserRepository, TelegramUserRepository>();
+            services.AddScoped<IUsernameHistoryRepository, UsernameHistoryRepository>();
 
             // Profile scan results
             services.AddScoped<IProfileScanResultsRepository, ProfileScanResultsRepository>();

--- a/TelegramGroupsAdmin.Telegram/Models/UserActionType.cs
+++ b/TelegramGroupsAdmin.Telegram/Models/UserActionType.cs
@@ -33,5 +33,8 @@ public enum UserActionType
     Kick = 8,
 
     /// <summary>Restore user permissions to chat defaults (unmute)</summary>
-    RestorePermissions = 9
+    RestorePermissions = 9,
+
+    /// <summary>Profile change detected (username, first name, or last name changed)</summary>
+    ProfileChange = 10
 }

--- a/TelegramGroupsAdmin.Telegram/Models/UsernameHistoryRecord.cs
+++ b/TelegramGroupsAdmin.Telegram/Models/UsernameHistoryRecord.cs
@@ -1,0 +1,13 @@
+namespace TelegramGroupsAdmin.Telegram.Models;
+
+/// <summary>
+/// Domain model for a username history entry.
+/// Each record captures the previous profile values at the moment a change was detected.
+/// </summary>
+public record UsernameHistoryRecord(
+    long Id,
+    long UserId,
+    string? Username,
+    string? FirstName,
+    string? LastName,
+    DateTimeOffset RecordedAt);

--- a/TelegramGroupsAdmin.Telegram/Repositories/IUsernameHistoryRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/IUsernameHistoryRepository.cs
@@ -1,0 +1,16 @@
+using TelegramGroupsAdmin.Telegram.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories;
+
+public interface IUsernameHistoryRepository
+{
+    /// <summary>
+    /// Record the previous profile values when a change is detected.
+    /// </summary>
+    Task InsertAsync(long userId, string? username, string? firstName, string? lastName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get all history entries for a user, most recent first.
+    /// </summary>
+    Task<List<UsernameHistoryRecord>> GetByUserIdAsync(long userId, CancellationToken cancellationToken = default);
+}

--- a/TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameHistoryMappings.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameHistoryMappings.cs
@@ -1,0 +1,18 @@
+using DataModels = TelegramGroupsAdmin.Data.Models;
+using UiModels = TelegramGroupsAdmin.Telegram.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories.Mappings;
+
+public static class UsernameHistoryMappings
+{
+    extension(DataModels.UsernameHistoryDto data)
+    {
+        public UiModels.UsernameHistoryRecord ToModel() => new(
+            Id: data.Id,
+            UserId: data.UserId,
+            Username: data.Username,
+            FirstName: data.FirstName,
+            LastName: data.LastName,
+            RecordedAt: data.RecordedAt);
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
@@ -487,11 +487,7 @@ public class TelegramUserRepository : ITelegramUserRepository
         if (!string.IsNullOrWhiteSpace(searchText))
         {
             var search = searchText.Trim().ToLower();
-            query = query.Where(u =>
-                (u.Username != null && EF.Functions.ILike(u.Username, $"%{search}%")) ||
-                (u.FirstName != null && EF.Functions.ILike(u.FirstName, $"%{search}%")) ||
-                (u.LastName != null && EF.Functions.ILike(u.LastName, $"%{search}%")) ||
-                EF.Functions.ILike(u.TelegramUserId.ToString(), $"%{search}%"));
+            query = ApplySearchFilter(query, context, search);
         }
 
         // Get total count before pagination
@@ -566,11 +562,7 @@ public class TelegramUserRepository : ITelegramUserRepository
         if (!string.IsNullOrWhiteSpace(searchText))
         {
             var search = searchText.Trim().ToLower();
-            query = query.Where(u =>
-                (u.Username != null && EF.Functions.ILike(u.Username, $"%{search}%")) ||
-                (u.FirstName != null && EF.Functions.ILike(u.FirstName, $"%{search}%")) ||
-                (u.LastName != null && EF.Functions.ILike(u.LastName, $"%{search}%")) ||
-                EF.Functions.ILike(u.TelegramUserId.ToString(), $"%{search}%"));
+            query = ApplySearchFilter(query, context, search);
         }
 
         var totalCount = await query.CountAsync(cancellationToken);
@@ -674,11 +666,7 @@ public class TelegramUserRepository : ITelegramUserRepository
         if (!string.IsNullOrWhiteSpace(searchText))
         {
             var search = searchText.Trim().ToLower();
-            baseQuery = baseQuery.Where(u =>
-                (u.Username != null && EF.Functions.ILike(u.Username, $"%{search}%")) ||
-                (u.FirstName != null && EF.Functions.ILike(u.FirstName, $"%{search}%")) ||
-                (u.LastName != null && EF.Functions.ILike(u.LastName, $"%{search}%")) ||
-                EF.Functions.ILike(u.TelegramUserId.ToString(), $"%{search}%"));
+            baseQuery = ApplySearchFilter(baseQuery, context, search);
         }
 
         // Run 5 count queries sequentially (DbContext is not thread-safe)
@@ -1172,7 +1160,7 @@ public class TelegramUserRepository : ITelegramUserRepository
 
         await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
-        // Fuzzy search: match against combined "first last" name OR username
+        // Fuzzy search: match against combined "first last" name OR username OR past names
         // Searches ALL users (active and inactive) for ban command
         var matches = await context.TelegramUsers
             .AsNoTracking()
@@ -1180,7 +1168,12 @@ public class TelegramUserRepository : ITelegramUserRepository
                 // Match against combined full name (first + space + last)
                 (u.FirstName + " " + u.LastName).ToLower().Contains(searchLower) ||
                 // Or match against username
-                (u.Username != null && u.Username.ToLower().Contains(searchLower)))
+                (u.Username != null && u.Username.ToLower().Contains(searchLower)) ||
+                // Or match against past names from username_history
+                context.UsernameHistory.Any(h =>
+                    h.UserId == u.TelegramUserId &&
+                    ((h.FirstName + " " + h.LastName).ToLower().Contains(searchLower) ||
+                     (h.Username != null && h.Username.ToLower().Contains(searchLower)))))
             .OrderBy(u => u.FirstName) // Alphabetical for consistent ordering
             .Take(limit)
             .ToListAsync(cancellationToken);
@@ -1293,5 +1286,27 @@ public class TelegramUserRepository : ITelegramUserRepository
             .ExecuteUpdateAsync(s => s
                 .SetProperty(u => u.ProfileScannedAt, DateTimeOffset.UtcNow)
                 .SetProperty(u => u.UpdatedAt, DateTimeOffset.UtcNow), cancellationToken);
+    }
+
+    // ============================================================================
+    // Search Helpers
+    // ============================================================================
+
+    /// <summary>
+    /// Builds a predicate that matches users by current OR past names from username_history.
+    /// </summary>
+    private static IQueryable<DataModels.TelegramUserDto> ApplySearchFilter(
+        IQueryable<DataModels.TelegramUserDto> query, AppDbContext context, string search)
+    {
+        return query.Where(u =>
+            (u.Username != null && EF.Functions.ILike(u.Username, $"%{search}%")) ||
+            (u.FirstName != null && EF.Functions.ILike(u.FirstName, $"%{search}%")) ||
+            (u.LastName != null && EF.Functions.ILike(u.LastName, $"%{search}%")) ||
+            EF.Functions.ILike(u.TelegramUserId.ToString(), $"%{search}%") ||
+            context.UsernameHistory.Any(h =>
+                h.UserId == u.TelegramUserId &&
+                ((h.Username != null && EF.Functions.ILike(h.Username, $"%{search}%")) ||
+                 (h.FirstName != null && EF.Functions.ILike(h.FirstName, $"%{search}%")) ||
+                 (h.LastName != null && EF.Functions.ILike(h.LastName, $"%{search}%")))));
     }
 }

--- a/TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs
@@ -28,11 +28,12 @@ public class UsernameHistoryRepository(IDbContextFactory<AppDbContext> contextFa
     {
         await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 
-        return await context.UsernameHistory
+        var dtos = await context.UsernameHistory
             .AsNoTracking()
             .Where(h => h.UserId == userId)
             .OrderByDescending(h => h.RecordedAt)
-            .Select(h => h.ToModel())
             .ToListAsync(cancellationToken);
+
+        return dtos.Select(h => h.ToModel()).ToList();
     }
 }

--- a/TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.Data.Models;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories.Mappings;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories;
+
+public class UsernameHistoryRepository(IDbContextFactory<AppDbContext> contextFactory) : IUsernameHistoryRepository
+{
+    public async Task InsertAsync(long userId, string? username, string? firstName, string? lastName, CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        context.UsernameHistory.Add(new UsernameHistoryDto
+        {
+            UserId = userId,
+            Username = username,
+            FirstName = firstName,
+            LastName = lastName,
+            RecordedAt = DateTimeOffset.UtcNow
+        });
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<List<UsernameHistoryRecord>> GetByUserIdAsync(long userId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context.UsernameHistory
+            .AsNoTracking()
+            .Where(h => h.UserId == userId)
+            .OrderByDescending(h => h.RecordedAt)
+            .Select(h => h.ToModel())
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
@@ -675,6 +675,29 @@ public partial class MessageProcessingService(
             {
                 LogProfileChangeDetected(logger, message.From.ToLogDebug(), existingUser.ToLogInfo(), message.From.ToLogInfo());
 
+                // Record previous profile values in username_history
+                var historyRepo = messageScope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+                await historyRepo.InsertAsync(
+                    existingUser.TelegramUserId,
+                    existingUser.Username,
+                    existingUser.FirstName,
+                    existingUser.LastName,
+                    cancellationToken);
+
+                // Record profile change in user_actions audit trail
+                var userActionsRepo = messageScope.ServiceProvider.GetRequiredService<IUserActionsRepository>();
+                var changeReason = BuildProfileChangeReason(existingUser, message.From);
+                await userActionsRepo.InsertAsync(new UserActionRecord(
+                    Id: 0,
+                    UserId: existingUser.TelegramUserId,
+                    ActionType: UserActionType.ProfileChange,
+                    MessageId: message.MessageId,
+                    ChatId: message.Chat.Id,
+                    IssuedBy: Actor.FromSystem("profile_diff_detection"),
+                    IssuedAt: DateTimeOffset.UtcNow,
+                    ExpiresAt: null,
+                    Reason: changeReason), cancellationToken);
+
                 try
                 {
                     var jobScheduler = messageScope.ServiceProvider.GetRequiredService<Handlers.BackgroundJobScheduler>();
@@ -816,6 +839,22 @@ public partial class MessageProcessingService(
         return !string.Equals(existing.FirstName, current.FirstName, StringComparison.Ordinal)
             || !string.Equals(existing.LastName, current.LastName, StringComparison.Ordinal)
             || !string.Equals(existing.Username, current.Username, StringComparison.Ordinal);
+    }
+
+    private static string BuildProfileChangeReason(TelegramUser old, global::Telegram.Bot.Types.User current)
+    {
+        var changes = new List<string>();
+
+        if (!string.Equals(old.Username, current.Username, StringComparison.Ordinal))
+            changes.Add($"Username: @{old.Username ?? "(none)"} → @{current.Username ?? "(none)"}");
+
+        if (!string.Equals(old.FirstName, current.FirstName, StringComparison.Ordinal))
+            changes.Add($"First name: {old.FirstName ?? "(none)"} → {current.FirstName ?? "(none)"}");
+
+        if (!string.Equals(old.LastName, current.LastName, StringComparison.Ordinal))
+            changes.Add($"Last name: {old.LastName ?? "(none)"} → {current.LastName ?? "(none)"}");
+
+        return string.Join(", ", changes);
     }
 
     // REFACTOR-2: Extracted methods to specialized handlers

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
@@ -841,7 +841,7 @@ public partial class MessageProcessingService(
             || !string.Equals(existing.Username, current.Username, StringComparison.Ordinal);
     }
 
-    private static string BuildProfileChangeReason(TelegramUser old, global::Telegram.Bot.Types.User current)
+    internal static string BuildProfileChangeReason(TelegramUser old, global::Telegram.Bot.Types.User current)
     {
         var changes = new List<string>();
 

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
@@ -693,7 +693,7 @@ public partial class MessageProcessingService(
                     ActionType: UserActionType.ProfileChange,
                     MessageId: message.MessageId,
                     ChatId: message.Chat.Id,
-                    IssuedBy: Actor.FromSystem("profile_diff_detection"),
+                    IssuedBy: Actor.ProfileDiffDetection,
                     IssuedAt: DateTimeOffset.UtcNow,
                     ExpiresAt: null,
                     Reason: changeReason), cancellationToken);

--- a/TelegramGroupsAdmin.Telegram/Services/ITelegramUserManagementService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ITelegramUserManagementService.cs
@@ -49,4 +49,7 @@ public interface ITelegramUserManagementService
 
     /// <summary>Unbans a user from all chats.</summary>
     Task<bool> UnbanAsync(long telegramUserId, Actor unbannedBy, string? reason = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets the username/name change history for a user.</summary>
+    Task<List<UsernameHistoryRecord>> GetNameHistoryAsync(long telegramUserId, CancellationToken cancellationToken = default);
 }

--- a/TelegramGroupsAdmin.Telegram/Services/TelegramUserManagementService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/TelegramUserManagementService.cs
@@ -15,15 +15,18 @@ public class TelegramUserManagementService : ITelegramUserManagementService
 {
     private readonly ITelegramUserRepository _userRepository;
     private readonly IUserActionsRepository _userActionsRepository;
+    private readonly IUsernameHistoryRepository _usernameHistoryRepository;
     private readonly ILogger<TelegramUserManagementService> _logger;
 
     public TelegramUserManagementService(
         ITelegramUserRepository userRepository,
         IUserActionsRepository userActionsRepository,
+        IUsernameHistoryRepository usernameHistoryRepository,
         ILogger<TelegramUserManagementService> logger)
     {
         _userRepository = userRepository;
         _userActionsRepository = userActionsRepository;
+        _usernameHistoryRepository = usernameHistoryRepository;
         _logger = logger;
     }
 
@@ -208,5 +211,11 @@ public class TelegramUserManagementService : ITelegramUserManagementService
             reason ?? "Manual unban");
 
         return true;
+    }
+
+    /// <inheritdoc/>
+    public Task<List<UsernameHistoryRecord>> GetNameHistoryAsync(long telegramUserId, CancellationToken cancellationToken = default)
+    {
+        return _usernameHistoryRepository.GetByUserIdAsync(telegramUserId, cancellationToken);
     }
 }

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/MessageProcessingServiceProfileDiffTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/MessageProcessingServiceProfileDiffTests.cs
@@ -1,0 +1,110 @@
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Services.BackgroundServices;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services;
+
+/// <summary>
+/// Unit tests for MessageProcessingService.BuildProfileChangeReason.
+/// Verifies that the human-readable audit reason string correctly describes
+/// username, first name, and last name changes, including null (none) cases.
+/// </summary>
+[TestFixture]
+public class MessageProcessingServiceProfileDiffTests
+{
+    [Test]
+    public void BuildProfileChangeReason_UsernameChanged_IncludesUsernameInReason()
+    {
+        var old = CreateUser(username: "old_user");
+        var current = CreateSdkUser(username: "new_user");
+
+        var result = MessageProcessingService.BuildProfileChangeReason(old, current);
+
+        Assert.That(result, Does.Contain("Username: @old_user → @new_user"));
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_FirstNameChanged_IncludesFirstNameInReason()
+    {
+        var old = CreateUser(firstName: "OldFirst");
+        var current = CreateSdkUser(firstName: "NewFirst");
+
+        var result = MessageProcessingService.BuildProfileChangeReason(old, current);
+
+        Assert.That(result, Does.Contain("First name: OldFirst → NewFirst"));
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_LastNameChanged_IncludesLastNameInReason()
+    {
+        var old = CreateUser(lastName: "OldLast");
+        var current = CreateSdkUser(lastName: "NewLast");
+
+        var result = MessageProcessingService.BuildProfileChangeReason(old, current);
+
+        Assert.That(result, Does.Contain("Last name: OldLast → NewLast"));
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_MultipleFieldsChanged_IncludesAll()
+    {
+        var old = CreateUser(username: "old_user", firstName: "OldFirst", lastName: "OldLast");
+        var current = CreateSdkUser(username: "new_user", firstName: "NewFirst", lastName: "NewLast");
+
+        var result = MessageProcessingService.BuildProfileChangeReason(old, current);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Does.Contain("Username: @old_user → @new_user"));
+            Assert.That(result, Does.Contain("First name: OldFirst → NewFirst"));
+            Assert.That(result, Does.Contain("Last name: OldLast → NewLast"));
+        });
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_NullToValue_ShowsNone()
+    {
+        var old = CreateUser(username: null);
+        var current = CreateSdkUser(username: "new_user");
+
+        var result = MessageProcessingService.BuildProfileChangeReason(old, current);
+
+        Assert.That(result, Does.Contain("Username: @(none) → @new_user"));
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_ValueToNull_ShowsNone()
+    {
+        var old = CreateUser(username: "old_user");
+        var current = CreateSdkUser(username: null);
+
+        var result = MessageProcessingService.BuildProfileChangeReason(old, current);
+
+        Assert.That(result, Does.Contain("Username: @old_user → @(none)"));
+    }
+
+    private static TelegramUser CreateUser(
+        string? username = "testuser", string? firstName = "Test", string? lastName = "User")
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new TelegramUser(
+            TelegramUserId: 12345,
+            Username: username, FirstName: firstName, LastName: lastName,
+            UserPhotoPath: null, PhotoHash: null, PhotoFileUniqueId: null,
+            IsBot: false, IsTrusted: false, IsBanned: false,
+            KickCount: 0, BotDmEnabled: false,
+            FirstSeenAt: now, LastSeenAt: now, CreatedAt: now, UpdatedAt: now);
+    }
+
+    private static global::Telegram.Bot.Types.User CreateSdkUser(
+        string? username = "testuser", string? firstName = "Test", string? lastName = "User")
+    {
+        return new global::Telegram.Bot.Types.User
+        {
+            Id = 12345,
+            IsBot = false,
+            FirstName = firstName ?? "Test",
+            LastName = lastName,
+            Username = username,
+        };
+    }
+}

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/TelegramUserManagementServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/TelegramUserManagementServiceTests.cs
@@ -20,6 +20,7 @@ public class TelegramUserManagementServiceTests
 {
     private ITelegramUserRepository _mockUserRepo = null!;
     private IUserActionsRepository _mockActionsRepo = null!;
+    private IUsernameHistoryRepository _mockHistoryRepo = null!;
     private ILogger<TelegramUserManagementService> _mockLogger = null!;
     private TelegramUserManagementService _service = null!;
 
@@ -30,6 +31,7 @@ public class TelegramUserManagementServiceTests
     {
         _mockUserRepo = Substitute.For<ITelegramUserRepository>();
         _mockActionsRepo = Substitute.For<IUserActionsRepository>();
+        _mockHistoryRepo = Substitute.For<IUsernameHistoryRepository>();
 
         // Logger is required by constructor but intentionally not verified.
         // Logging is an implementation detail - tests focus on business logic outcomes.
@@ -38,6 +40,7 @@ public class TelegramUserManagementServiceTests
         _service = new TelegramUserManagementService(
             _mockUserRepo,
             _mockActionsRepo,
+            _mockHistoryRepo,
             _mockLogger);
     }
 

--- a/TelegramGroupsAdmin/Components/Pages/Users.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Users.razor
@@ -20,7 +20,7 @@
     <MudPaper Class="pa-4 mb-4" Elevation="1">
         <MudTextField @bind-Value="_searchText"
                       Label="Search users"
-                      Placeholder="Search by name, username, or ID..."
+                      Placeholder="Search by name, username, ID, or past names..."
                       Variant="Variant.Outlined"
                       Adornment="Adornment.Start"
                       AdornmentIcon="@Icons.Material.Filled.Search"

--- a/TelegramGroupsAdmin/Components/Pages/Users.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Users.razor
@@ -20,7 +20,7 @@
     <MudPaper Class="pa-4 mb-4" Elevation="1">
         <MudTextField @bind-Value="_searchText"
                       Label="Search users"
-                      Placeholder="Search by name, username, ID, or past names..."
+                      Placeholder="Search by name, username, ID, or name history..."
                       Variant="Variant.Outlined"
                       Adornment="Adornment.Start"
                       AdornmentIcon="@Icons.Material.Filled.Search"

--- a/TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
@@ -4,6 +4,7 @@
 @using TelegramGroupsAdmin.Core.Utilities
 @using TelegramGroupsAdmin.Telegram.Services.Bot
 @using TelegramGroupsAdmin.Telegram.Services.Moderation
+@using TelegramGroupsAdmin.Telegram.Repositories
 @inject ITelegramUserManagementService UserManagementService
 @inject IBotModerationService ModerationService
 @inject IAdminNotesRepository AdminNotesRepository
@@ -15,6 +16,7 @@
 @inject NavigationManager Navigation
 @inject TelegramGroupsAdmin.Telegram.Services.UserApi.IProfileScanService ProfileScanService
 @inject TelegramGroupsAdmin.Telegram.Repositories.ITelegramUserRepository TelegramUserRepository
+@inject IUsernameHistoryRepository UsernameHistoryRepo
 
 <MudDialog>
     <DialogContent>
@@ -423,6 +425,36 @@
                     </MudPaper>
                 }
 
+                <!-- Name History -->
+                @if (_nameHistory.Count > 0)
+                {
+                    <MudExpansionPanels Class="mt-4" Elevation="0">
+                        <MudExpansionPanel Text="@($"Name History ({_nameHistory.Count})")"
+                                           Icon="@Icons.Material.Filled.History"
+                                           Expanded="false">
+                            <MudSimpleTable Dense="true" Hover="true" Striped="true">
+                                <thead>
+                                    <tr>
+                                        <th>Username</th>
+                                        <th>Name</th>
+                                        <th>Date</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var entry in _nameHistory)
+                                    {
+                                        <tr>
+                                            <td>@(entry.Username != null ? $"@{entry.Username}" : "(no username)")</td>
+                                            <td>@FormatName(entry.FirstName, entry.LastName)</td>
+                                            <td>@entry.RecordedAt.LocalDateTime.ToString("MMM d, yyyy")</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        </MudExpansionPanel>
+                    </MudExpansionPanels>
+                }
+
                 <!-- Admin Notes (Phase 4.12) -->
                 <MudPaper Elevation="1" Class="pa-3 mb-4">
                     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-3">
@@ -556,6 +588,7 @@
     private TelegramUserDetail? _userDetail;
     private bool _loading = true;
     private Dictionary<string, TagColor> _tagColorMap = new();
+    private List<UsernameHistoryRecord> _nameHistory = [];
 
     // Timeline state
     private bool _timelineExpanded;
@@ -593,6 +626,7 @@
         try
         {
             _userDetail = await UserManagementService.GetUserDetailAsync(UserId);
+            _nameHistory = await UsernameHistoryRepo.GetByUserIdAsync(UserId);
         }
         catch (Exception ex)
         {
@@ -1194,5 +1228,11 @@
                 Snackbar.Add($"Error removing warning: {ex.Message}", Severity.Error);
             }
         }
+    }
+
+    private static string FormatName(string? firstName, string? lastName)
+    {
+        var parts = new[] { firstName, lastName }.Where(p => !string.IsNullOrEmpty(p));
+        return parts.Any() ? string.Join(" ", parts) : "(no name)";
     }
 }

--- a/TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
@@ -427,7 +427,7 @@
                 <!-- Name History -->
                 @if (_nameHistory.Count > 0)
                 {
-                    <MudExpansionPanels Class="mt-4" Elevation="0">
+                    <MudExpansionPanels Class="mb-4" Elevation="1">
                         <MudExpansionPanel Text="@($"Name History ({_nameHistory.Count})")"
                                            Icon="@Icons.Material.Filled.History"
                                            Expanded="false">
@@ -445,7 +445,7 @@
                                         <tr>
                                             <td>@(entry.Username != null ? $"@{entry.Username}" : "(no username)")</td>
                                             <td>@FormatName(entry.FirstName, entry.LastName)</td>
-                                            <td>@entry.RecordedAt.LocalDateTime.ToString("MMM d, yyyy")</td>
+                                            <td><LocalTimestamp Value="@entry.RecordedAt" /></td>
                                         </tr>
                                     }
                                 </tbody>

--- a/TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
@@ -16,7 +16,6 @@
 @inject NavigationManager Navigation
 @inject TelegramGroupsAdmin.Telegram.Services.UserApi.IProfileScanService ProfileScanService
 @inject TelegramGroupsAdmin.Telegram.Repositories.ITelegramUserRepository TelegramUserRepository
-@inject IUsernameHistoryRepository UsernameHistoryRepo
 
 <MudDialog>
     <DialogContent>
@@ -626,7 +625,7 @@
         try
         {
             _userDetail = await UserManagementService.GetUserDetailAsync(UserId);
-            _nameHistory = await UsernameHistoryRepo.GetByUserIdAsync(UserId);
+            _nameHistory = await UserManagementService.GetNameHistoryAsync(UserId);
         }
         catch (Exception ex)
         {

--- a/docs/superpowers/plans/2026-04-03-username-history-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-03-username-history-review-fixes.md
@@ -1,0 +1,631 @@
+# Username History Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address 8 code review findings from the `feat/username-history` branch before PR to `develop`.
+
+**Architecture:** All changes are surgical fixes to existing files — no new files, no new migrations. The largest structural change is moving the name history query from the Razor component into the service layer.
+
+**Tech Stack:** Blazor Server, MudBlazor 9, EF Core 10, NUnit, bUnit
+
+---
+
+### Task 1: Add `Actor.ProfileDiffDetection` static field and update call site
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Core/Models/Actor.cs:57`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs:696`
+
+- [ ] **Step 1: Add the static field to Actor.cs**
+
+Add after the `Bootstrap` field (line 57):
+
+```csharp
+public static readonly Actor ProfileDiffDetection = FromSystem("profile_diff_detection");
+```
+
+- [ ] **Step 2: Update the call site in MessageProcessingService.cs**
+
+Replace line 696:
+```csharp
+IssuedBy: Actor.FromSystem("profile_diff_detection"),
+```
+with:
+```csharp
+IssuedBy: Actor.ProfileDiffDetection,
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `dotnet build TelegramGroupsAdmin.Telegram/TelegramGroupsAdmin.Telegram.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Core/Models/Actor.cs TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+git commit -m "fix: add Actor.ProfileDiffDetection static field, remove magic string"
+```
+
+---
+
+### Task 2: Fix `UsernameHistoryRepository` to materialize before mapping
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs:31-36`
+
+- [ ] **Step 1: Update GetByUserIdAsync to materialize before mapping**
+
+Replace the return statement (lines 31-36):
+```csharp
+        return await context.UsernameHistory
+            .AsNoTracking()
+            .Where(h => h.UserId == userId)
+            .OrderByDescending(h => h.RecordedAt)
+            .Select(h => h.ToModel())
+            .ToListAsync(cancellationToken);
+```
+with:
+```csharp
+        var dtos = await context.UsernameHistory
+            .AsNoTracking()
+            .Where(h => h.UserId == userId)
+            .OrderByDescending(h => h.RecordedAt)
+            .ToListAsync(cancellationToken);
+
+        return dtos.Select(h => h.ToModel()).ToList();
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `dotnet build TelegramGroupsAdmin.Telegram/TelegramGroupsAdmin.Telegram.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Run existing integration tests to confirm no regression**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "UsernameHistoryRepository" --verbosity normal`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs
+git commit -m "fix: materialize query before ToModel() mapping in UsernameHistoryRepository"
+```
+
+---
+
+### Task 3: Clean up `UsernameHistoryDto` — remove `virtual` and redundant `[ForeignKey]`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs:35-37`
+
+- [ ] **Step 1: Remove virtual keyword and ForeignKey attribute**
+
+Replace lines 35-37:
+```csharp
+    // Navigation
+    [ForeignKey(nameof(UserId))]
+    public virtual TelegramUserDto? User { get; set; }
+```
+with:
+```csharp
+    // Navigation
+    public TelegramUserDto? User { get; set; }
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `dotnet build TelegramGroupsAdmin.Data/TelegramGroupsAdmin.Data.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Verify no migration diff is generated**
+
+Run: `dotnet ef migrations has-pending-model-changes -p TelegramGroupsAdmin.Data -s TelegramGroupsAdmin`
+Expected: No pending model changes (Fluent API already configures the FK)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs
+git commit -m "fix: remove virtual keyword and redundant ForeignKey attribute from UsernameHistoryDto"
+```
+
+---
+
+### Task 4: Fix index naming convention in AppDbContext
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Data/AppDbContext.cs:647-658`
+
+- [ ] **Step 1: Rename indexes to snake_case convention**
+
+Replace lines 647-658:
+```csharp
+        // UsernameHistory indexes
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => h.UserId)
+            .HasDatabaseName("IX_username_history_user_id");
+
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => h.Username)
+            .HasDatabaseName("IX_username_history_username_lower");
+
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => new { h.FirstName, h.LastName })
+            .HasDatabaseName("IX_username_history_name_lower");
+```
+with:
+```csharp
+        // UsernameHistory indexes
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => h.UserId)
+            .HasDatabaseName("ix_username_history_user_id");
+
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => h.Username)
+            .HasDatabaseName("ix_username_history_username");
+
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => new { h.FirstName, h.LastName })
+            .HasDatabaseName("ix_username_history_name");
+```
+
+- [ ] **Step 2: Generate migration for the index renames**
+
+Run: `dotnet ef migrations add RenameUsernameHistoryIndexes -p TelegramGroupsAdmin.Data -s TelegramGroupsAdmin`
+
+- [ ] **Step 3: Review the generated migration**
+
+Open the generated migration file. It should contain `RenameIndex` operations only — no table drops/creates. Verify it looks like:
+```csharp
+migrationBuilder.RenameIndex(
+    name: "IX_username_history_user_id",
+    table: "username_history",
+    newName: "ix_username_history_user_id");
+// ... similar for the other two
+```
+
+If EF Core generated DROP+CREATE instead of RENAME, manually fix the migration to use `RenameIndex`.
+
+- [ ] **Step 4: Verify build**
+
+Run: `dotnet build TelegramGroupsAdmin.Data/TelegramGroupsAdmin.Data.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Data/AppDbContext.cs TelegramGroupsAdmin.Data/Migrations/
+git commit -m "fix: rename username_history indexes to snake_case convention"
+```
+
+---
+
+### Task 5: Move name history loading from Razor into service layer
+
+This is the largest change — moves `IUsernameHistoryRepository` out of the Razor component and behind `ITelegramUserManagementService`.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Models/TelegramUserDetail.cs:48`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ITelegramUserManagementService.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/TelegramUserManagementService.cs`
+- Modify: `TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor:19,591,629`
+- Modify: `TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs`
+- Modify: `TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs`
+
+- [ ] **Step 1: Add NameHistory to TelegramUserDetail model**
+
+In `TelegramGroupsAdmin.Telegram/Models/TelegramUserDetail.cs`, add after the Tags property (line 48):
+
+```csharp
+    public List<UsernameHistoryRecord> NameHistory { get; set; } = [];
+```
+
+- [ ] **Step 2: Add GetNameHistoryAsync to ITelegramUserManagementService**
+
+In `TelegramGroupsAdmin.Telegram/Services/ITelegramUserManagementService.cs`, add before the closing brace:
+
+```csharp
+    /// <summary>Gets the username/name change history for a user.</summary>
+    Task<List<UsernameHistoryRecord>> GetNameHistoryAsync(long telegramUserId, CancellationToken cancellationToken = default);
+```
+
+Add the using at the top if not present:
+```csharp
+using TelegramGroupsAdmin.Telegram.Models;
+```
+
+- [ ] **Step 3: Implement GetNameHistoryAsync in TelegramUserManagementService**
+
+In `TelegramGroupsAdmin.Telegram/Services/TelegramUserManagementService.cs`:
+
+Add `IUsernameHistoryRepository` to the constructor:
+```csharp
+    private readonly IUsernameHistoryRepository _usernameHistoryRepository;
+
+    public TelegramUserManagementService(
+        ITelegramUserRepository userRepository,
+        IUserActionsRepository userActionsRepository,
+        IUsernameHistoryRepository usernameHistoryRepository,
+        ILogger<TelegramUserManagementService> logger)
+    {
+        _userRepository = userRepository;
+        _userActionsRepository = userActionsRepository;
+        _usernameHistoryRepository = usernameHistoryRepository;
+        _logger = logger;
+    }
+```
+
+Add the method implementation:
+```csharp
+    /// <inheritdoc/>
+    public Task<List<UsernameHistoryRecord>> GetNameHistoryAsync(long telegramUserId, CancellationToken cancellationToken = default)
+    {
+        return _usernameHistoryRepository.GetByUserIdAsync(telegramUserId, cancellationToken);
+    }
+```
+
+Add the using at the top:
+```csharp
+using TelegramGroupsAdmin.Telegram.Repositories;
+```
+
+- [ ] **Step 4: Update UserDetailDialog.razor — remove repository injection and use service**
+
+In `TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor`:
+
+Remove line 19:
+```razor
+@inject IUsernameHistoryRepository UsernameHistoryRepo
+```
+
+Replace the `_nameHistory` field declaration (line 591):
+```csharp
+    private List<UsernameHistoryRecord> _nameHistory = [];
+```
+with:
+```csharp
+    private List<UsernameHistoryRecord> _nameHistory = [];
+```
+(This stays the same — but now it's populated differently.)
+
+Replace line 629:
+```csharp
+            _nameHistory = await UsernameHistoryRepo.GetByUserIdAsync(UserId);
+```
+with:
+```csharp
+            _nameHistory = await UserManagementService.GetNameHistoryAsync(UserId);
+```
+
+- [ ] **Step 5: Update component tests — remove IUsernameHistoryRepository mock, use service mock**
+
+In `TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs`:
+
+Remove the `_mockHistoryRepo` field (line 28):
+```csharp
+    private IUsernameHistoryRepository _mockHistoryRepo = null!;
+```
+
+In the constructor, remove:
+```csharp
+        _mockHistoryRepo = Substitute.For<IUsernameHistoryRepository>();
+```
+and:
+```csharp
+        Services.AddSingleton(_mockHistoryRepo);
+```
+and:
+```csharp
+        // Default: no history entries
+        _mockHistoryRepo.GetByUserIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
+```
+
+Instead, add to the existing `_mockUserService` setup area:
+```csharp
+        _mockUserService.GetNameHistoryAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
+```
+
+In the `[SetUp]` method, replace:
+```csharp
+        _mockHistoryRepo.GetByUserIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
+```
+with:
+```csharp
+        _mockUserService.GetNameHistoryAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
+```
+
+In each test that sets up history records, replace `_mockHistoryRepo.GetByUserIdAsync(...)` with `_mockUserService.GetNameHistoryAsync(...)`. There are 3 tests to update:
+- `NameHistoryPanel_RenderedCollapsed_WhenHistoryExists` (line 150)
+- `NameHistoryPanel_ShowsCorrectData_WhenExpanded` (line 180)
+- `NameHistoryPanel_HandlesNullUsername` (line 212)
+
+In `TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs`:
+
+Remove the `IUsernameHistoryRepository` mock registration if present. Add `GetNameHistoryAsync` default to the `_mockUserService` setup:
+```csharp
+        _mockUserService.GetNameHistoryAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<UsernameHistoryRecord>()));
+```
+
+- [ ] **Step 6: Verify build and tests**
+
+Run: `dotnet build`
+Expected: Build succeeded
+
+Run: `dotnet test TelegramGroupsAdmin.ComponentTests --filter "UserDetailDialog" --verbosity normal`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Models/TelegramUserDetail.cs \
+  TelegramGroupsAdmin.Telegram/Services/ITelegramUserManagementService.cs \
+  TelegramGroupsAdmin.Telegram/Services/TelegramUserManagementService.cs \
+  TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor \
+  TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs \
+  TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogTests.cs
+git commit -m "refactor: move name history loading from Razor into TelegramUserManagementService"
+```
+
+---
+
+### Task 6: Fix date formatting and expansion panel styling in UserDetailDialog
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor:431,449`
+
+- [ ] **Step 1: Fix expansion panel styling to match sibling sections**
+
+Replace lines 431-455:
+```razor
+                    <MudExpansionPanels Class="mt-4" Elevation="0">
+                        <MudExpansionPanel Text="@($"Name History ({_nameHistory.Count})")"
+                                           Icon="@Icons.Material.Filled.History"
+                                           Expanded="false">
+                            <MudSimpleTable Dense="true" Hover="true" Striped="true">
+                                <thead>
+                                    <tr>
+                                        <th>Username</th>
+                                        <th>Name</th>
+                                        <th>Date</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var entry in _nameHistory)
+                                    {
+                                        <tr>
+                                            <td>@(entry.Username != null ? $"@{entry.Username}" : "(no username)")</td>
+                                            <td>@FormatName(entry.FirstName, entry.LastName)</td>
+                                            <td>@entry.RecordedAt.LocalDateTime.ToString("MMM d, yyyy")</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        </MudExpansionPanel>
+                    </MudExpansionPanels>
+```
+with:
+```razor
+                    <MudExpansionPanels Class="mb-4" Elevation="1">
+                        <MudExpansionPanel Text="@($"Name History ({_nameHistory.Count})")"
+                                           Icon="@Icons.Material.Filled.History"
+                                           Expanded="false">
+                            <MudSimpleTable Dense="true" Hover="true" Striped="true">
+                                <thead>
+                                    <tr>
+                                        <th>Username</th>
+                                        <th>Name</th>
+                                        <th>Date</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var entry in _nameHistory)
+                                    {
+                                        <tr>
+                                            <td>@(entry.Username != null ? $"@{entry.Username}" : "(no username)")</td>
+                                            <td>@FormatName(entry.FirstName, entry.LastName)</td>
+                                            <td><LocalTimestamp Value="@entry.RecordedAt" /></td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        </MudExpansionPanel>
+                    </MudExpansionPanels>
+```
+
+Changes: `Class="mt-4"` → `Class="mb-4"`, `Elevation="0"` → `Elevation="1"`, date column uses `<LocalTimestamp>`.
+
+- [ ] **Step 2: Update the component test that asserts on the date format**
+
+In `TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs`, the test `NameHistoryPanel_ShowsCorrectData_WhenExpanded` (line 193) asserts `Does.Contain("Jun")`. Since `<LocalTimestamp>` renders differently than `.LocalDateTime.ToString("MMM d, yyyy")`, update the assertion to check for the recorded date content that `<LocalTimestamp>` will produce. The `<LocalTimestamp>` component renders the UTC value formatted for the user's timezone — in tests the cascading `TimeZoneInfo` defaults to UTC, so the output will still contain "Jun" and "2024". Keep the assertion as-is since the component test environment uses UTC.
+
+No change needed to the test — `<LocalTimestamp>` in UTC timezone with `2024-06-15T12:00:00Z` will still render with "Jun".
+
+- [ ] **Step 3: Verify build and component tests**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded
+
+Run: `dotnet test TelegramGroupsAdmin.ComponentTests --filter "UserDetailDialogHistory" --verbosity normal`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
+git commit -m "fix: use LocalTimestamp for name history dates and match sibling panel styling"
+```
+
+---
+
+### Task 7: Update search placeholder text
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Pages/Users.razor:23`
+
+- [ ] **Step 1: Update placeholder text**
+
+Replace line 23:
+```razor
+                      Placeholder="Search by name, username, ID, or past names..."
+```
+with:
+```razor
+                      Placeholder="Search by name, username, ID, or name history..."
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Pages/Users.razor
+git commit -m "fix: clarify search placeholder to say 'name history'"
+```
+
+---
+
+### Task 8: Add integration tests for SearchByNameAsync past-name subquery
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs`
+
+- [ ] **Step 1: Add test for SearchByNameAsync matching past username**
+
+Add to the `#region Search with Username History Tests` section:
+
+```csharp
+    [Test]
+    public async Task SearchByNameAsync_MatchesPastUsername()
+    {
+        // Seed an active user with current username "current_handle"
+        const long userId = 200010L;
+        await SeedActiveUserAsync(userId, username: "current_handle", firstName: "Search", lastName: "Test");
+
+        // Insert a history entry recording the old username
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userId, "legacy_handle", "Search", "Test");
+        }
+
+        // Search by old username — should find the user via username_history subquery
+        var results = await _repository!.SearchByNameAsync("legacy_handle", limit: 10);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].TelegramUserId, Is.EqualTo(userId));
+    }
+```
+
+- [ ] **Step 2: Add test for SearchByNameAsync matching past first name**
+
+```csharp
+    [Test]
+    public async Task SearchByNameAsync_MatchesPastFirstName()
+    {
+        const long userId = 200011L;
+        await SeedActiveUserAsync(userId, username: "name_search_user", firstName: "CurrentFirst", lastName: "Test");
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userId, "name_search_user", "FormerFirst", "Test");
+        }
+
+        var results = await _repository!.SearchByNameAsync("FormerFirst", limit: 10);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].TelegramUserId, Is.EqualTo(userId));
+    }
+```
+
+- [ ] **Step 3: Add negative/isolation test — past name search does not bleed across users**
+
+```csharp
+    [Test]
+    public async Task GetPagedUsersAsync_SearchByPastName_DoesNotReturnDifferentUser()
+    {
+        // Seed two users
+        const long userA = 200020L;
+        const long userB = 200021L;
+        await SeedActiveUserAsync(userA, username: "user_a", firstName: "Alice", lastName: "Smith");
+        await SeedActiveUserAsync(userB, username: "user_b", firstName: "Bob", lastName: "Jones");
+
+        // Only userA has a history entry with the distinctive name
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userA, "unique_old_handle", "Alice", "Smith");
+        }
+
+        // Search by userA's old username — should NOT return userB
+        var (items, totalCount) = await _repository!.GetPagedUsersAsync(
+            UiModels.UserListFilter.Active, skip: 0, take: 10,
+            searchText: "unique_old_handle", chatIds: null,
+            sortLabel: null, sortDescending: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(totalCount, Is.EqualTo(1));
+            Assert.That(items[0].TelegramUserId, Is.EqualTo(userA));
+        });
+    }
+```
+
+- [ ] **Step 4: Add negative/isolation test for SearchByNameAsync**
+
+```csharp
+    [Test]
+    public async Task SearchByNameAsync_DoesNotReturnUserWithoutMatchingHistory()
+    {
+        // Seed two users — only userA has a matching history entry
+        const long userA = 200030L;
+        const long userB = 200031L;
+        await SeedActiveUserAsync(userA, username: "iso_user_a", firstName: "Ava", lastName: "Test");
+        await SeedActiveUserAsync(userB, username: "iso_user_b", firstName: "Ben", lastName: "Test");
+
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+            await historyRepo.InsertAsync(userA, "distinctive_old_name", "Ava", "Test");
+        }
+
+        var results = await _repository!.SearchByNameAsync("distinctive_old_name", limit: 10);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(results, Has.Count.EqualTo(1));
+            Assert.That(results[0].TelegramUserId, Is.EqualTo(userA));
+        });
+    }
+```
+
+- [ ] **Step 5: Run the new tests**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "TelegramUserRepositoryTests" --verbosity normal`
+Expected: All tests pass (existing + 4 new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
+git commit -m "test: add integration tests for SearchByNameAsync past-name subquery and isolation"
+```
+
+---
+
+### Task 9: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `dotnet test --verbosity normal`
+Expected: All 3,757+ tests pass, 0 failures
+
+- [ ] **Step 2: Verify migration applies cleanly**
+
+Run: `dotnet run --project TelegramGroupsAdmin -- --migrate-only`
+Expected: Migration applies without error, process exits cleanly

--- a/docs/superpowers/plans/2026-04-03-username-history.md
+++ b/docs/superpowers/plans/2026-04-03-username-history.md
@@ -1,0 +1,1235 @@
+# Username History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track username/name changes in a normalized history table with global search integration and audit trail.
+
+**Architecture:** New `username_history` table with FK cascade to `telegram_users`. Capture point is the existing `ProfileDiffDetected` block in `MessageProcessingService`. Search extends the existing `ILike` queries with an `OR EXISTS` subquery. UI adds a collapsed expansion panel to `UserDetailDialog`.
+
+**Tech Stack:** EF Core 10, PostgreSQL 18, MudBlazor 9, NUnit, bUnit, NSubstitute
+
+**Spec:** `docs/superpowers/specs/2026-04-03-username-history-design.md`
+
+---
+
+### Task 1: Add `ProfileChange` to `UserActionType` enums
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Data/Models/UserActionType.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Models/UserActionType.cs`
+- Modify: `TelegramGroupsAdmin.Core/Models/Actor.cs:100-117`
+
+- [ ] **Step 1: Add enum value to Data layer**
+
+In `TelegramGroupsAdmin.Data/Models/UserActionType.cs`, add after `RestorePermissions = 9`:
+
+```csharp
+    /// <summary>Profile change detected (username, first name, or last name changed)</summary>
+    ProfileChange = 10
+```
+
+- [ ] **Step 2: Add enum value to Telegram layer**
+
+In `TelegramGroupsAdmin.Telegram/Models/UserActionType.cs`, add after `RestorePermissions = 9`:
+
+```csharp
+    /// <summary>Profile change detected (username, first name, or last name changed)</summary>
+    ProfileChange = 10
+```
+
+- [ ] **Step 3: Add display name mapping for Actor.ForSystem**
+
+In `TelegramGroupsAdmin.Core/Models/Actor.cs`, in the `ForSystem` switch expression (around line 100-117), add:
+
+```csharp
+            "profile_diff_detection" => "Profile Change Detection",
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `dotnet build --no-restore 2>&1 | tail -5`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Data/Models/UserActionType.cs TelegramGroupsAdmin.Telegram/Models/UserActionType.cs TelegramGroupsAdmin.Core/Models/Actor.cs
+git commit -m "feat: add ProfileChange user action type for name history tracking"
+```
+
+---
+
+### Task 2: Create `UsernameHistoryDto` entity and EF Core configuration
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs`
+- Modify: `TelegramGroupsAdmin.Data/AppDbContext.cs`
+
+- [ ] **Step 1: Create the entity class**
+
+Create `TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TelegramGroupsAdmin.Data.Models;
+
+/// <summary>
+/// Tracks historical username/name values for a Telegram user.
+/// Each row captures the previous values at the moment a profile change is detected.
+/// </summary>
+[Table("username_history")]
+public class UsernameHistoryDto
+{
+    [Key]
+    [Column("id")]
+    public long Id { get; set; }
+
+    [Column("user_id")]
+    public long UserId { get; set; }
+
+    [Column("username")]
+    [MaxLength(32)]
+    public string? Username { get; set; }
+
+    [Column("first_name")]
+    [MaxLength(64)]
+    public string? FirstName { get; set; }
+
+    [Column("last_name")]
+    [MaxLength(64)]
+    public string? LastName { get; set; }
+
+    [Column("recorded_at")]
+    public DateTimeOffset RecordedAt { get; set; }
+
+    // Navigation
+    [ForeignKey(nameof(UserId))]
+    public virtual TelegramUserDto? User { get; set; }
+}
+```
+
+- [ ] **Step 2: Add DbSet to AppDbContext**
+
+In `TelegramGroupsAdmin.Data/AppDbContext.cs`, after the `TelegramUsers` DbSet (around line 37):
+
+```csharp
+    public DbSet<UsernameHistoryDto> UsernameHistory => Set<UsernameHistoryDto>();
+```
+
+- [ ] **Step 3: Add fluent configuration in OnModelCreating**
+
+In `AppDbContext.OnModelCreating`, add a new section for username history configuration. Place it near the other `TelegramUsers`-related config:
+
+```csharp
+        // UsernameHistory → TelegramUsers (cascade delete)
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasOne(h => h.User)
+            .WithMany()
+            .HasForeignKey(h => h.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // UsernameHistory indexes
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => h.UserId)
+            .HasDatabaseName("IX_username_history_user_id");
+
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => h.Username)
+            .HasDatabaseName("IX_username_history_username_lower");
+
+        modelBuilder.Entity<UsernameHistoryDto>()
+            .HasIndex(h => new { h.FirstName, h.LastName })
+            .HasDatabaseName("IX_username_history_name_lower");
+```
+
+- [ ] **Step 4: Generate EF Core migration**
+
+Run: `dotnet ef migrations add AddUsernameHistoryTable -p TelegramGroupsAdmin.Data -s TelegramGroupsAdmin`
+
+Review the generated migration to ensure it creates the table with correct columns, FK, and indexes. Verify it does NOT drop/recreate any existing tables.
+
+- [ ] **Step 5: Validate migration applies cleanly**
+
+Run: `dotnet run --project TelegramGroupsAdmin --migrate-only`
+Expected: Migration applies without errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Data/Models/UsernameHistoryDto.cs TelegramGroupsAdmin.Data/AppDbContext.cs TelegramGroupsAdmin.Data/Migrations/
+git commit -m "feat: add username_history table with cascade delete and search indexes"
+```
+
+---
+
+### Task 3: Create domain model, repository, and DI registration
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Telegram/Models/UsernameHistoryRecord.cs`
+- Create: `TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameHistoryMappings.cs`
+- Create: `TelegramGroupsAdmin.Telegram/Repositories/IUsernameHistoryRepository.cs`
+- Create: `TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs:60`
+
+- [ ] **Step 1: Create domain model**
+
+Create `TelegramGroupsAdmin.Telegram/Models/UsernameHistoryRecord.cs`:
+
+```csharp
+namespace TelegramGroupsAdmin.Telegram.Models;
+
+/// <summary>
+/// Domain model for a username history entry.
+/// Each record captures the previous profile values at the moment a change was detected.
+/// </summary>
+public record UsernameHistoryRecord(
+    long Id,
+    long UserId,
+    string? Username,
+    string? FirstName,
+    string? LastName,
+    DateTimeOffset RecordedAt);
+```
+
+- [ ] **Step 2: Create mapping extensions**
+
+Create `TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameHistoryMappings.cs`:
+
+```csharp
+using DataModels = TelegramGroupsAdmin.Data.Models;
+using UiModels = TelegramGroupsAdmin.Telegram.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories.Mappings;
+
+public static class UsernameHistoryMappings
+{
+    extension(DataModels.UsernameHistoryDto data)
+    {
+        public UiModels.UsernameHistoryRecord ToModel() => new(
+            Id: data.Id,
+            UserId: data.UserId,
+            Username: data.Username,
+            FirstName: data.FirstName,
+            LastName: data.LastName,
+            RecordedAt: data.RecordedAt);
+    }
+}
+```
+
+- [ ] **Step 3: Create repository interface**
+
+Create `TelegramGroupsAdmin.Telegram/Repositories/IUsernameHistoryRepository.cs`:
+
+```csharp
+using TelegramGroupsAdmin.Telegram.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories;
+
+public interface IUsernameHistoryRepository
+{
+    /// <summary>
+    /// Record the previous profile values when a change is detected.
+    /// </summary>
+    Task InsertAsync(long userId, string? username, string? firstName, string? lastName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get all history entries for a user, most recent first.
+    /// </summary>
+    Task<List<UsernameHistoryRecord>> GetByUserIdAsync(long userId, CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 4: Create repository implementation**
+
+Create `TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.Data.Models;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories.Mappings;
+
+namespace TelegramGroupsAdmin.Telegram.Repositories;
+
+public class UsernameHistoryRepository(IDbContextFactory<AppDbContext> contextFactory) : IUsernameHistoryRepository
+{
+    public async Task InsertAsync(long userId, string? username, string? firstName, string? lastName, CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        context.UsernameHistory.Add(new UsernameHistoryDto
+        {
+            UserId = userId,
+            Username = username,
+            FirstName = firstName,
+            LastName = lastName,
+            RecordedAt = DateTimeOffset.UtcNow
+        });
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<List<UsernameHistoryRecord>> GetByUserIdAsync(long userId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context.UsernameHistory
+            .AsNoTracking()
+            .Where(h => h.UserId == userId)
+            .OrderByDescending(h => h.RecordedAt)
+            .Select(h => h.ToModel())
+            .ToListAsync(cancellationToken);
+    }
+}
+```
+
+- [ ] **Step 5: Register in DI**
+
+In `TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs`, after the `ITelegramUserRepository` registration (line 60):
+
+```csharp
+            services.AddScoped<IUsernameHistoryRepository, UsernameHistoryRepository>();
+```
+
+- [ ] **Step 6: Build to verify**
+
+Run: `dotnet build --no-restore 2>&1 | tail -5`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Models/UsernameHistoryRecord.cs TelegramGroupsAdmin.Telegram/Repositories/Mappings/UsernameHistoryMappings.cs TelegramGroupsAdmin.Telegram/Repositories/IUsernameHistoryRepository.cs TelegramGroupsAdmin.Telegram/Repositories/UsernameHistoryRepository.cs TelegramGroupsAdmin.Telegram/Extensions/ServiceCollectionExtensions.cs
+git commit -m "feat: add UsernameHistoryRepository with domain model and DI registration"
+```
+
+---
+
+### Task 4: Wire capture logic into `MessageProcessingService`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs:672-689`
+
+- [ ] **Step 1: Add history and action insertion to ProfileDiffDetected block**
+
+In `MessageProcessingService.cs`, the `ProfileDiffDetected` block currently looks like this (after the hotfix):
+
+```csharp
+            if (existingUser is not null
+                && contentCheckSkipReason == ContentCheckSkipReason.NotSkipped
+                && ProfileDiffDetected(existingUser, message.From))
+            {
+                LogProfileChangeDetected(logger, message.From.ToLogDebug(), existingUser.ToLogInfo(), message.From.ToLogInfo());
+
+                try
+                {
+                    var jobScheduler = messageScope.ServiceProvider.GetRequiredService<Handlers.BackgroundJobScheduler>();
+                    await jobScheduler.ScheduleProfileScanAsync(message.From.Id, message.Chat.Id, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to schedule profile scan for user {UserId}", message.From.Id);
+                }
+            }
+
+            await telegramUserRepo.UpsertAsync(telegramUser, cancellationToken);
+```
+
+Replace with:
+
+```csharp
+            if (existingUser is not null
+                && contentCheckSkipReason == ContentCheckSkipReason.NotSkipped
+                && ProfileDiffDetected(existingUser, message.From))
+            {
+                LogProfileChangeDetected(logger, message.From.ToLogDebug(), existingUser.ToLogInfo(), message.From.ToLogInfo());
+
+                // Record previous profile values in username_history
+                var historyRepo = messageScope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+                await historyRepo.InsertAsync(
+                    existingUser.TelegramUserId,
+                    existingUser.Username,
+                    existingUser.FirstName,
+                    existingUser.LastName,
+                    cancellationToken);
+
+                // Record profile change in user_actions audit trail
+                var userActionsRepo = messageScope.ServiceProvider.GetRequiredService<IUserActionsRepository>();
+                var changeReason = BuildProfileChangeReason(existingUser, message.From);
+                await userActionsRepo.InsertAsync(new UserActionRecord(
+                    Id: 0,
+                    UserId: existingUser.TelegramUserId,
+                    ActionType: UserActionType.ProfileChange,
+                    MessageId: message.MessageId,
+                    ChatId: message.Chat.Id,
+                    IssuedBy: Actor.ForSystem("profile_diff_detection"),
+                    IssuedAt: DateTimeOffset.UtcNow,
+                    ExpiresAt: null,
+                    Reason: changeReason), cancellationToken);
+
+                try
+                {
+                    var jobScheduler = messageScope.ServiceProvider.GetRequiredService<Handlers.BackgroundJobScheduler>();
+                    await jobScheduler.ScheduleProfileScanAsync(message.From.Id, message.Chat.Id, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to schedule profile scan for user {UserId}", message.From.Id);
+                }
+            }
+
+            await telegramUserRepo.UpsertAsync(telegramUser, cancellationToken);
+```
+
+- [ ] **Step 2: Add the BuildProfileChangeReason helper method**
+
+Add this private static method to `MessageProcessingService` (near the `ProfileDiffDetected` method, around line 807):
+
+```csharp
+    private static string BuildProfileChangeReason(TelegramUser old, global::Telegram.Bot.Types.User current)
+    {
+        var changes = new List<string>();
+
+        if (!string.Equals(old.Username, current.Username, StringComparison.Ordinal))
+            changes.Add($"Username: @{old.Username ?? "(none)"} → @{current.Username ?? "(none)"}");
+
+        if (!string.Equals(old.FirstName, current.FirstName, StringComparison.Ordinal))
+            changes.Add($"First name: {old.FirstName ?? "(none)"} → {current.FirstName ?? "(none)"}");
+
+        if (!string.Equals(old.LastName, current.LastName, StringComparison.Ordinal))
+            changes.Add($"Last name: {old.LastName ?? "(none)"} → {current.LastName ?? "(none)"}");
+
+        return string.Join(", ", changes);
+    }
+```
+
+- [ ] **Step 3: Add required usings**
+
+At the top of `MessageProcessingService.cs`, ensure these usings are present (add any that are missing):
+
+```csharp
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Models;
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `dotnet build --no-restore 2>&1 | tail -5`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/BackgroundServices/MessageProcessingService.cs
+git commit -m "feat: capture username history and audit action on profile change"
+```
+
+---
+
+### Task 5: Extend search queries to include username history
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs` (lines 487-494, 566-573, 674-681, ~1175)
+- Modify: `TelegramGroupsAdmin/Components/Pages/Users.razor:23`
+
+- [ ] **Step 1: Create a reusable search predicate helper**
+
+In `TelegramUserRepository.cs`, add a private static method to avoid duplicating the history subquery across 4 search locations. Place it near the bottom of the class:
+
+```csharp
+    /// <summary>
+    /// Builds a predicate that matches users by current OR past names from username_history.
+    /// </summary>
+    private static IQueryable<TelegramUserDto> ApplySearchFilter(
+        IQueryable<TelegramUserDto> query, AppDbContext context, string search)
+    {
+        return query.Where(u =>
+            (u.Username != null && EF.Functions.ILike(u.Username, $"%{search}%")) ||
+            (u.FirstName != null && EF.Functions.ILike(u.FirstName, $"%{search}%")) ||
+            (u.LastName != null && EF.Functions.ILike(u.LastName, $"%{search}%")) ||
+            EF.Functions.ILike(u.TelegramUserId.ToString(), $"%{search}%") ||
+            context.UsernameHistory.Any(h =>
+                h.UserId == u.TelegramUserId &&
+                ((h.Username != null && EF.Functions.ILike(h.Username, $"%{search}%")) ||
+                 (h.FirstName != null && EF.Functions.ILike(h.FirstName, $"%{search}%")) ||
+                 (h.LastName != null && EF.Functions.ILike(h.LastName, $"%{search}%")))));
+    }
+```
+
+- [ ] **Step 2: Replace search block in GetPagedUsersAsync**
+
+In `GetPagedUsersAsync` (around line 487-494), replace:
+
+```csharp
+        if (!string.IsNullOrWhiteSpace(searchText))
+        {
+            var search = searchText.Trim().ToLower();
+            query = query.Where(u =>
+                (u.Username != null && EF.Functions.ILike(u.Username, $"%{search}%")) ||
+                (u.FirstName != null && EF.Functions.ILike(u.FirstName, $"%{search}%")) ||
+                (u.LastName != null && EF.Functions.ILike(u.LastName, $"%{search}%")) ||
+                EF.Functions.ILike(u.TelegramUserId.ToString(), $"%{search}%"));
+```
+
+With:
+
+```csharp
+        if (!string.IsNullOrWhiteSpace(searchText))
+        {
+            var search = searchText.Trim().ToLower();
+            query = ApplySearchFilter(query, context, search);
+```
+
+- [ ] **Step 3: Replace search block in GetPagedBannedUsersWithDetailsAsync**
+
+In `GetPagedBannedUsersWithDetailsAsync` (around line 566-573), apply the same replacement — replace the inline `query.Where(...)` with `ApplySearchFilter(query, context, search)`.
+
+- [ ] **Step 4: Replace search block in GetUserTabCountsAsync**
+
+In `GetUserTabCountsAsync` (around line 674-681), apply the same replacement — replace the inline `baseQuery.Where(...)` with `ApplySearchFilter(baseQuery, context, search)`.
+
+- [ ] **Step 5: Update SearchByNameAsync**
+
+In `SearchByNameAsync` (around line 1169), extend the existing fuzzy search query to also match against `username_history`. Add an `OR` clause using `context.UsernameHistory.Any(...)` following the same pattern as `ApplySearchFilter`, but adapted to the existing query structure of that method.
+
+- [ ] **Step 6: Update search placeholder text**
+
+In `TelegramGroupsAdmin/Components/Pages/Users.razor` line 23, change:
+
+```razor
+                      Placeholder="Search by name, username, or ID..."
+```
+
+To:
+
+```razor
+                      Placeholder="Search by name, username, ID, or past names..."
+```
+
+- [ ] **Step 7: Build to verify**
+
+Run: `dotnet build --no-restore 2>&1 | tail -5`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs TelegramGroupsAdmin/Components/Pages/Users.razor
+git commit -m "feat: extend user search to match past usernames from history"
+```
+
+---
+
+### Task 6: Add name history panel to UserDetailDialog
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor`
+
+- [ ] **Step 1: Inject the repository**
+
+Add to the inject block at the top of `UserDetailDialog.razor`:
+
+```razor
+@inject IUsernameHistoryRepository UsernameHistoryRepo
+```
+
+And add the using if not already present:
+
+```razor
+@using TelegramGroupsAdmin.Telegram.Repositories
+```
+
+- [ ] **Step 2: Add state field and load history**
+
+In the `@code` block, add a field:
+
+```csharp
+    private List<UsernameHistoryRecord> _nameHistory = [];
+```
+
+In the existing `OnParametersSetAsync` or `OnInitializedAsync` method (wherever user data is loaded), add after the user detail is loaded:
+
+```csharp
+    _nameHistory = await UsernameHistoryRepo.GetByUserIdAsync(UserId, cancellationToken);
+```
+
+- [ ] **Step 3: Add the expansion panel to the dialog body**
+
+Add the name history panel in the dialog body, after the existing user info section. Only render when history exists:
+
+```razor
+@if (_nameHistory.Count > 0)
+{
+    <MudExpansionPanels Class="mt-4" Elevation="0">
+        <MudExpansionPanel Text="@($"Name History ({_nameHistory.Count})")"
+                           Icon="@Icons.Material.Filled.History"
+                           IsInitiallyExpanded="false">
+            <MudSimpleTable Dense="true" Hover="true" Striped="true">
+                <thead>
+                    <tr>
+                        <th>Username</th>
+                        <th>Name</th>
+                        <th>Date</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var entry in _nameHistory)
+                    {
+                        <tr>
+                            <td>@(entry.Username != null ? $"@{entry.Username}" : "(no username)")</td>
+                            <td>@FormatName(entry.FirstName, entry.LastName)</td>
+                            <td>@entry.RecordedAt.LocalDateTime.ToString("MMM d, yyyy")</td>
+                        </tr>
+                    }
+                </tbody>
+            </MudSimpleTable>
+        </MudExpansionPanel>
+    </MudExpansionPanels>
+}
+```
+
+- [ ] **Step 4: Add the FormatName helper**
+
+In the `@code` block:
+
+```csharp
+    private static string FormatName(string? firstName, string? lastName)
+    {
+        var parts = new[] { firstName, lastName }.Where(p => !string.IsNullOrEmpty(p));
+        return parts.Any() ? string.Join(" ", parts) : "(no name)";
+    }
+```
+
+- [ ] **Step 5: Build to verify**
+
+Run: `dotnet build --no-restore 2>&1 | tail -5`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Shared/UserDetailDialog.razor
+git commit -m "feat: add collapsed name history panel to user detail dialog"
+```
+
+---
+
+### Task 7: Integration tests for UsernameHistoryRepository
+
+**Files:**
+- Create: `TelegramGroupsAdmin.IntegrationTests/Repositories/UsernameHistoryRepositoryTests.cs`
+
+- [ ] **Step 1: Create the test class**
+
+Create `TelegramGroupsAdmin.IntegrationTests/Repositories/UsernameHistoryRepositoryTests.cs`:
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+
+namespace TelegramGroupsAdmin.IntegrationTests.Repositories;
+
+[TestFixture]
+[Category("Integration")]
+public class UsernameHistoryRepositoryTests
+{
+    private MigrationTestHelper? _testHelper;
+    private IServiceProvider? _serviceProvider;
+
+    private const long TestUserId = 111222333;
+    private const long OtherUserId = 444555666;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _testHelper = new MigrationTestHelper();
+        await _testHelper.CreateDatabaseAndApplyMigrationsAsync();
+
+        var services = new ServiceCollection();
+
+        services.AddDbContextFactory<AppDbContext>((_, options) =>
+        {
+            options.UseNpgsql(_testHelper.ConnectionString);
+        });
+
+        services.AddLogging(builder => builder.AddConsole());
+        services.AddScoped<IUsernameHistoryRepository, UsernameHistoryRepository>();
+        services.AddScoped<ITelegramUserRepository, TelegramUserRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_testHelper != null)
+            await _testHelper.DisposeAsync();
+    }
+
+    private async Task SeedUserAsync(long userId, string? username = "testuser", string? firstName = "Test", string? lastName = "User")
+    {
+        using var scope = _serviceProvider!.CreateScope();
+        var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
+        var now = DateTimeOffset.UtcNow;
+        await userRepo.UpsertAsync(new TelegramUser(
+            TelegramUserId: userId,
+            Username: username,
+            FirstName: firstName,
+            LastName: lastName,
+            UserPhotoPath: null,
+            PhotoHash: null,
+            PhotoFileUniqueId: null,
+            IsBot: false,
+            IsTrusted: false,
+            IsBanned: false,
+            KickCount: 0,
+            BotDmEnabled: false,
+            FirstSeenAt: now,
+            LastSeenAt: now,
+            CreatedAt: now,
+            UpdatedAt: now));
+    }
+
+    [Test]
+    public async Task InsertAsync_And_GetByUserIdAsync_RoundTrips()
+    {
+        await SeedUserAsync(TestUserId);
+
+        using var scope = _serviceProvider!.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+
+        await repo.InsertAsync(TestUserId, "old_username", "OldFirst", "OldLast");
+
+        var history = await repo.GetByUserIdAsync(TestUserId);
+
+        Assert.That(history, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(history[0].Username, Is.EqualTo("old_username"));
+            Assert.That(history[0].FirstName, Is.EqualTo("OldFirst"));
+            Assert.That(history[0].LastName, Is.EqualTo("OldLast"));
+            Assert.That(history[0].UserId, Is.EqualTo(TestUserId));
+        });
+    }
+
+    [Test]
+    public async Task GetByUserIdAsync_ReturnsDescendingByRecordedAt()
+    {
+        await SeedUserAsync(TestUserId);
+
+        using var scope = _serviceProvider!.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+
+        await repo.InsertAsync(TestUserId, "first_name", "A", "A");
+        await Task.Delay(50); // Ensure different timestamps
+        await repo.InsertAsync(TestUserId, "second_name", "B", "B");
+
+        var history = await repo.GetByUserIdAsync(TestUserId);
+
+        Assert.That(history, Has.Count.EqualTo(2));
+        Assert.That(history[0].Username, Is.EqualTo("second_name")); // Most recent first
+        Assert.That(history[1].Username, Is.EqualTo("first_name"));
+    }
+
+    [Test]
+    public async Task CascadeDelete_RemovesHistoryWhenUserDeleted()
+    {
+        await SeedUserAsync(TestUserId);
+
+        using var scope = _serviceProvider!.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+        await repo.InsertAsync(TestUserId, "old_name", "Old", "Name");
+
+        // Delete the parent user
+        var contextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        await using var context = await contextFactory.CreateDbContextAsync();
+        await context.TelegramUsers.Where(u => u.TelegramUserId == TestUserId).ExecuteDeleteAsync();
+
+        // History should be gone
+        var history = await repo.GetByUserIdAsync(TestUserId);
+        Assert.That(history, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetByUserIdAsync_DoesNotReturnOtherUsersHistory()
+    {
+        await SeedUserAsync(TestUserId);
+        await SeedUserAsync(OtherUserId, "otheruser");
+
+        using var scope = _serviceProvider!.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+
+        await repo.InsertAsync(TestUserId, "my_old_name", "My", "Name");
+        await repo.InsertAsync(OtherUserId, "their_old_name", "Their", "Name");
+
+        var history = await repo.GetByUserIdAsync(TestUserId);
+
+        Assert.That(history, Has.Count.EqualTo(1));
+        Assert.That(history[0].Username, Is.EqualTo("my_old_name"));
+    }
+
+    [Test]
+    public async Task InsertAsync_HandlesNullFields()
+    {
+        await SeedUserAsync(TestUserId);
+
+        using var scope = _serviceProvider!.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+
+        await repo.InsertAsync(TestUserId, null, null, null);
+
+        var history = await repo.GetByUserIdAsync(TestUserId);
+
+        Assert.That(history, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(history[0].Username, Is.Null);
+            Assert.That(history[0].FirstName, Is.Null);
+            Assert.That(history[0].LastName, Is.Null);
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~UsernameHistoryRepositoryTests" -v normal 2>&1 | tail -20`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin.IntegrationTests/Repositories/UsernameHistoryRepositoryTests.cs
+git commit -m "test: add integration tests for UsernameHistoryRepository"
+```
+
+---
+
+### Task 8: Integration tests for search with username history
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs`
+
+- [ ] **Step 1: Add search-by-past-username tests**
+
+Add the following tests to the existing `TelegramUserRepositoryTests.cs` class. These tests verify that the search queries in `GetPagedUsersAsync` and `GetPagedBannedUsersWithDetailsAsync` match users by past names from `username_history`.
+
+```csharp
+    [Test]
+    public async Task GetPagedUsersAsync_SearchMatchesPastUsername()
+    {
+        // Seed a user with current username "new_name"
+        await SeedUserAsync(TestUserId, username: "new_name", firstName: "Current", lastName: "Name");
+
+        // Insert history entry with old username
+        using var scope = _serviceProvider!.CreateScope();
+        var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+        await historyRepo.InsertAsync(TestUserId, "old_name", "Previous", "Name");
+
+        var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
+        var (items, totalCount) = await userRepo.GetPagedUsersAsync(
+            UserListFilter.All, skip: 0, take: 10,
+            searchText: "old_name", chatIds: null,
+            sortLabel: null, sortDescending: false);
+
+        Assert.That(totalCount, Is.EqualTo(1));
+        Assert.That(items[0].TelegramUserId, Is.EqualTo(TestUserId));
+    }
+
+    [Test]
+    public async Task GetPagedUsersAsync_SearchMatchesPastFirstName()
+    {
+        await SeedUserAsync(TestUserId, username: "user1", firstName: "CurrentFirst", lastName: "Name");
+
+        using var scope = _serviceProvider!.CreateScope();
+        var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+        await historyRepo.InsertAsync(TestUserId, "user1", "OldFirst", "Name");
+
+        var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
+        var (items, totalCount) = await userRepo.GetPagedUsersAsync(
+            UserListFilter.All, skip: 0, take: 10,
+            searchText: "OldFirst", chatIds: null,
+            sortLabel: null, sortDescending: false);
+
+        Assert.That(totalCount, Is.EqualTo(1));
+        Assert.That(items[0].TelegramUserId, Is.EqualTo(TestUserId));
+    }
+
+    [Test]
+    public async Task GetUserTabCountsAsync_IncludesUsersMatchedByPastNames()
+    {
+        await SeedUserAsync(TestUserId, username: "new_name", firstName: "Current", lastName: "Name");
+
+        using var scope = _serviceProvider!.CreateScope();
+        var historyRepo = scope.ServiceProvider.GetRequiredService<IUsernameHistoryRepository>();
+        await historyRepo.InsertAsync(TestUserId, "old_name", "Previous", "Name");
+
+        var userRepo = scope.ServiceProvider.GetRequiredService<ITelegramUserRepository>();
+        var counts = await userRepo.GetUserTabCountsAsync(chatIds: null, searchText: "old_name");
+
+        Assert.That(counts.ActiveCount, Is.EqualTo(1));
+    }
+```
+
+Note: You will need to register `IUsernameHistoryRepository` in the test's `SetUp` method's `ServiceCollection` alongside the existing repository registrations:
+
+```csharp
+        services.AddScoped<IUsernameHistoryRepository, UsernameHistoryRepository>();
+```
+
+- [ ] **Step 2: Run the search tests**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~TelegramUserRepositoryTests" -v normal 2>&1 | tail -20`
+Expected: All tests pass (existing + new).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
+git commit -m "test: add integration tests for search by past usernames"
+```
+
+---
+
+### Task 9: Component tests for name history panel
+
+**Files:**
+- Create: `TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs`
+
+- [ ] **Step 1: Create the component test class**
+
+Create `TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs`. Follow the same pattern as the existing `UserDetailDialogTests.cs` — extend `MudBlazorTestContext`, mock the same services, and add `IUsernameHistoryRepository` mock:
+
+```csharp
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using NSubstitute;
+using TelegramGroupsAdmin.Components.Shared;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services;
+using TelegramGroupsAdmin.Telegram.Services.Bot;
+using TelegramGroupsAdmin.Telegram.Services.UserApi;
+
+namespace TelegramGroupsAdmin.ComponentTests.Components;
+
+[TestFixture]
+public class UserDetailDialogHistoryTests : MudBlazorTestContext
+{
+    private ITelegramUserManagementService _mockUserService = null!;
+    private IBotModerationService _mockModerationService = null!;
+    private IAdminNotesRepository _mockNotesRepo = null!;
+    private IUserTagsRepository _mockTagsRepo = null!;
+    private ITagDefinitionsRepository _mockTagDefinitionsRepo = null!;
+    private IUserActionsRepository _mockActionsRepo = null!;
+    private IUsernameHistoryRepository _mockHistoryRepo = null!;
+    private IDialogService _dialogService = null!;
+
+    private const long TestUserId = 123456789;
+
+    public UserDetailDialogHistoryTests()
+    {
+        JSInterop.SetupVoid("mudPopover.initialize", _ => true).SetVoidResult();
+        JSInterop.SetupVoid("mudPopover.connect", _ => true).SetVoidResult();
+        JSInterop.SetupVoid("mudPopover.disconnect", _ => true).SetVoidResult();
+        this.AddTestWebUser();
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockUserService = Substitute.For<ITelegramUserManagementService>();
+        _mockModerationService = Substitute.For<IBotModerationService>();
+        _mockNotesRepo = Substitute.For<IAdminNotesRepository>();
+        _mockTagsRepo = Substitute.For<IUserTagsRepository>();
+        _mockTagDefinitionsRepo = Substitute.For<ITagDefinitionsRepository>();
+        _mockActionsRepo = Substitute.For<IUserActionsRepository>();
+        _mockHistoryRepo = Substitute.For<IUsernameHistoryRepository>();
+
+        Services.AddSingleton(_mockUserService);
+        Services.AddSingleton(_mockModerationService);
+        Services.AddSingleton(_mockNotesRepo);
+        Services.AddSingleton(_mockTagsRepo);
+        Services.AddSingleton(_mockTagDefinitionsRepo);
+        Services.AddSingleton(_mockActionsRepo);
+        Services.AddSingleton(_mockHistoryRepo);
+    }
+
+    private void SetupUserDetailReturn(TelegramUserDetail detail)
+    {
+        _mockUserService.GetUserDetailAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(detail);
+    }
+
+    [Test]
+    public async Task NameHistoryPanel_NotRendered_WhenNoHistory()
+    {
+        // Arrange - user exists, no history
+        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameHistoryRecord>());
+
+        // Setup minimal user detail (adapt to actual constructor)
+        // ... render dialog and assert no expansion panel with "Name History" text
+
+        // Assert
+        // Find the dialog provider markup and verify "Name History" text is absent
+    }
+
+    [Test]
+    public async Task NameHistoryPanel_RenderedCollapsed_WhenHistoryExists()
+    {
+        // Arrange
+        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameHistoryRecord>
+            {
+                new(1, TestUserId, "old_user", "Old", "Name", DateTimeOffset.UtcNow.AddDays(-7)),
+            });
+
+        // ... render dialog and verify expansion panel exists with "Name History (1)" text
+        // Verify panel is collapsed (content not visible)
+    }
+
+    [Test]
+    public async Task NameHistoryPanel_ShowsCorrectData_WhenExpanded()
+    {
+        // Arrange
+        var entries = new List<UsernameHistoryRecord>
+        {
+            new(2, TestUserId, "recent_user", "Recent", "Name", DateTimeOffset.UtcNow.AddDays(-1)),
+            new(1, TestUserId, "oldest_user", "Oldest", "Name", DateTimeOffset.UtcNow.AddDays(-30)),
+        };
+        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(entries);
+
+        // ... render dialog, expand the panel, verify:
+        // - "@recent_user" appears before "@oldest_user"
+        // - "Recent Name" and "Oldest Name" displayed
+        // - Dates formatted correctly
+    }
+
+    [Test]
+    public async Task NameHistoryPanel_HandlesNullUsername()
+    {
+        // Arrange
+        _mockHistoryRepo.GetByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns(new List<UsernameHistoryRecord>
+            {
+                new(1, TestUserId, null, "NoUsername", "User", DateTimeOffset.UtcNow),
+            });
+
+        // ... render dialog, expand panel, verify "(no username)" displayed
+    }
+}
+```
+
+Note: The test bodies above are intentionally sketched — the implementer must adapt them to match the actual `UserDetailDialog` rendering pattern from the existing `UserDetailDialogTests.cs` (dialog parameters, how to open the dialog, how to find markup). The assertions and mock setup are correct; the rendering boilerplate should be copied from the existing test file.
+
+- [ ] **Step 2: Run component tests**
+
+Run: `dotnet test TelegramGroupsAdmin.ComponentTests --filter "FullyQualifiedName~UserDetailDialogHistoryTests" -v normal 2>&1 | tail -20`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin.ComponentTests/Components/UserDetailDialogHistoryTests.cs
+git commit -m "test: add component tests for name history panel in UserDetailDialog"
+```
+
+---
+
+### Task 10: Unit tests for capture logic
+
+**Files:**
+- Create: `TelegramGroupsAdmin.UnitTests/Telegram/Services/MessageProcessingServiceProfileDiffTests.cs`
+
+- [ ] **Step 1: Create the unit test class**
+
+This tests the `BuildProfileChangeReason` method and verifies the correct services are called during profile diff handling. Since `MessageProcessingService` is a complex singleton with many dependencies, the most practical approach is to test the `BuildProfileChangeReason` helper directly (extract it as `internal static` if needed) and use integration-level verification for the full flow.
+
+Create `TelegramGroupsAdmin.UnitTests/Telegram/Services/MessageProcessingServiceProfileDiffTests.cs`:
+
+```csharp
+using TelegramGroupsAdmin.Telegram.Services.BackgroundServices;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services;
+
+/// <summary>
+/// Unit tests for profile diff reason building logic in MessageProcessingService.
+/// The full capture flow (history insert + action insert) is verified by integration tests.
+/// </summary>
+[TestFixture]
+public class MessageProcessingServiceProfileDiffTests
+{
+    [Test]
+    public void BuildProfileChangeReason_UsernameChanged_IncludesUsernameInReason()
+    {
+        var old = CreateUser(username: "old_user");
+        var current = CreateSdkUser(username: "new_user");
+
+        var reason = InvokeBuildReason(old, current);
+
+        Assert.That(reason, Does.Contain("Username: @old_user → @new_user"));
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_FirstNameChanged_IncludesFirstNameInReason()
+    {
+        var old = CreateUser(firstName: "OldFirst");
+        var current = CreateSdkUser(firstName: "NewFirst");
+
+        var reason = InvokeBuildReason(old, current);
+
+        Assert.That(reason, Does.Contain("First name: OldFirst → NewFirst"));
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_LastNameChanged_IncludesLastNameInReason()
+    {
+        var old = CreateUser(lastName: "OldLast");
+        var current = CreateSdkUser(lastName: "NewLast");
+
+        var reason = InvokeBuildReason(old, current);
+
+        Assert.That(reason, Does.Contain("Last name: OldLast → NewLast"));
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_MultipleFieldsChanged_IncludesAll()
+    {
+        var old = CreateUser(username: "old_user", firstName: "OldFirst", lastName: "OldLast");
+        var current = CreateSdkUser(username: "new_user", firstName: "NewFirst", lastName: "NewLast");
+
+        var reason = InvokeBuildReason(old, current);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reason, Does.Contain("Username:"));
+            Assert.That(reason, Does.Contain("First name:"));
+            Assert.That(reason, Does.Contain("Last name:"));
+        });
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_NullToValue_ShowsNone()
+    {
+        var old = CreateUser(username: null);
+        var current = CreateSdkUser(username: "new_user");
+
+        var reason = InvokeBuildReason(old, current);
+
+        Assert.That(reason, Does.Contain("@(none) → @new_user"));
+    }
+
+    [Test]
+    public void BuildProfileChangeReason_ValueToNull_ShowsNone()
+    {
+        var old = CreateUser(username: "old_user");
+        var current = CreateSdkUser(username: null);
+
+        var reason = InvokeBuildReason(old, current);
+
+        Assert.That(reason, Does.Contain("@old_user → @(none)"));
+    }
+
+    // Helper: create a TelegramUser with defaults
+    private static TelegramGroupsAdmin.Telegram.Models.TelegramUser CreateUser(
+        string? username = "testuser", string? firstName = "Test", string? lastName = "User")
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new TelegramGroupsAdmin.Telegram.Models.TelegramUser(
+            TelegramUserId: 12345,
+            Username: username,
+            FirstName: firstName,
+            LastName: lastName,
+            UserPhotoPath: null, PhotoHash: null, PhotoFileUniqueId: null,
+            IsBot: false, IsTrusted: false, IsBanned: false,
+            KickCount: 0, BotDmEnabled: false,
+            FirstSeenAt: now, LastSeenAt: now, CreatedAt: now, UpdatedAt: now);
+    }
+
+    // Helper: create an SDK User with defaults
+    private static Telegram.Bot.Types.User CreateSdkUser(
+        string? username = "testuser", string? firstName = "Test", string? lastName = "User")
+    {
+        return new Telegram.Bot.Types.User
+        {
+            Id = 12345,
+            IsBot = false,
+            FirstName = firstName ?? "Test",
+            LastName = lastName,
+            Username = username,
+        };
+    }
+
+    // Helper: invoke the private static method via reflection (or make it internal + InternalsVisibleTo)
+    private static string InvokeBuildReason(
+        TelegramGroupsAdmin.Telegram.Models.TelegramUser old,
+        Telegram.Bot.Types.User current)
+    {
+        var method = typeof(MessageProcessingService)
+            .GetMethod("BuildProfileChangeReason",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        return (string)method!.Invoke(null, [old, current])!;
+    }
+}
+```
+
+Note: If reflection is not preferred, change `BuildProfileChangeReason` to `internal static` and add `[assembly: InternalsVisibleTo("TelegramGroupsAdmin.UnitTests")]` to the Telegram project. Check the existing pattern in the project.
+
+- [ ] **Step 2: Run unit tests**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~MessageProcessingServiceProfileDiffTests" -v normal 2>&1 | tail -20`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TelegramGroupsAdmin.UnitTests/Telegram/Services/MessageProcessingServiceProfileDiffTests.cs
+git commit -m "test: add unit tests for BuildProfileChangeReason logic"
+```
+
+---
+
+### Task 11: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full build**
+
+Run: `dotnet build --no-restore 2>&1 | tail -5`
+Expected: `Build succeeded. 0 Warning(s) 0 Error(s)`
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests -v normal 2>&1 | tail -10`
+Expected: All tests pass, no regressions.
+
+- [ ] **Step 3: Run component tests**
+
+Run: `dotnet test TelegramGroupsAdmin.ComponentTests -v normal 2>&1 | tail -10`
+Expected: All tests pass.
+
+- [ ] **Step 4: Run integration tests** (background — takes ~20min)
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests -v normal > /tmp/integration-test-results.txt 2>&1`
+Expected: All tests pass. Check results with `tail -20 /tmp/integration-test-results.txt`.
+
+- [ ] **Step 5: Validate migration applies cleanly**
+
+Run: `dotnet run --project TelegramGroupsAdmin --migrate-only`
+Expected: Clean exit, no errors.
+
+- [ ] **Step 6: Final commit (if any fixups needed)**
+
+Only if previous steps required fixes. Otherwise, the feature is complete.

--- a/docs/superpowers/specs/2026-04-03-username-history-design.md
+++ b/docs/superpowers/specs/2026-04-03-username-history-design.md
@@ -1,0 +1,139 @@
+# Username History Tracking
+
+## Problem
+
+When a Telegram user changes their username, first name, or last name, the `telegram_users` table is overwritten on the next message via `UpsertAsync`. The old values are lost permanently. Admins who remember a user by a previous name have no way to find them, and there is no audit trail of profile changes.
+
+This was surfaced by a production bug where `ProfileDiffDetected` was firing but the scheduled `ProfileScanJob` threw an `ArgumentException`, masking the fact that profile changes were being detected but not recorded anywhere.
+
+## Scope
+
+- Track **username, first name, last name** changes only (Bot API fields compared by `ProfileDiffDetected`)
+- Bio, channel, stories, and other User API fields are out of scope (already tracked via `profile_scan_results`)
+- Primary goal: **admin visibility and lookup** — not moderation scoring
+
+## Data Model
+
+### New table: `username_history`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `bigint` PK | Auto-generated |
+| `user_id` | `bigint` FK | References `telegram_users(telegram_user_id)`, CASCADE DELETE |
+| `username` | `varchar(32)` nullable | Previous username at time of change |
+| `first_name` | `varchar(64)` nullable | Previous first name at time of change |
+| `last_name` | `varchar(64)` nullable | Previous last name at time of change |
+| `recorded_at` | `timestamptz` | When the change was detected |
+
+Each row captures the **old** values at the moment of change. Current values remain on `telegram_users`.
+
+### Indexes
+
+- `IX_username_history_user_id` on `user_id` — load history for user detail dialog
+- `IX_username_history_username_lower` on `LOWER(username)` — global search by past username
+- `IX_username_history_name_lower` on `LOWER(first_name), LOWER(last_name)` — global search by past name
+
+### Retention
+
+No separate retention policy. Rows are deleted via CASCADE when the parent `telegram_users` row is deleted. Name history is lightweight and its value increases over time.
+
+### New `UserActionType` enum value
+
+Add `ProfileChange = 10` to `UserActionType`. When a profile diff is detected, insert a `user_actions` row:
+
+- **Actor:** `system_identifier = "ProfileDiffDetection"`
+- **Target:** `user_id` of the user whose profile changed
+- **Reason:** Summary of changed fields, e.g. `"Username: @old_name → @new_name, Name: Joe Koops → Joseph K"`
+- **chat_id / message_id:** From the message that triggered detection (provides context for where the change was first seen)
+
+## Capture Logic
+
+Single insertion point: `MessageProcessingService.HandleNewMessageAsync`, inside the existing `ProfileDiffDetected` block.
+
+Sequence after this change:
+
+1. `ProfileDiffDetected` returns true (username, first name, or last name differs)
+2. Log the change at Info level with old/new values (already implemented in hotfix)
+3. **Insert row into `username_history`** with `existingUser`'s old values
+4. **Insert `ProfileChange` action into `user_actions`** with change summary
+5. Schedule profile scan via Quartz (already implemented)
+6. `UpsertAsync` overwrites `telegram_users` with new values
+
+No other code paths update user profile fields from Telegram data — `BotMessageService.UpsertAsync` calls are for bot user records, not real user profiles.
+
+## Search Integration
+
+### Repository changes
+
+Extend the search `WHERE` clause in three `TelegramUserRepository` methods:
+
+- `GetPagedUsersAsync` (line 487-494)
+- `GetPagedBannedUsersWithDetailsAsync` (line 566-573)
+- `GetUserTabCountsAsync` (line 674-681)
+
+Each currently searches `telegram_users` via `ILike` on username, first_name, last_name, and telegram_user_id. Add an `OR EXISTS` subquery:
+
+```csharp
+// Existing
+query = query.Where(u =>
+    (u.Username != null && EF.Functions.ILike(u.Username, $"%{search}%")) ||
+    (u.FirstName != null && EF.Functions.ILike(u.FirstName, $"%{search}%")) ||
+    (u.LastName != null && EF.Functions.ILike(u.LastName, $"%{search}%")) ||
+    EF.Functions.ILike(u.TelegramUserId.ToString(), $"%{search}%") ||
+    // NEW: match past names
+    context.Set<UsernameHistoryDto>().Any(h =>
+        h.UserId == u.TelegramUserId &&
+        ((h.Username != null && EF.Functions.ILike(h.Username, $"%{search}%")) ||
+         (h.FirstName != null && EF.Functions.ILike(h.FirstName, $"%{search}%")) ||
+         (h.LastName != null && EF.Functions.ILike(h.LastName, $"%{search}%")))
+    ));
+```
+
+Also update `SearchByNameAsync` (used by ban command autocomplete) with the same pattern.
+
+### Placeholder text
+
+Update the search bar placeholder from `"Search by name, username, or ID..."` to `"Search by name, username, ID, or past names..."`.
+
+## UI Display
+
+### User Detail Dialog
+
+Add a **Name History** section using `MudExpansionPanel`, collapsed by default. Only rendered if the user has history entries.
+
+Content: a `MudSimpleTable` showing past names in reverse chronological order:
+
+| Username | Name | Date |
+|----------|------|------|
+| @old_username | Joe Koops | Mar 15, 2026 |
+| @spammer123 | Joseph K | Feb 28, 2026 |
+
+This is a secondary reference — the primary visibility is through the `ProfileChange` action in the existing action timeline, which renders alongside bans, warns, kicks, etc.
+
+### Audit Page
+
+No changes needed. The `ProfileChange` user action will appear automatically in the existing audit timeline rendering.
+
+## Files to Create
+
+| File | Project | Purpose |
+|------|---------|---------|
+| `UsernameHistoryDto.cs` | Data | EF Core entity |
+| `UsernameHistoryRecord.cs` | Telegram/Models | Domain model |
+| `UsernameHistoryMappings.cs` | Telegram/Repositories/Mappings | Dto <-> Model |
+| `IUsernameHistoryRepository.cs` | Telegram/Repositories | Interface |
+| `UsernameHistoryRepository.cs` | Telegram/Repositories | Implementation |
+| EF migration | Data/Migrations | Table + indexes |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `AppDbContext.cs` | Add `DbSet<UsernameHistoryDto>`, fluent config |
+| `UserActionType.cs` (Data) | Add `ProfileChange = 10` |
+| `UserActionType.cs` (Telegram) | Add `ProfileChange = 10` |
+| `MessageProcessingService.cs` | Insert history + action in `ProfileDiffDetected` block |
+| `TelegramUserRepository.cs` | Extend search queries with history subquery |
+| `UserDetailDialog.razor` | Add collapsed name history expansion panel |
+| `Users.razor` | Update search placeholder text |
+| `ServiceCollectionExtensions.cs` (Telegram) | Register `IUsernameHistoryRepository` |

--- a/docs/superpowers/specs/2026-04-03-username-history-design.md
+++ b/docs/superpowers/specs/2026-04-03-username-history-design.md
@@ -114,6 +114,60 @@ This is a secondary reference — the primary visibility is through the `Profile
 
 No changes needed. The `ProfileChange` user action will appear automatically in the existing audit timeline rendering.
 
+## Testing
+
+### Unit Tests
+
+**`MessageProcessingServiceProfileDiffTests.cs`** (UnitTests/Telegram/Services)
+
+Tests for the capture logic in the `ProfileDiffDetected` block:
+
+- Inserts history row when username changes
+- Inserts history row when first name changes
+- Inserts history row when last name changes
+- Inserts history row when multiple fields change simultaneously
+- Does not insert history when no diff detected (existing user, same fields)
+- Does not insert history for new users (`existingUser == null`)
+- Does not insert history for trusted/admin users (skipped by `contentCheckSkipReason`)
+- Inserts `ProfileChange` user action with correct actor (`system_identifier = "ProfileDiffDetection"`)
+- User action reason contains old and new values for changed fields only
+- User action includes chat_id and message_id from triggering message
+- Profile scan scheduling failure does not prevent history/action insertion (try/catch isolation)
+
+### Integration Tests
+
+**`UsernameHistoryRepositoryTests.cs`** (IntegrationTests/Repositories)
+
+Tests against a real PostgreSQL database via `MigrationTestHelper`:
+
+- Insert and retrieve history entries for a user
+- History ordered by `recorded_at` descending
+- Cascade delete: deleting parent `telegram_users` row deletes all history
+- Search by past username returns matching user (via repository search query)
+- Search by past first/last name returns matching user
+- Search does not return false positives (different user's history)
+- Multiple history entries for same user returned correctly
+
+**`TelegramUserRepositorySearchTests.cs`** (extend existing or new file)
+
+- `GetPagedUsersAsync` search matches past username from history
+- `GetPagedBannedUsersWithDetailsAsync` search matches past username from history
+- `GetUserTabCountsAsync` counts include users matched by past names
+- `SearchByNameAsync` matches past names (ban command autocomplete)
+
+### Component Tests
+
+**`UserDetailDialogHistoryTests.cs`** (ComponentTests/Components)
+
+bUnit + NSubstitute tests for the name history UI:
+
+- Name history panel not rendered when user has no history entries
+- Name history panel rendered collapsed when user has history entries
+- Expanding panel shows table with correct columns (username, name, date)
+- History entries displayed in reverse chronological order
+- Null username displays gracefully (e.g., "(no username)")
+- Null first/last name displays gracefully
+
 ## Files to Create
 
 | File | Project | Purpose |
@@ -124,6 +178,9 @@ No changes needed. The `ProfileChange` user action will appear automatically in 
 | `IUsernameHistoryRepository.cs` | Telegram/Repositories | Interface |
 | `UsernameHistoryRepository.cs` | Telegram/Repositories | Implementation |
 | EF migration | Data/Migrations | Table + indexes |
+| `MessageProcessingServiceProfileDiffTests.cs` | UnitTests | Capture logic tests |
+| `UsernameHistoryRepositoryTests.cs` | IntegrationTests | DB repository tests |
+| `UserDetailDialogHistoryTests.cs` | ComponentTests | Name history UI tests |
 
 ## Files to Modify
 


### PR DESCRIPTION
Closes #442

## Summary

- Add `username_history` table to record previous usernames, first names, and last names when profile changes are detected
- Capture history automatically in the message processing pipeline with `ProfileChange` audit action
- Extend user search (both Users page and ban autocomplete) to match past usernames and names
- Add collapsible "Name History" panel to the User Detail dialog
- Add `ProfileChange` user action type for audit trail

## Review Fixes (post-review)

After comprehensive multi-agent code review, the following fixes were applied:
- Add `Actor.ProfileDiffDetection` static field to eliminate magic string
- Materialize EF Core query before `ToModel()` mapping in `UsernameHistoryRepository`
- Remove `virtual` keyword and redundant `[ForeignKey]` from `UsernameHistoryDto`
- Rename indexes to `ix_` snake_case convention and drop two unused indexes
- Move name history loading from Razor component into `TelegramUserManagementService`
- Replace `.LocalDateTime` with `<LocalTimestamp>` component for proper timezone handling
- Update search placeholder text to "name history"
- Add 4 integration tests for `SearchByNameAsync` past-name subquery and user isolation

## Test plan

- [x] 1,840 unit tests pass
- [x] 1,046 integration tests pass (including 4 new SearchByNameAsync tests)
- [x] 590 component tests pass (including name history panel tests)
- [x] 284/285 E2E tests pass (1 pre-existing flake in Chats page, unrelated)
- [x] Migration generates and applies cleanly
- [x] Build succeeds with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)