### PR TITLE
fix(notifications): cross-admin button expiration and clickable DM mentions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,70 +1,72 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <!-- UI / Web -->
     <PackageVersion Include="AngleSharp" Version="1.4.0" />
     <PackageVersion Include="Blazor-ApexCharts" Version="6.1.0" />
-    <PackageVersion Include="bunit" Version="2.6.2" />
-    <PackageVersion Include="MudBlazor" Version="9.1.0" />
+    <PackageVersion Include="bunit" Version="2.7.2" />
+    <PackageVersion Include="MudBlazor" Version="9.4.0" />
 
     <!-- Markdown -->
-    <PackageVersion Include="Markdig" Version="1.1.1" />
+    <PackageVersion Include="Markdig" Version="1.1.3" />
     <PackageVersion Include="Markdown.ColorCode" Version="3.0.1" />
 
     <!-- Database -->
     <PackageVersion Include="Dapper" Version="2.1.72" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
-    <PackageVersion Include="Npgsql" Version="10.0.1" />
-    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.1" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageVersion Include="Npgsql" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.2" />
 
     <!-- Microsoft Extensions -->
-    <PackageVersion Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
 
     <!-- AI / ML -->
     <PackageVersion Include="Microsoft.Extensions.ML" Version="5.0.0" />
     <PackageVersion Include="Microsoft.ML" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.73.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.73.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.74.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.74.0" />
 
     <!-- Telegram -->
-    <PackageVersion Include="Telegram.Bot" Version="22.9.5.3" />
-    <PackageVersion Include="WTelegramClient" Version="4.4.2" />
+    <PackageVersion Include="Telegram.Bot" Version="22.9.6.1" />
+    <PackageVersion Include="WTelegramClient" Version="4.4.3" />
 
     <!-- Background Jobs -->
     <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
-    <PackageVersion Include="HumanCron" Version="0.5.0" />
-    <PackageVersion Include="HumanCron.Quartz" Version="0.5.0" />
-    <PackageVersion Include="Quartz" Version="3.16.1" />
-    <PackageVersion Include="Quartz.AspNetCore" Version="3.16.1" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.16.1" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.16.1" />
-    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.16.1" />
+    <PackageVersion Include="HumanCron" Version="0.5.2" />
+    <PackageVersion Include="HumanCron.Quartz" Version="0.5.2" />
+    <PackageVersion Include="Quartz" Version="3.18.0" />
+    <PackageVersion Include="Quartz.AspNetCore" Version="3.18.0" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.18.0" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.18.0" />
+    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.18.0" />
 
     <!-- Observability -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.11.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
@@ -81,25 +83,25 @@
     <PackageVersion Include="nClam" Version="9.0.0" />
     <PackageVersion Include="Otp.NET" Version="1.4.1" />
     <PackageVersion Include="Panlingo.LanguageIdentification.FastText" Version="0.7.2" />
-    <PackageVersion Include="QRCoder" Version="1.7.0" />
+    <PackageVersion Include="QRCoder" Version="1.8.0" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.6" />
-    <PackageVersion Include="Testably.Abstractions" Version="10.1.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.7" />
+    <PackageVersion Include="Testably.Abstractions" Version="10.2.0" />
     <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
 
     <!-- Testing -->
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.58.0" />
-    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.58.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
+    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.59.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageVersion Include="Testably.Abstractions.Testing" Version="5.3.0" />
-    <PackageVersion Include="Testcontainers" Version="4.10.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
-    <PackageVersion Include="WireMock.Net" Version="1.25.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="Testably.Abstractions.Testing" Version="6.2.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="WireMock.Net" Version="2.4.0" />
   </ItemGroup>
 </Project>

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
@@ -76,8 +76,6 @@ public class DataCleanupJob : IJob
 
         var messageRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.MessageRetention, DataCleanupSettings.DefaultMessageRetention);
         var reportRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.ReportRetention, DataCleanupSettings.DefaultReportRetention);
-        // Callback context cleanup is now orphan-based; retention value kept only for log formatting until Task 7 reworks the signature.
-        var contextRetention = DataCleanupSettings.DefaultShortRetention;
         var notificationRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.WebNotificationRetention, DataCleanupSettings.DefaultShortRetention);
         var fileScanRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.FileScanResultRetention, DataCleanupSettings.DefaultFileScanResultRetention);
 
@@ -91,8 +89,8 @@ public class DataCleanupJob : IJob
         // 2. Clean up old resolved reports
         totalDeleted += await CleanupReportsAsync(sp, reportRetention, cancellationToken);
 
-        // 3. Clean up expired DM callback contexts
-        totalDeleted += await CleanupCallbackContextsAsync(sp, contextRetention, cancellationToken);
+        // 3. Clean up orphaned DM callback contexts
+        totalDeleted += await CleanupCallbackContextsAsync(sp, cancellationToken);
 
         // 4. Clean up old read web notifications
         totalDeleted += await CleanupNotificationsAsync(sp, notificationRetention, cancellationToken);
@@ -182,7 +180,7 @@ public class DataCleanupJob : IJob
         return reportsDeleted;
     }
 
-    private async Task<long> CleanupCallbackContextsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
+    private async Task<long> CleanupCallbackContextsAsync(IServiceProvider sp, CancellationToken cancellationToken)
     {
         var callbackContextRepo = sp.GetRequiredService<IReportCallbackContextRepository>();
         var contextsDeleted = await callbackContextRepo.DeleteOrphanedAsync(cancellationToken);
@@ -190,9 +188,8 @@ public class DataCleanupJob : IJob
         if (contextsDeleted > 0)
         {
             _logger.LogInformation(
-                "Callback context cleanup: {Count} expired contexts deleted (retention: {Retention})",
-                contextsDeleted,
-                TimeSpanUtilities.FormatDuration(retention));
+                "Callback context cleanup: {Count} orphaned contexts deleted (no matching report)",
+                contextsDeleted);
         }
 
         return contextsDeleted;

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
@@ -184,7 +184,7 @@ public class DataCleanupJob : IJob
     private async Task<long> CleanupCallbackContextsAsync(IServiceProvider sp, TimeSpan retention, CancellationToken cancellationToken)
     {
         var callbackContextRepo = sp.GetRequiredService<IReportCallbackContextRepository>();
-        var contextsDeleted = await callbackContextRepo.DeleteExpiredAsync(retention, cancellationToken);
+        var contextsDeleted = await callbackContextRepo.DeleteOrphanedAsync(cancellationToken);
 
         if (contextsDeleted > 0)
         {

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
@@ -76,7 +76,8 @@ public class DataCleanupJob : IJob
 
         var messageRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.MessageRetention, DataCleanupSettings.DefaultMessageRetention);
         var reportRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.ReportRetention, DataCleanupSettings.DefaultReportRetention);
-        var contextRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.CallbackContextRetention, DataCleanupSettings.DefaultShortRetention);
+        // Callback context cleanup is now orphan-based; retention value kept only for log formatting until Task 7 reworks the signature.
+        var contextRetention = DataCleanupSettings.DefaultShortRetention;
         var notificationRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.WebNotificationRetention, DataCleanupSettings.DefaultShortRetention);
         var fileScanRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.FileScanResultRetention, DataCleanupSettings.DefaultFileScanResultRetention);
 

--- a/TelegramGroupsAdmin.BackgroundJobs/Jobs/FileScanJob.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Jobs/FileScanJob.cs
@@ -303,7 +303,7 @@ public class FileScanJob(
             // Try to send DM using IBotDmService with fallback to chat
             // IBotDmService handles the fallback automatically when fallbackChatId is provided
             var dmResult = await dmService.SendDmAsync(
-                payload.User.Id,
+                payload.User,
                 notificationText,
                 fallbackChatId: payload.Chat.Id, // Fallback to chat if DM fails
                 cancellationToken: cancellationToken);

--- a/TelegramGroupsAdmin.BackgroundJobs/Listeners/RetryJobListener.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Listeners/RetryJobListener.cs
@@ -85,8 +85,8 @@ public class RetryJobListener(ILogger<RetryJobListener> logger, ISchedulerFactor
         // Preserve original payload if present (ad-hoc jobs)
         if (context.JobDetail.JobDataMap.ContainsKey(JobDataKeys.PayloadJson))
         {
-            retryJobData.Put(JobDataKeys.PayloadJson, context.JobDetail.JobDataMap.GetString(JobDataKeys.PayloadJson));
-            retryJobData.Put(JobDataKeys.PayloadType, context.JobDetail.JobDataMap.GetString(JobDataKeys.PayloadType));
+            retryJobData[JobDataKeys.PayloadJson] = context.JobDetail.JobDataMap.GetString(JobDataKeys.PayloadJson)!;
+            retryJobData[JobDataKeys.PayloadType] = context.JobDetail.JobDataMap.GetString(JobDataKeys.PayloadType)!;
         }
 
         var retryTrigger = TriggerBuilder.Create()

--- a/TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs
+++ b/TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs
@@ -22,7 +22,7 @@ public record DataCleanupSettings
     public static readonly TimeSpan DefaultReportRetention = TimeSpan.FromDays(30);
 
     /// <summary>
-    /// Fallback retention for callback contexts and notifications if parsing fails (7 days).
+    /// Fallback retention for notifications if parsing fails (7 days).
     /// </summary>
     public static readonly TimeSpan DefaultShortRetention = TimeSpan.FromDays(7);
 
@@ -47,11 +47,6 @@ public record DataCleanupSettings
     /// Pending reports are never deleted.
     /// </summary>
     public string ReportRetention { get; init; } = "30d";
-
-    /// <summary>
-    /// Retention period for DM callback button contexts (default: 7 days).
-    /// </summary>
-    public string CallbackContextRetention { get; init; } = "7d";
 
     /// <summary>
     /// Retention period for read web notifications (default: 7 days).

--- a/TelegramGroupsAdmin.Core/Services/INotificationService.cs
+++ b/TelegramGroupsAdmin.Core/Services/INotificationService.cs
@@ -29,9 +29,7 @@ public interface INotificationService
     Task<Dictionary<string, bool>> SendReportNotificationAsync(
         ChatIdentity chat,
         UserIdentity reportedUser,
-        long? reporterUserId,
-        string? reporterName,
-        bool isAutomated,
+        Actor reporter,
         string messagePreview,
         string? photoPath,
         long reportId,

--- a/TelegramGroupsAdmin.E2ETests/Infrastructure/TestWebApplicationFactory.cs
+++ b/TelegramGroupsAdmin.E2ETests/Infrastructure/TestWebApplicationFactory.cs
@@ -12,6 +12,7 @@ using Telegram.Bot.Types.ReplyMarkups;
 using TelegramGroupsAdmin.Configuration.Models;
 using TelegramGroupsAdmin.Configuration.Repositories;
 using TelegramGroupsAdmin.ContentDetection.Services;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Services.AI;
 using TelegramGroupsAdmin.Data;
 using TelegramGroupsAdmin.Services.Email;
@@ -111,12 +112,12 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
 
         // Configure SendDmAsync to return success
         _mockBotDmService.SendDmAsync(
-                Arg.Any<long>(), Arg.Any<string>(), Arg.Any<long?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIdentity>(), Arg.Any<string>(), Arg.Any<long?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>())
             .Returns(new DmDeliveryResult { DmSent = true, Failed = false, MessageId = Random.Shared.Next(1, 100000) });
 
         // Configure SendDmWithKeyboardAsync to return success with message ID (used for exam questions)
         _mockBotDmService.SendDmWithKeyboardAsync(
-                Arg.Any<long>(), Arg.Any<string>(), Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIdentity>(), Arg.Any<string>(), Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup>(), Arg.Any<CancellationToken>())
             .Returns(new DmDeliveryResult { DmSent = true, Failed = false, MessageId = Random.Shared.Next(1, 100000) });
 
         // Configure DeleteDmMessageAsync to succeed (used after answering exam questions)

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/ReportCallbackContextRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/ReportCallbackContextRepositoryTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Repositories;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+
+namespace TelegramGroupsAdmin.IntegrationTests.Repositories;
+
+/// <summary>
+/// Integration tests for ReportCallbackContextRepository.
+///
+/// Covers the orphan-based cleanup strategy: contexts whose associated report
+/// no longer exists (anti-join against reports) are deleted, while contexts
+/// still referencing a live report are retained regardless of age.
+/// </summary>
+[TestFixture]
+public class ReportCallbackContextRepositoryTests
+{
+    private MigrationTestHelper? _testHelper;
+    private IServiceProvider? _serviceProvider;
+    private IServiceScope? _scope;
+    private IReportsRepository? _reportsRepo;
+    private IReportCallbackContextRepository? _callbackRepo;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _testHelper = new MigrationTestHelper();
+        await _testHelper.CreateDatabaseAndApplyMigrationsAsync();
+
+        var services = new ServiceCollection();
+
+        services.AddDbContextFactory<AppDbContext>(options =>
+            options.UseNpgsql(_testHelper.ConnectionString));
+
+        services.AddLogging(builder =>
+            builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+
+        services.AddScoped<IReportsRepository, ReportsRepository>();
+        services.AddScoped<IReportCallbackContextRepository, ReportCallbackContextRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _scope = _serviceProvider.CreateScope();
+        _reportsRepo = _scope.ServiceProvider.GetRequiredService<IReportsRepository>();
+        _callbackRepo = _scope.ServiceProvider.GetRequiredService<IReportCallbackContextRepository>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _scope?.Dispose();
+        (_serviceProvider as IDisposable)?.Dispose();
+        _testHelper?.Dispose();
+    }
+
+    [Test]
+    public async Task DeleteOrphanedAsync_RemovesContextsForMissingReports_KeepsContextsForExistingReports()
+    {
+        // Arrange - insert a real report; its context must be kept.
+        var reportId = await _reportsRepo!.InsertContentReportAsync(new Report(
+            Id: 0,
+            MessageId: 100,
+            Chat: new ChatIdentity(-1001L, "TestChat"),
+            ReportCommandMessageId: null,
+            ReportedByUserId: 200L,
+            ReportedByUserName: "tester",
+            ReportedAt: DateTimeOffset.UtcNow,
+            Status: ReportStatus.Pending,
+            ReviewedBy: null,
+            ReviewedAt: null,
+            ActionTaken: null,
+            AdminNotes: null),
+            CancellationToken.None);
+
+        // Context 1: tied to existing report — must survive cleanup.
+        var liveContextId = await _callbackRepo!.CreateAsync(new ReportCallbackContext(
+            Id: 0,
+            ReportId: reportId,
+            ReportType: ReportType.ContentReport,
+            ChatId: -1001L,
+            UserId: 300L,
+            CreatedAt: DateTimeOffset.UtcNow),
+            CancellationToken.None);
+
+        // Context 2: orphan (ReportId references a report that does not exist) — must be deleted.
+        var orphanContextId = await _callbackRepo.CreateAsync(new ReportCallbackContext(
+            Id: 0,
+            ReportId: 9999L,
+            ReportType: ReportType.ContentReport,
+            ChatId: -1001L,
+            UserId: 300L,
+            CreatedAt: DateTimeOffset.UtcNow),
+            CancellationToken.None);
+
+        // Act
+        var deleted = await _callbackRepo.DeleteOrphanedAsync(CancellationToken.None);
+
+        // Assert
+        Assert.That(deleted, Is.EqualTo(1), "exactly one orphan deleted");
+
+        var liveContext = await _callbackRepo.GetByIdAsync(liveContextId, CancellationToken.None);
+        var orphanContext = await _callbackRepo.GetByIdAsync(orphanContextId, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(liveContext, Is.Not.Null, "context tied to existing report must survive");
+            Assert.That(orphanContext, Is.Null, "orphan context must be removed");
+        }
+    }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/Services/BackgroundJobConfigPersistenceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/BackgroundJobConfigPersistenceTests.cs
@@ -116,7 +116,6 @@ public class BackgroundJobConfigPersistenceTests
         {
             MessageRetention = "60d",
             ReportRetention = "120d",
-            CallbackContextRetention = "14d",
             WebNotificationRetention = "30d"
         };
 
@@ -129,7 +128,6 @@ public class BackgroundJobConfigPersistenceTests
         {
             Assert.That(reloaded!.DataCleanup!.MessageRetention, Is.EqualTo("60d"));
             Assert.That(reloaded.DataCleanup.ReportRetention, Is.EqualTo("120d"));
-            Assert.That(reloaded.DataCleanup.CallbackContextRetention, Is.EqualTo("14d"));
             Assert.That(reloaded.DataCleanup.WebNotificationRetention, Is.EqualTo("30d"));
         }
     }

--- a/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
@@ -903,7 +903,7 @@ public class BackupServiceTests
         };
 
         public Task<DmDeliveryResult> SendDmAsync(
-            long telegramUserId,
+            UserIdentity user,
             string messageText,
             long? fallbackChatId = null,
             int? autoDeleteSeconds = null,
@@ -911,7 +911,7 @@ public class BackupServiceTests
             => Task.FromResult(SuccessResult);
 
         public Task<DmDeliveryResult> SendDmWithQueueAsync(
-            long telegramUserId,
+            UserIdentity user,
             string notificationType,
             string messageText,
             ParseMode parseMode = ParseMode.MarkdownV2,
@@ -919,7 +919,7 @@ public class BackupServiceTests
             => Task.FromResult(SuccessResult);
 
         public Task<DmDeliveryResult> SendDmWithMediaAsync(
-            long telegramUserId,
+            UserIdentity user,
             string notificationType,
             string messageText,
             string? photoPath = null,
@@ -928,7 +928,7 @@ public class BackupServiceTests
             => Task.FromResult(SuccessResult);
 
         public Task<DmDeliveryResult> SendDmWithMediaAndKeyboardAsync(
-            long telegramUserId,
+            UserIdentity user,
             string notificationType,
             string messageText,
             string? photoPath = null,
@@ -961,14 +961,14 @@ public class BackupServiceTests
             => Task.CompletedTask;
 
         public Task<DmDeliveryResult> SendDmWithKeyboardAsync(
-            long telegramUserId,
+            UserIdentity user,
             string messageText,
             InlineKeyboardMarkup keyboard,
             CancellationToken cancellationToken = default)
             => Task.FromResult(SuccessResult);
 
         public Task<DmDeliveryResult> SendDmWithEntitiesAsync(
-            long telegramUserId,
+            UserIdentity user,
             string notificationType,
             string text,
             IReadOnlyList<MessageEntity> entities,
@@ -976,7 +976,7 @@ public class BackupServiceTests
             => Task.FromResult(SuccessResult);
 
         public Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
-            long telegramUserId,
+            UserIdentity user,
             string notificationType,
             string text,
             IReadOnlyList<MessageEntity> entities,
@@ -1005,7 +1005,7 @@ public class BackupServiceTests
 
         // Typed methods (no-op for backup tests)
         public Task<Dictionary<string, bool>> SendSpamBanNotificationAsync(ChatIdentity chat, UserIdentity user, Actor? bannedBy, double netScore, double score, string? detectionReason, int chatsAffected, bool messageDeleted, int messageId, string? messagePreview, string? photoPath, string? videoPath, CancellationToken ct = default) => Task.FromResult(EmptyResults);
-        public Task<Dictionary<string, bool>> SendReportNotificationAsync(ChatIdentity chat, UserIdentity? reportedUser, long? reporterUserId, string? reporterName, bool isAutomated, string messagePreview, string? photoPath, long reportId, ReportType reportType, CancellationToken ct = default) => Task.FromResult(EmptyResults);
+        public Task<Dictionary<string, bool>> SendReportNotificationAsync(ChatIdentity chat, UserIdentity reportedUser, Actor reporter, string messagePreview, string? photoPath, long reportId, ReportType reportType, CancellationToken ct = default) => Task.FromResult(EmptyResults);
         public Task<Dictionary<string, bool>> SendProfileScanAlertAsync(ChatIdentity chat, UserIdentity user, decimal score, string signals, string? aiReason, long reportId, CancellationToken ct = default) => Task.FromResult(EmptyResults);
         public Task<Dictionary<string, bool>> SendExamFailureNotificationAsync(ChatIdentity chat, UserIdentity user, int mcCorrectCount, int mcTotal, int mcScore, int mcPassingThreshold, string? openEndedQuestion, string? openEndedAnswer, string? aiReasoning, long examFailureId, CancellationToken ct = default) => Task.FromResult(EmptyResults);
         public Task<Dictionary<string, bool>> SendBanNotificationAsync(UserIdentity user, Actor executor, string? reason, ChatIdentity? chat = null, CancellationToken ct = default) => Task.FromResult(EmptyResults);

--- a/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/Backup/BackupServiceTests.cs
@@ -966,6 +966,25 @@ public class BackupServiceTests
             InlineKeyboardMarkup keyboard,
             CancellationToken cancellationToken = default)
             => Task.FromResult(SuccessResult);
+
+        public Task<DmDeliveryResult> SendDmWithEntitiesAsync(
+            long telegramUserId,
+            string notificationType,
+            string text,
+            IReadOnlyList<MessageEntity> entities,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(SuccessResult);
+
+        public Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
+            long telegramUserId,
+            string notificationType,
+            string text,
+            IReadOnlyList<MessageEntity> entities,
+            string? photoPath = null,
+            string? videoPath = null,
+            InlineKeyboardMarkup? keyboard = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(SuccessResult);
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/BanCelebrationServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/BanCelebrationServiceTests.cs
@@ -424,7 +424,7 @@ public class BanCelebrationServiceTests
         await EnableDmWelcomeMode(TestChatId);
 
         _mockDmService!.SendDmWithMediaAsync(
-            Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<UserIdentity>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>()
         ).Returns(new DmDeliveryResult { DmSent = true });
 
@@ -434,7 +434,7 @@ public class BanCelebrationServiceTests
 
         // Assert - DM delivery was attempted
         await _mockDmService!.Received(1).SendDmWithMediaAsync(
-            TestUserId, "ban_celebration", Arg.Any<string>(),
+            Arg.Is<UserIdentity>(u => u.Id == TestUserId), "ban_celebration", Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
@@ -451,7 +451,7 @@ public class BanCelebrationServiceTests
 
         // Assert - DM delivery was NOT attempted
         await _mockDmService!.DidNotReceive().SendDmWithMediaAsync(
-            Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<UserIdentity>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
@@ -469,7 +469,7 @@ public class BanCelebrationServiceTests
 
         // Assert - DM delivery was NOT attempted (no DM mode enabled)
         await _mockDmService!.DidNotReceive().SendDmWithMediaAsync(
-            Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<UserIdentity>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
@@ -482,7 +482,7 @@ public class BanCelebrationServiceTests
         await EnableDmWelcomeMode(TestChatId);
 
         _mockDmService!.SendDmWithMediaAsync(
-            Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<UserIdentity>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>()
         ).Returns(new DmDeliveryResult { DmSent = false, Failed = true, ErrorMessage = "User blocked bot" });
 

--- a/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/Bot/BotDmServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/Bot/BotDmServiceTests.cs
@@ -7,6 +7,7 @@ using Telegram.Bot.Exceptions;
 using Telegram.Bot.Types;
 using TelegramGroupsAdmin.Core.BackgroundJobs;
 using TelegramGroupsAdmin.Core.JobPayloads;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Data;
 using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
 using TelegramGroupsAdmin.Telegram.Repositories;
@@ -112,7 +113,7 @@ public class BotDmServiceTests
         ).Returns(TelegramTestFactory.CreateMessage(messageId: 999, chatId: TestUserId));
 
         // Act
-        var result = await _service!.SendDmAsync(TestUserId, "Test message");
+        var result = await _service!.SendDmAsync(UserIdentity.FromId(TestUserId), "Test message");
 
         // Assert
         using (Assert.EnterMultipleScope())
@@ -144,7 +145,7 @@ public class BotDmServiceTests
         ).ThrowsAsync(new ApiRequestException("Forbidden", 403));
 
         // Act
-        var result = await _service!.SendDmAsync(TestUserId, "Test message");
+        var result = await _service!.SendDmAsync(UserIdentity.FromId(TestUserId), "Test message");
 
         // Assert
         using (Assert.EnterMultipleScope())
@@ -188,7 +189,7 @@ public class BotDmServiceTests
 
         // Act
         var result = await _service!.SendDmAsync(
-            TestUserId,
+            UserIdentity.FromId(TestUserId),
             "Test message",
             fallbackChatId: TestChatId,
             autoDeleteSeconds: 30);
@@ -234,7 +235,7 @@ public class BotDmServiceTests
 
         // Act
         var result = await _service!.SendDmWithQueueAsync(
-            TestUserId,
+            UserIdentity.FromId(TestUserId),
             "test_notification",
             "Test message");
 
@@ -266,7 +267,7 @@ public class BotDmServiceTests
 
         // Act
         var result = await _service!.SendDmWithQueueAsync(
-            TestUserId,
+            UserIdentity.FromId(TestUserId),
             "report_resolved",
             "Your report was resolved!");
 
@@ -318,7 +319,7 @@ public class BotDmServiceTests
 
         // Act
         var result = await _service!.SendDmWithKeyboardAsync(
-            TestUserId,
+            UserIdentity.FromId(TestUserId),
             "Choose an option:",
             keyboard);
 
@@ -355,7 +356,7 @@ public class BotDmServiceTests
 
         // Act
         var result = await _service!.SendDmWithKeyboardAsync(
-            TestUserId,
+            UserIdentity.FromId(TestUserId),
             "Choose an option:",
             keyboard);
 

--- a/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/Bot/BotDmServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/Bot/BotDmServiceTests.cs
@@ -107,6 +107,7 @@ public class BotDmServiceTests
             Arg.Any<global::Telegram.Bot.Types.Enums.ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).Returns(TelegramTestFactory.CreateMessage(messageId: 999, chatId: TestUserId));
 
@@ -138,6 +139,7 @@ public class BotDmServiceTests
             Arg.Any<global::Telegram.Bot.Types.Enums.ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).ThrowsAsync(new ApiRequestException("Forbidden", 403));
 
@@ -167,6 +169,7 @@ public class BotDmServiceTests
             Arg.Any<global::Telegram.Bot.Types.Enums.ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).ThrowsAsync(new ApiRequestException("Forbidden", 403));
 
@@ -176,6 +179,7 @@ public class BotDmServiceTests
             Arg.Any<global::Telegram.Bot.Types.Enums.ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).Returns(TelegramTestFactory.CreateMessage(messageId: 888, chatId: TestChatId));
 
@@ -224,6 +228,7 @@ public class BotDmServiceTests
             Arg.Any<global::Telegram.Bot.Types.Enums.ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).Returns(TelegramTestFactory.CreateMessage(messageId: 999, chatId: TestUserId));
 
@@ -255,6 +260,7 @@ public class BotDmServiceTests
             Arg.Any<global::Telegram.Bot.Types.Enums.ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).ThrowsAsync(new ApiRequestException("Forbidden", 403));
 
@@ -306,6 +312,7 @@ public class BotDmServiceTests
             Arg.Any<global::Telegram.Bot.Types.Enums.ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).Returns(TelegramTestFactory.CreateMessage(messageId: 777, chatId: TestUserId));
 
@@ -342,6 +349,7 @@ public class BotDmServiceTests
             Arg.Any<global::Telegram.Bot.Types.Enums.ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).ThrowsAsync(new ApiRequestException("Forbidden", 403));
 

--- a/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/Bot/BotMessageServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/Bot/BotMessageServiceTests.cs
@@ -153,6 +153,7 @@ public class BotMessageServiceTests
             Arg.Any<ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).Returns(sentMessage);
 
@@ -195,6 +196,7 @@ public class BotMessageServiceTests
             Arg.Any<ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).Returns(sentMessage);
 
@@ -229,6 +231,7 @@ public class BotMessageServiceTests
             Arg.Any<ParseMode?>(),
             Arg.Any<ReplyParameters?>(),
             Arg.Any<InlineKeyboardMarkup?>(),
+            Arg.Any<IReadOnlyList<MessageEntity>?>(),
             Arg.Any<CancellationToken>()
         ).Returns(sentMessage);
 

--- a/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/ExamFlowServiceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Telegram/Services/ExamFlowServiceTests.cs
@@ -92,14 +92,14 @@ public class ExamFlowServiceTests
         // Mock DM service methods - exam questions are sent via DM
         var dmSuccessResult = new DmDeliveryResult { DmSent = true, MessageId = 1 };
         _mockDmService.SendDmWithKeyboardAsync(
-                Arg.Any<long>(),
+                Arg.Any<UserIdentity>(),
                 Arg.Any<string>(),
                 Arg.Any<InlineKeyboardMarkup>(),
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(dmSuccessResult));
 
         _mockDmService.SendDmAsync(
-                Arg.Any<long>(),
+                Arg.Any<UserIdentity>(),
                 Arg.Any<string>(),
                 Arg.Any<long?>(),
                 Arg.Any<int?>(),

--- a/TelegramGroupsAdmin.Telegram/Repositories/IReportCallbackContextRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/IReportCallbackContextRepository.cs
@@ -37,9 +37,8 @@ public interface IReportCallbackContextRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Delete all expired callback contexts (cleanup job).
+    /// Delete all callback contexts whose associated report no longer exists.
+    /// Used by the data cleanup job — contexts live as long as their report does.
     /// </summary>
-    Task<int> DeleteExpiredAsync(
-        TimeSpan maxAge,
-        CancellationToken cancellationToken = default);
+    Task<int> DeleteOrphanedAsync(CancellationToken cancellationToken = default);
 }

--- a/TelegramGroupsAdmin.Telegram/Repositories/ReportCallbackContextRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/ReportCallbackContextRepository.cs
@@ -61,16 +61,12 @@ public class ReportCallbackContextRepository : IReportCallbackContextRepository
             .ExecuteDeleteAsync(cancellationToken);
     }
 
-    public async Task<int> DeleteExpiredAsync(
-        TimeSpan maxAge,
-        CancellationToken cancellationToken = default)
+    public async Task<int> DeleteOrphanedAsync(CancellationToken cancellationToken = default)
     {
         await using var dbContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
-        var cutoff = DateTimeOffset.UtcNow - maxAge;
-
         return await dbContext.ReportCallbackContexts
-            .Where(rcc => rcc.CreatedAt < cutoff)
+            .Where(rcc => !dbContext.Reports.Any(r => r.Id == rcc.ReportId))
             .ExecuteDeleteAsync(cancellationToken);
     }
 }

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/DetectionActionService.cs
@@ -150,7 +150,7 @@ public class DetectionActionService(
                 await reportService.CreateReportAsync(
                     borderlineReport,
                     message,
-                    isAutomated: true,
+                    Actor.AutoDetection,
                     cancellationToken);
                 pipelineMetrics.RecordModerationAction("report", "auto");
 

--- a/TelegramGroupsAdmin.Telegram/Services/BanCelebrationService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BanCelebrationService.cs
@@ -319,7 +319,7 @@ public class BanCelebrationService(
             }
 
             var result = await dmDeliveryService.SendDmWithMediaAsync(
-                bannedUser.Id,
+                bannedUser,
                 "ban_celebration",
                 dmCaption,
                 photoPath,

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs
@@ -592,6 +592,201 @@ public class BotDmService(
         }
     }
 
+    /// <inheritdoc />
+    public async Task<DmDeliveryResult> SendDmWithEntitiesAsync(
+        long telegramUserId,
+        string notificationType,
+        string text,
+        IReadOnlyList<MessageEntity> entities,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
+
+        try
+        {
+            await messageHandler.SendAsync(
+                chatId: telegramUserId,
+                text: text,
+                parseMode: null,
+                entities: entities,
+                ct: cancellationToken);
+
+            logger.LogInformation(
+                "DM sent successfully to {User} (notification type: {NotificationType})",
+                user.ToLogInfo(telegramUserId),
+                notificationType);
+
+            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
+
+            return new DmDeliveryResult
+            {
+                DmSent = true,
+                FallbackUsed = false,
+                Failed = false
+            };
+        }
+        catch (ApiRequestException ex) when (ex.ErrorCode == 403)
+        {
+            logger.LogWarning(
+                "DM blocked for {User} - queueing {NotificationType} notification for later delivery",
+                user.ToLogDebug(telegramUserId),
+                notificationType);
+
+            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
+
+            await pendingNotificationsRepository.AddPendingNotificationAsync(
+                telegramUserId,
+                notificationType,
+                text,
+                cancellationToken: cancellationToken);
+
+            return new DmDeliveryResult
+            {
+                DmSent = false,
+                FallbackUsed = false,
+                Failed = true,
+                ErrorMessage = "User has not enabled DMs - notification queued for later delivery"
+            };
+        }
+        catch (Exception ex)
+        {
+            if (IsNetworkError(ex))
+            {
+                logger.LogWarning(
+                    "Failed to send DM to {User} - network unavailable (notification type: {NotificationType})",
+                    user.ToLogDebug(telegramUserId),
+                    notificationType);
+            }
+            else
+            {
+                logger.LogError(
+                    ex,
+                    "Failed to send DM to {User} (notification type: {NotificationType})",
+                    user.ToLogDebug(telegramUserId),
+                    notificationType);
+            }
+
+            return new DmDeliveryResult
+            {
+                DmSent = false,
+                FallbackUsed = false,
+                Failed = true,
+                ErrorMessage = ex.Message
+            };
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
+        long telegramUserId,
+        string notificationType,
+        string text,
+        IReadOnlyList<MessageEntity> entities,
+        string? photoPath = null,
+        string? videoPath = null,
+        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup? keyboard = null,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
+
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
+            {
+                await using var photoStream = File.OpenRead(photoPath);
+                await messageHandler.SendPhotoAsync(
+                    chatId: telegramUserId,
+                    photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
+                    caption: text,
+                    parseMode: null,
+                    replyMarkup: keyboard,
+                    captionEntities: entities,
+                    ct: cancellationToken);
+
+                logger.LogInformation(
+                    "DM with photo/entities/keyboard sent successfully to {User}",
+                    user.ToLogInfo(telegramUserId));
+            }
+            else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
+            {
+                await using var videoStream = File.OpenRead(videoPath);
+                await messageHandler.SendVideoAsync(
+                    chatId: telegramUserId,
+                    video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
+                    caption: text,
+                    parseMode: null,
+                    replyMarkup: keyboard,
+                    captionEntities: entities,
+                    ct: cancellationToken);
+
+                logger.LogInformation(
+                    "DM with video/entities/keyboard sent successfully to {User}",
+                    user.ToLogInfo(telegramUserId));
+            }
+            else
+            {
+                await messageHandler.SendAsync(
+                    chatId: telegramUserId,
+                    text: text,
+                    parseMode: null,
+                    replyMarkup: keyboard,
+                    entities: entities,
+                    ct: cancellationToken);
+
+                logger.LogInformation(
+                    "DM with entities/keyboard sent successfully to {User}",
+                    user.ToLogInfo(telegramUserId));
+            }
+
+            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
+
+            return new DmDeliveryResult
+            {
+                DmSent = true,
+                FallbackUsed = false,
+                Failed = false
+            };
+        }
+        catch (ApiRequestException ex) when (ex.ErrorCode == 403)
+        {
+            logger.LogInformation(
+                "{User} has blocked bot DMs (403), queuing notification",
+                user.ToLogInfo(telegramUserId));
+
+            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
+
+            // Queue notification for later delivery (text only, no buttons/media/entities)
+            await pendingNotificationsRepository.AddPendingNotificationAsync(
+                telegramUserId,
+                notificationType,
+                text,
+                cancellationToken: cancellationToken);
+
+            return new DmDeliveryResult
+            {
+                DmSent = false,
+                FallbackUsed = false,
+                Failed = true,
+                ErrorMessage = "User has blocked bot DMs - notification queued for later delivery"
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Failed to send DM with entities/media/keyboard to {User}",
+                user.ToLogDebug(telegramUserId));
+
+            return new DmDeliveryResult
+            {
+                DmSent = false,
+                FallbackUsed = false,
+                Failed = true,
+                ErrorMessage = ex.Message
+            };
+        }
+    }
+
     /// <summary>
     /// Check if exception is a network error (DNS, connection timeout, etc.)
     /// </summary>

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs
@@ -18,6 +18,9 @@ namespace TelegramGroupsAdmin.Telegram.Services.Bot;
 /// Centralized DM delivery service with consistent bot_dm_enabled tracking and fallback handling.
 /// Scoped service with direct dependency injection.
 /// Part of the Bot services layer - can use IBotMessageHandler directly.
+///
+/// Callers pass a <see cref="UserIdentity"/> so the service never fetches the user for logging.
+/// Use <c>user.Id</c> for the DM target chat and the Enable/Disable flag updates.
 /// </summary>
 public class BotDmService(
     IBotMessageHandler messageHandler,
@@ -29,28 +32,22 @@ public class BotDmService(
 {
 
     public async Task<DmDeliveryResult> SendDmAsync(
-        long telegramUserId,
+        UserIdentity user,
         string messageText,
         long? fallbackChatId = null,
         int? autoDeleteSeconds = null,
         CancellationToken cancellationToken = default)
     {
-        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
         try
         {
-            // Attempt to send DM
             var sentMessage = await messageHandler.SendAsync(
-                chatId: telegramUserId,
+                chatId: user.Id,
                 text: messageText,
                 ct: cancellationToken);
 
-            logger.LogInformation(
-                "DM sent successfully to {User}",
-                user.ToLogInfo(telegramUserId));
+            logger.LogInformation("DM sent successfully to {User}", user.ToLogInfo());
 
-            // Update bot_dm_enabled flag to true (user can receive DMs)
-            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
+            await telegramUserRepository.EnableBotDmAsync(user.Id, cancellationToken);
 
             return new DmDeliveryResult
             {
@@ -62,16 +59,13 @@ public class BotDmService(
         }
         catch (ApiRequestException ex) when (ex.ErrorCode == 403)
         {
-            // User has blocked the bot or hasn't started a DM
             logger.LogWarning(
                 "DM blocked for {User} (403 Forbidden){FallbackInfo}",
-                user.ToLogDebug(telegramUserId),
+                user.ToLogDebug(),
                 fallbackChatId.HasValue ? $" - falling back to chat {fallbackChatId.Value}" : " - no fallback configured");
 
-            // Update bot_dm_enabled flag to false
-            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
+            await telegramUserRepository.DisableBotDmAsync(user.Id, cancellationToken);
 
-            // If fallback chat is configured, post message there
             if (fallbackChatId.HasValue)
             {
                 return await SendFallbackToChatAsync(
@@ -91,10 +85,7 @@ public class BotDmService(
         }
         catch (Exception ex)
         {
-            logger.LogError(
-                ex,
-                "Failed to send DM to {User}",
-                user.ToLogDebug(telegramUserId));
+            logger.LogError(ex, "Failed to send DM to {User}", user.ToLogDebug());
 
             return new DmDeliveryResult
             {
@@ -107,18 +98,18 @@ public class BotDmService(
     }
 
     public Task<DmDeliveryResult> SendDmWithQueueAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string messageText,
         ParseMode parseMode = ParseMode.MarkdownV2,
         CancellationToken cancellationToken = default)
     {
         return TrySendWithQueueAsync(
-            telegramUserId,
+            user,
             notificationType,
             queuedText: messageText,
-            sendAction: () => messageHandler.SendAsync(
-                chatId: telegramUserId,
+            sendAction: _ => messageHandler.SendAsync(
+                chatId: user.Id,
                 text: messageText,
                 parseMode: parseMode,
                 ct: cancellationToken),
@@ -152,7 +143,6 @@ public class BotDmService(
                 (chat?.Identity ?? ChatIdentity.FromId(chatId)).ToLogInfo(),
                 autoDeleteSeconds.HasValue ? $", will delete in {autoDeleteSeconds.Value} seconds" : "");
 
-            // Schedule auto-delete if requested
             if (autoDeleteSeconds.HasValue && autoDeleteSeconds.Value > 0)
             {
                 var deletePayload = new DeleteMessagePayload(
@@ -179,7 +169,6 @@ public class BotDmService(
         }
         catch (Exception ex)
         {
-            // Log network errors cleanly without stack traces
             if (IsNetworkError(ex))
             {
                 logger.LogWarning(
@@ -205,7 +194,7 @@ public class BotDmService(
     }
 
     public Task<DmDeliveryResult> SendDmWithMediaAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string messageText,
         string? photoPath = null,
@@ -215,12 +204,11 @@ public class BotDmService(
         // Media variants log success internally (messages differ for photo/video/text paths).
         // The helper therefore skips the default success log and delegates entirely to sendAction.
         return TrySendWithQueueAsync(
-            telegramUserId,
+            user,
             notificationType,
             queuedText: messageText,
-            sendAction: async () =>
+            sendAction: async identity =>
             {
-                var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
                 var hasMedia = !string.IsNullOrWhiteSpace(photoPath) || !string.IsNullOrWhiteSpace(videoPath);
 
                 if (hasMedia)
@@ -229,34 +217,33 @@ public class BotDmService(
                     {
                         await using var photoStream = File.OpenRead(photoPath);
                         await messageHandler.SendPhotoAsync(
-                            chatId: telegramUserId,
+                            chatId: identity.Id,
                             photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
                             caption: messageText,
                             parseMode: ParseMode.MarkdownV2,
                             ct: cancellationToken);
 
-                        logger.LogInformation("DM with photo sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                        logger.LogInformation("DM with photo sent successfully to {User}", identity.ToLogInfo());
                     }
                     else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
                     {
                         await using var videoStream = File.OpenRead(videoPath);
                         await messageHandler.SendVideoAsync(
-                            chatId: telegramUserId,
+                            chatId: identity.Id,
                             video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
                             caption: messageText,
                             parseMode: ParseMode.MarkdownV2,
                             ct: cancellationToken);
 
-                        logger.LogInformation("DM with video sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                        logger.LogInformation("DM with video sent successfully to {User}", identity.ToLogInfo());
                     }
                     else
                     {
-                        // Media path provided but file doesn't exist - fallback to text only
                         logger.LogWarning("Media file not found (photo: {PhotoPath}, video: {VideoPath}), sending text-only DM to {User}",
-                            photoPath, videoPath, user.ToLogDebug(telegramUserId));
+                            photoPath, videoPath, identity.ToLogDebug());
 
                         await messageHandler.SendAsync(
-                            chatId: telegramUserId,
+                            chatId: identity.Id,
                             text: messageText,
                             parseMode: ParseMode.MarkdownV2,
                             ct: cancellationToken);
@@ -264,24 +251,23 @@ public class BotDmService(
                 }
                 else
                 {
-                    // No media - send text only
                     await messageHandler.SendAsync(
-                        chatId: telegramUserId,
+                        chatId: identity.Id,
                         text: messageText,
                         parseMode: ParseMode.MarkdownV2,
                         ct: cancellationToken);
 
-                    logger.LogInformation("DM sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                    logger.LogInformation("DM sent successfully to {User}", identity.ToLogInfo());
                 }
             },
             cancellationToken,
             logStyle: DmLogStyle.Media,
-            mediaErrorVariant: "media",
+            mediaErrorVariant: DmMediaLogVariant.Media,
             networkErrorAware: false);
     }
 
     public Task<DmDeliveryResult> SendDmWithMediaAndKeyboardAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string messageText,
         string? photoPath = null,
@@ -291,55 +277,52 @@ public class BotDmService(
         CancellationToken cancellationToken = default)
     {
         return TrySendWithQueueAsync(
-            telegramUserId,
+            user,
             notificationType,
             queuedText: messageText,
-            sendAction: async () =>
+            sendAction: async identity =>
             {
-                var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
                 if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
                 {
                     await using var photoStream = File.OpenRead(photoPath);
                     await messageHandler.SendPhotoAsync(
-                        chatId: telegramUserId,
+                        chatId: identity.Id,
                         photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
                         caption: messageText,
                         parseMode: parseMode,
                         replyMarkup: keyboard,
                         ct: cancellationToken);
 
-                    logger.LogInformation("DM with photo and keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                    logger.LogInformation("DM with photo and keyboard sent successfully to {User}", identity.ToLogInfo());
                 }
                 else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
                 {
                     await using var videoStream = File.OpenRead(videoPath);
                     await messageHandler.SendVideoAsync(
-                        chatId: telegramUserId,
+                        chatId: identity.Id,
                         video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
                         caption: messageText,
                         parseMode: parseMode,
                         replyMarkup: keyboard,
                         ct: cancellationToken);
 
-                    logger.LogInformation("DM with video and keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                    logger.LogInformation("DM with video and keyboard sent successfully to {User}", identity.ToLogInfo());
                 }
                 else
                 {
-                    // Text-only with keyboard
                     await messageHandler.SendAsync(
-                        chatId: telegramUserId,
+                        chatId: identity.Id,
                         text: messageText,
                         parseMode: parseMode,
                         replyMarkup: keyboard,
                         ct: cancellationToken);
 
-                    logger.LogInformation("DM with keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                    logger.LogInformation("DM with keyboard sent successfully to {User}", identity.ToLogInfo());
                 }
             },
             cancellationToken,
             logStyle: DmLogStyle.Media,
-            mediaErrorVariant: "keyboard",
+            mediaErrorVariant: DmMediaLogVariant.Keyboard,
             networkErrorAware: false);
     }
 
@@ -394,29 +377,25 @@ public class BotDmService(
 
     /// <inheritdoc />
     public async Task<DmDeliveryResult> SendDmWithKeyboardAsync(
-        long telegramUserId,
+        UserIdentity user,
         string messageText,
         InlineKeyboardMarkup keyboard,
         CancellationToken cancellationToken = default)
     {
-        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
         try
         {
-            // Send DM with keyboard
             var sentMessage = await messageHandler.SendAsync(
-                chatId: telegramUserId,
+                chatId: user.Id,
                 text: messageText,
                 replyMarkup: keyboard,
                 ct: cancellationToken);
 
             logger.LogDebug(
                 "DM with keyboard sent successfully to {User} (MessageId: {MessageId})",
-                user.ToLogDebug(telegramUserId),
+                user.ToLogDebug(),
                 sentMessage.MessageId);
 
-            // Update bot_dm_enabled flag to true
-            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
+            await telegramUserRepository.EnableBotDmAsync(user.Id, cancellationToken);
 
             return new DmDeliveryResult
             {
@@ -428,12 +407,11 @@ public class BotDmService(
         }
         catch (ApiRequestException ex) when (ex.ErrorCode == 403)
         {
-            // User has blocked the bot - can't send keyboard messages, no queue fallback
             logger.LogWarning(
                 "DM blocked for {User} (403 Forbidden) - cannot send keyboard message",
-                user.ToLogDebug(telegramUserId));
+                user.ToLogDebug());
 
-            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
+            await telegramUserRepository.DisableBotDmAsync(user.Id, cancellationToken);
 
             return new DmDeliveryResult
             {
@@ -448,7 +426,7 @@ public class BotDmService(
             logger.LogError(
                 ex,
                 "Failed to send DM with keyboard to {User}",
-                user.ToLogDebug(telegramUserId));
+                user.ToLogDebug());
 
             return new DmDeliveryResult
             {
@@ -462,18 +440,18 @@ public class BotDmService(
 
     /// <inheritdoc />
     public Task<DmDeliveryResult> SendDmWithEntitiesAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string text,
         IReadOnlyList<MessageEntity> entities,
         CancellationToken cancellationToken = default)
     {
         return TrySendWithQueueAsync(
-            telegramUserId,
+            user,
             notificationType,
             queuedText: text,
-            sendAction: () => messageHandler.SendAsync(
-                chatId: telegramUserId,
+            sendAction: _ => messageHandler.SendAsync(
+                chatId: user.Id,
                 text: text,
                 parseMode: null,
                 entities: entities,
@@ -485,7 +463,7 @@ public class BotDmService(
 
     /// <inheritdoc />
     public Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string text,
         IReadOnlyList<MessageEntity> entities,
@@ -495,18 +473,16 @@ public class BotDmService(
         CancellationToken cancellationToken = default)
     {
         return TrySendWithQueueAsync(
-            telegramUserId,
+            user,
             notificationType,
             queuedText: text,
-            sendAction: async () =>
+            sendAction: async identity =>
             {
-                var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
                 if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
                 {
                     await using var photoStream = File.OpenRead(photoPath);
                     await messageHandler.SendPhotoAsync(
-                        chatId: telegramUserId,
+                        chatId: identity.Id,
                         photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
                         caption: text,
                         parseMode: null,
@@ -516,13 +492,13 @@ public class BotDmService(
 
                     logger.LogInformation(
                         "DM with photo/entities/keyboard sent successfully to {User}",
-                        user.ToLogInfo(telegramUserId));
+                        identity.ToLogInfo());
                 }
                 else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
                 {
                     await using var videoStream = File.OpenRead(videoPath);
                     await messageHandler.SendVideoAsync(
-                        chatId: telegramUserId,
+                        chatId: identity.Id,
                         video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
                         caption: text,
                         parseMode: null,
@@ -532,12 +508,12 @@ public class BotDmService(
 
                     logger.LogInformation(
                         "DM with video/entities/keyboard sent successfully to {User}",
-                        user.ToLogInfo(telegramUserId));
+                        identity.ToLogInfo());
                 }
                 else
                 {
                     await messageHandler.SendAsync(
-                        chatId: telegramUserId,
+                        chatId: identity.Id,
                         text: text,
                         parseMode: null,
                         replyMarkup: keyboard,
@@ -546,69 +522,56 @@ public class BotDmService(
 
                     logger.LogInformation(
                         "DM with entities/keyboard sent successfully to {User}",
-                        user.ToLogInfo(telegramUserId));
+                        identity.ToLogInfo());
                 }
             },
             cancellationToken,
             logStyle: DmLogStyle.Media,
-            mediaErrorVariant: "entities/media/keyboard",
+            mediaErrorVariant: DmMediaLogVariant.EntitiesMediaKeyboard,
             networkErrorAware: false);
     }
 
     /// <summary>
-    /// Log style for <see cref="TrySendWithQueueAsync"/>.
-    /// Queue-style matches the parse-mode/entities text methods (info success + warning on 403 with
-    /// "queueing" verbiage + network-aware error). Media-style matches the media/keyboard variants
-    /// (success logged internally by the sendAction + info on 403 with "blocked bot DMs" verbiage
-    /// + custom error wording).
-    /// </summary>
-    private enum DmLogStyle
-    {
-        Queue,
-        Media
-    }
-
-    /// <summary>
     /// Shared try/catch/403/queue skeleton for DM send methods.
-    /// Handles user lookup, success flag flip, 403 → queue, and generic error logging so each
+    /// Handles success flag flip, 403 → queue, and generic error logging so each
     /// public overload only has to supply the actual send action.
     /// </summary>
     /// <param name="sendAction">
-    /// Delegate that performs the actual Telegram API call. For Media-style callers, this delegate
-    /// is also responsible for logging the success message (since the message differs per path —
-    /// photo vs video vs text-only). For Queue-style callers, the helper logs a single generic
-    /// success message.
+    /// Delegate that performs the actual Telegram API call; receives the caller-provided
+    /// <see cref="UserIdentity"/> so it can log success without re-fetching. For Media-style
+    /// callers, this delegate is also responsible for logging the success message (since
+    /// the message differs per path — photo vs video vs text-only). For Queue-style callers,
+    /// the helper logs a single generic success message.
     /// </param>
     /// <param name="mediaErrorVariant">
-    /// Required when <paramref name="logStyle"/> is Media — the wording inserted into the generic
-    /// error log, e.g. "media" → "Failed to send DM with media to {User}".
+    /// Required when <paramref name="logStyle"/> is Media — controls the wording inserted
+    /// into the generic error log so structured log consumers still see the same distinct
+    /// templates the refactor preserved.
     /// </param>
     private async Task<DmDeliveryResult> TrySendWithQueueAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string queuedText,
-        Func<Task> sendAction,
+        Func<UserIdentity, Task> sendAction,
         CancellationToken cancellationToken,
         DmLogStyle logStyle,
-        string? mediaErrorVariant = null,
+        DmMediaLogVariant? mediaErrorVariant = null,
         bool networkErrorAware = false)
     {
-        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
         try
         {
-            await sendAction();
+            await sendAction(user);
 
             if (logStyle == DmLogStyle.Queue)
             {
                 logger.LogInformation(
                     "DM sent successfully to {User} (notification type: {NotificationType})",
-                    user.ToLogInfo(telegramUserId),
+                    user.ToLogInfo(),
                     notificationType);
             }
             // Media-style logs success inside sendAction (different message per photo/video/text path).
 
-            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
+            await telegramUserRepository.EnableBotDmAsync(user.Id, cancellationToken);
 
             return new DmDeliveryResult
             {
@@ -623,20 +586,20 @@ public class BotDmService(
             {
                 logger.LogWarning(
                     "DM blocked for {User} - queueing {NotificationType} notification for later delivery",
-                    user.ToLogDebug(telegramUserId),
+                    user.ToLogDebug(),
                     notificationType);
             }
             else
             {
                 logger.LogInformation(
                     "{User} has blocked bot DMs (403), queuing notification",
-                    user.ToLogInfo(telegramUserId));
+                    user.ToLogInfo());
             }
 
-            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
+            await telegramUserRepository.DisableBotDmAsync(user.Id, cancellationToken);
 
             await pendingNotificationsRepository.AddPendingNotificationAsync(
-                telegramUserId,
+                user.Id,
                 notificationType,
                 queuedText,
                 cancellationToken: cancellationToken);
@@ -657,7 +620,7 @@ public class BotDmService(
             {
                 logger.LogWarning(
                     "Failed to send DM to {User} - network unavailable (notification type: {NotificationType})",
-                    user.ToLogDebug(telegramUserId),
+                    user.ToLogDebug(),
                     notificationType);
             }
             else if (logStyle == DmLogStyle.Queue)
@@ -665,7 +628,7 @@ public class BotDmService(
                 logger.LogError(
                     ex,
                     "Failed to send DM to {User} (notification type: {NotificationType})",
-                    user.ToLogDebug(telegramUserId),
+                    user.ToLogDebug(),
                     notificationType);
             }
             else
@@ -674,17 +637,17 @@ public class BotDmService(
                 // log consumers see the same template strings as before the refactor.
                 switch (mediaErrorVariant)
                 {
-                    case "media":
-                        logger.LogError(ex, "Failed to send DM with media to {User}", user.ToLogDebug(telegramUserId));
+                    case DmMediaLogVariant.Media:
+                        logger.LogError(ex, "Failed to send DM with media to {User}", user.ToLogDebug());
                         break;
-                    case "keyboard":
-                        logger.LogError(ex, "Failed to send DM with keyboard to {User}", user.ToLogDebug(telegramUserId));
+                    case DmMediaLogVariant.Keyboard:
+                        logger.LogError(ex, "Failed to send DM with keyboard to {User}", user.ToLogDebug());
                         break;
-                    case "entities/media/keyboard":
-                        logger.LogError(ex, "Failed to send DM with entities/media/keyboard to {User}", user.ToLogDebug(telegramUserId));
+                    case DmMediaLogVariant.EntitiesMediaKeyboard:
+                        logger.LogError(ex, "Failed to send DM with entities/media/keyboard to {User}", user.ToLogDebug());
                         break;
                     default:
-                        logger.LogError(ex, "Failed to send DM to {User}", user.ToLogDebug(telegramUserId));
+                        logger.LogError(ex, "Failed to send DM to {User}", user.ToLogDebug());
                         break;
                 }
             }
@@ -704,7 +667,6 @@ public class BotDmService(
     /// </summary>
     private static bool IsNetworkError(Exception ex)
     {
-        // Check for HttpRequestException or SocketException (network errors)
         return ex is HttpRequestException
                || ex.InnerException is HttpRequestException
                || ex.InnerException?.InnerException is System.Net.Sockets.SocketException

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Telegram.Bot.Exceptions;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
 using TelegramGroupsAdmin.Core.Extensions;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.JobPayloads;
@@ -105,92 +106,25 @@ public class BotDmService(
         }
     }
 
-    public async Task<DmDeliveryResult> SendDmWithQueueAsync(
+    public Task<DmDeliveryResult> SendDmWithQueueAsync(
         long telegramUserId,
         string notificationType,
         string messageText,
         ParseMode parseMode = ParseMode.MarkdownV2,
         CancellationToken cancellationToken = default)
     {
-        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
-        try
-        {
-            // Attempt to send DM
-            await messageHandler.SendAsync(
+        return TrySendWithQueueAsync(
+            telegramUserId,
+            notificationType,
+            queuedText: messageText,
+            sendAction: () => messageHandler.SendAsync(
                 chatId: telegramUserId,
                 text: messageText,
                 parseMode: parseMode,
-                ct: cancellationToken);
-
-            logger.LogInformation(
-                "DM sent successfully to {User} (notification type: {NotificationType})",
-                user.ToLogInfo(telegramUserId),
-                notificationType);
-
-            // Update bot_dm_enabled flag to true (user can receive DMs)
-            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
-
-            return new DmDeliveryResult
-            {
-                DmSent = true,
-                FallbackUsed = false,
-                Failed = false
-            };
-        }
-        catch (ApiRequestException ex) when (ex.ErrorCode == 403)
-        {
-            // User has blocked the bot or hasn't started a DM - queue for later
-            logger.LogWarning(
-                "DM blocked for {User} - queueing {NotificationType} notification for later delivery",
-                user.ToLogDebug(telegramUserId),
-                notificationType);
-
-            // Update bot_dm_enabled flag to false and queue notification
-            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
-
-            // Queue notification for later delivery
-            await pendingNotificationsRepository.AddPendingNotificationAsync(
-                telegramUserId,
-                notificationType,
-                messageText,
-                cancellationToken: cancellationToken);
-
-            return new DmDeliveryResult
-            {
-                DmSent = false,
-                FallbackUsed = false,
-                Failed = true,
-                ErrorMessage = "User has not enabled DMs - notification queued for later delivery"
-            };
-        }
-        catch (Exception ex)
-        {
-            // Log network errors cleanly without stack traces
-            if (IsNetworkError(ex))
-            {
-                logger.LogWarning(
-                    "Failed to send DM to {User} - network unavailable (notification type: {NotificationType})",
-                    user.ToLogDebug(telegramUserId),
-                    notificationType);
-            }
-            else
-            {
-                logger.LogError(
-                    ex,
-                    "Failed to send DM to {User} (notification type: {NotificationType})",
-                    user.ToLogDebug(telegramUserId),
-                    notificationType);
-            }
-
-            return new DmDeliveryResult
-            {
-                DmSent = false,
-                FallbackUsed = false,
-                Failed = true,
-                ErrorMessage = ex.Message
-            };
-        }
+                ct: cancellationToken),
+            cancellationToken,
+            logStyle: DmLogStyle.Queue,
+            networkErrorAware: true);
     }
 
     /// <summary>
@@ -270,7 +204,7 @@ public class BotDmService(
         }
     }
 
-    public async Task<DmDeliveryResult> SendDmWithMediaAsync(
+    public Task<DmDeliveryResult> SendDmWithMediaAsync(
         long telegramUserId,
         string notificationType,
         string messageText,
@@ -278,208 +212,142 @@ public class BotDmService(
         string? videoPath = null,
         CancellationToken cancellationToken = default)
     {
-        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
-        try
-        {
-            // Determine if we're sending with media
-            var hasMedia = !string.IsNullOrWhiteSpace(photoPath) || !string.IsNullOrWhiteSpace(videoPath);
-
-            if (hasMedia)
+        // Media variants log success internally (messages differ for photo/video/text paths).
+        // The helper therefore skips the default success log and delegates entirely to sendAction.
+        return TrySendWithQueueAsync(
+            telegramUserId,
+            notificationType,
+            queuedText: messageText,
+            sendAction: async () =>
             {
-                // Send with media (photo or video)
-                if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
-                {
-                    // Send photo with caption
-                    await using var photoStream = File.OpenRead(photoPath);
-                    await messageHandler.SendPhotoAsync(
-                        chatId: telegramUserId,
-                        photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
-                        caption: messageText,
-                        parseMode: ParseMode.MarkdownV2,
-                        ct: cancellationToken);
+                var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
+                var hasMedia = !string.IsNullOrWhiteSpace(photoPath) || !string.IsNullOrWhiteSpace(videoPath);
 
-                    logger.LogInformation("DM with photo sent successfully to {User}", user.ToLogInfo(telegramUserId));
-                }
-                else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
+                if (hasMedia)
                 {
-                    // Send video with caption
-                    await using var videoStream = File.OpenRead(videoPath);
-                    await messageHandler.SendVideoAsync(
-                        chatId: telegramUserId,
-                        video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
-                        caption: messageText,
-                        parseMode: ParseMode.MarkdownV2,
-                        ct: cancellationToken);
+                    if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
+                    {
+                        await using var photoStream = File.OpenRead(photoPath);
+                        await messageHandler.SendPhotoAsync(
+                            chatId: telegramUserId,
+                            photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
+                            caption: messageText,
+                            parseMode: ParseMode.MarkdownV2,
+                            ct: cancellationToken);
 
-                    logger.LogInformation("DM with video sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                        logger.LogInformation("DM with photo sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                    }
+                    else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
+                    {
+                        await using var videoStream = File.OpenRead(videoPath);
+                        await messageHandler.SendVideoAsync(
+                            chatId: telegramUserId,
+                            video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
+                            caption: messageText,
+                            parseMode: ParseMode.MarkdownV2,
+                            ct: cancellationToken);
+
+                        logger.LogInformation("DM with video sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                    }
+                    else
+                    {
+                        // Media path provided but file doesn't exist - fallback to text only
+                        logger.LogWarning("Media file not found (photo: {PhotoPath}, video: {VideoPath}), sending text-only DM to {User}",
+                            photoPath, videoPath, user.ToLogDebug(telegramUserId));
+
+                        await messageHandler.SendAsync(
+                            chatId: telegramUserId,
+                            text: messageText,
+                            parseMode: ParseMode.MarkdownV2,
+                            ct: cancellationToken);
+                    }
                 }
                 else
                 {
-                    // Media path provided but file doesn't exist - fallback to text only
-                    logger.LogWarning("Media file not found (photo: {PhotoPath}, video: {VideoPath}), sending text-only DM to {User}",
-                        photoPath, videoPath, user.ToLogDebug(telegramUserId));
-
+                    // No media - send text only
                     await messageHandler.SendAsync(
                         chatId: telegramUserId,
                         text: messageText,
                         parseMode: ParseMode.MarkdownV2,
                         ct: cancellationToken);
+
+                    logger.LogInformation("DM sent successfully to {User}", user.ToLogInfo(telegramUserId));
                 }
-            }
-            else
-            {
-                // No media - send text only
-                await messageHandler.SendAsync(
-                    chatId: telegramUserId,
-                    text: messageText,
-                    parseMode: ParseMode.MarkdownV2,
-                    ct: cancellationToken);
-
-                logger.LogInformation("DM sent successfully to {User}", user.ToLogInfo(telegramUserId));
-            }
-
-            // Update bot_dm_enabled flag to true
-            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
-
-            return new DmDeliveryResult
-            {
-                DmSent = true,
-                FallbackUsed = false,
-                Failed = false
-            };
-        }
-        catch (ApiRequestException ex) when (ex.ErrorCode == 403)
-        {
-            // User has blocked the bot - update flag and queue notification
-            logger.LogInformation("{User} has blocked bot DMs (403), queuing notification", user.ToLogInfo(telegramUserId));
-
-            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
-
-            // Queue notification for later delivery
-            await pendingNotificationsRepository.AddPendingNotificationAsync(telegramUserId, notificationType, messageText, cancellationToken: cancellationToken);
-
-            return new DmDeliveryResult
-            {
-                DmSent = false,
-                FallbackUsed = false,
-                Failed = true,
-                ErrorMessage = "User has blocked bot DMs - notification queued for later delivery"
-            };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to send DM with media to {User}", user.ToLogDebug(telegramUserId));
-            return new DmDeliveryResult
-            {
-                DmSent = false,
-                FallbackUsed = false,
-                Failed = true,
-                ErrorMessage = ex.Message
-            };
-        }
+            },
+            cancellationToken,
+            logStyle: DmLogStyle.Media,
+            mediaErrorVariant: "media",
+            networkErrorAware: false);
     }
 
-    public async Task<DmDeliveryResult> SendDmWithMediaAndKeyboardAsync(
+    public Task<DmDeliveryResult> SendDmWithMediaAndKeyboardAsync(
         long telegramUserId,
         string notificationType,
         string messageText,
         string? photoPath = null,
         string? videoPath = null,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup? keyboard = null,
+        InlineKeyboardMarkup? keyboard = null,
         ParseMode parseMode = ParseMode.MarkdownV2,
         CancellationToken cancellationToken = default)
     {
-        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
-        try
-        {
-            // Send with photo if available
-            if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
+        return TrySendWithQueueAsync(
+            telegramUserId,
+            notificationType,
+            queuedText: messageText,
+            sendAction: async () =>
             {
-                await using var photoStream = File.OpenRead(photoPath);
-                await messageHandler.SendPhotoAsync(
-                    chatId: telegramUserId,
-                    photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
-                    caption: messageText,
-                    parseMode: parseMode,
-                    replyMarkup: keyboard,
-                    ct: cancellationToken);
+                var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
 
-                logger.LogInformation("DM with photo and keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
-            }
-            else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
-            {
-                await using var videoStream = File.OpenRead(videoPath);
-                await messageHandler.SendVideoAsync(
-                    chatId: telegramUserId,
-                    video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
-                    caption: messageText,
-                    parseMode: parseMode,
-                    replyMarkup: keyboard,
-                    ct: cancellationToken);
+                if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
+                {
+                    await using var photoStream = File.OpenRead(photoPath);
+                    await messageHandler.SendPhotoAsync(
+                        chatId: telegramUserId,
+                        photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
+                        caption: messageText,
+                        parseMode: parseMode,
+                        replyMarkup: keyboard,
+                        ct: cancellationToken);
 
-                logger.LogInformation("DM with video and keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
-            }
-            else
-            {
-                // Text-only with keyboard
-                await messageHandler.SendAsync(
-                    chatId: telegramUserId,
-                    text: messageText,
-                    parseMode: parseMode,
-                    replyMarkup: keyboard,
-                    ct: cancellationToken);
+                    logger.LogInformation("DM with photo and keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                }
+                else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
+                {
+                    await using var videoStream = File.OpenRead(videoPath);
+                    await messageHandler.SendVideoAsync(
+                        chatId: telegramUserId,
+                        video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
+                        caption: messageText,
+                        parseMode: parseMode,
+                        replyMarkup: keyboard,
+                        ct: cancellationToken);
 
-                logger.LogInformation("DM with keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
-            }
+                    logger.LogInformation("DM with video and keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                }
+                else
+                {
+                    // Text-only with keyboard
+                    await messageHandler.SendAsync(
+                        chatId: telegramUserId,
+                        text: messageText,
+                        parseMode: parseMode,
+                        replyMarkup: keyboard,
+                        ct: cancellationToken);
 
-            // Update bot_dm_enabled flag to true
-            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
-
-            return new DmDeliveryResult
-            {
-                DmSent = true,
-                FallbackUsed = false,
-                Failed = false
-            };
-        }
-        catch (ApiRequestException ex) when (ex.ErrorCode == 403)
-        {
-            // User has blocked the bot - update flag and queue notification (without buttons)
-            logger.LogInformation("{User} has blocked bot DMs (403), queuing notification", user.ToLogInfo(telegramUserId));
-
-            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
-
-            // Queue notification for later delivery (text only, no buttons)
-            await pendingNotificationsRepository.AddPendingNotificationAsync(telegramUserId, notificationType, messageText, cancellationToken: cancellationToken);
-
-            return new DmDeliveryResult
-            {
-                DmSent = false,
-                FallbackUsed = false,
-                Failed = true,
-                ErrorMessage = "User has blocked bot DMs - notification queued for later delivery"
-            };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to send DM with keyboard to {User}", user.ToLogDebug(telegramUserId));
-            return new DmDeliveryResult
-            {
-                DmSent = false,
-                FallbackUsed = false,
-                Failed = true,
-                ErrorMessage = ex.Message
-            };
-        }
+                    logger.LogInformation("DM with keyboard sent successfully to {User}", user.ToLogInfo(telegramUserId));
+                }
+            },
+            cancellationToken,
+            logStyle: DmLogStyle.Media,
+            mediaErrorVariant: "keyboard",
+            networkErrorAware: false);
     }
 
     public async Task<Message> EditDmTextAsync(
         long dmChatId,
         int messageId,
         string text,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup? replyMarkup = null,
+        InlineKeyboardMarkup? replyMarkup = null,
         CancellationToken cancellationToken = default)
     {
         var editedMessage = await messageHandler.EditTextAsync(
@@ -498,7 +366,7 @@ public class BotDmService(
         long dmChatId,
         int messageId,
         string? caption,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup? replyMarkup = null,
+        InlineKeyboardMarkup? replyMarkup = null,
         CancellationToken cancellationToken = default)
     {
         var editedMessage = await messageHandler.EditCaptionAsync(
@@ -528,7 +396,7 @@ public class BotDmService(
     public async Task<DmDeliveryResult> SendDmWithKeyboardAsync(
         long telegramUserId,
         string messageText,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup keyboard,
+        InlineKeyboardMarkup keyboard,
         CancellationToken cancellationToken = default)
     {
         var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
@@ -593,28 +461,152 @@ public class BotDmService(
     }
 
     /// <inheritdoc />
-    public async Task<DmDeliveryResult> SendDmWithEntitiesAsync(
+    public Task<DmDeliveryResult> SendDmWithEntitiesAsync(
         long telegramUserId,
         string notificationType,
         string text,
         IReadOnlyList<MessageEntity> entities,
         CancellationToken cancellationToken = default)
     {
-        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
-        try
-        {
-            await messageHandler.SendAsync(
+        return TrySendWithQueueAsync(
+            telegramUserId,
+            notificationType,
+            queuedText: text,
+            sendAction: () => messageHandler.SendAsync(
                 chatId: telegramUserId,
                 text: text,
                 parseMode: null,
                 entities: entities,
-                ct: cancellationToken);
+                ct: cancellationToken),
+            cancellationToken,
+            logStyle: DmLogStyle.Queue,
+            networkErrorAware: true);
+    }
 
-            logger.LogInformation(
-                "DM sent successfully to {User} (notification type: {NotificationType})",
-                user.ToLogInfo(telegramUserId),
-                notificationType);
+    /// <inheritdoc />
+    public Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
+        long telegramUserId,
+        string notificationType,
+        string text,
+        IReadOnlyList<MessageEntity> entities,
+        string? photoPath = null,
+        string? videoPath = null,
+        InlineKeyboardMarkup? keyboard = null,
+        CancellationToken cancellationToken = default)
+    {
+        return TrySendWithQueueAsync(
+            telegramUserId,
+            notificationType,
+            queuedText: text,
+            sendAction: async () =>
+            {
+                var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
+
+                if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
+                {
+                    await using var photoStream = File.OpenRead(photoPath);
+                    await messageHandler.SendPhotoAsync(
+                        chatId: telegramUserId,
+                        photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
+                        caption: text,
+                        parseMode: null,
+                        replyMarkup: keyboard,
+                        captionEntities: entities,
+                        ct: cancellationToken);
+
+                    logger.LogInformation(
+                        "DM with photo/entities/keyboard sent successfully to {User}",
+                        user.ToLogInfo(telegramUserId));
+                }
+                else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
+                {
+                    await using var videoStream = File.OpenRead(videoPath);
+                    await messageHandler.SendVideoAsync(
+                        chatId: telegramUserId,
+                        video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
+                        caption: text,
+                        parseMode: null,
+                        replyMarkup: keyboard,
+                        captionEntities: entities,
+                        ct: cancellationToken);
+
+                    logger.LogInformation(
+                        "DM with video/entities/keyboard sent successfully to {User}",
+                        user.ToLogInfo(telegramUserId));
+                }
+                else
+                {
+                    await messageHandler.SendAsync(
+                        chatId: telegramUserId,
+                        text: text,
+                        parseMode: null,
+                        replyMarkup: keyboard,
+                        entities: entities,
+                        ct: cancellationToken);
+
+                    logger.LogInformation(
+                        "DM with entities/keyboard sent successfully to {User}",
+                        user.ToLogInfo(telegramUserId));
+                }
+            },
+            cancellationToken,
+            logStyle: DmLogStyle.Media,
+            mediaErrorVariant: "entities/media/keyboard",
+            networkErrorAware: false);
+    }
+
+    /// <summary>
+    /// Log style for <see cref="TrySendWithQueueAsync"/>.
+    /// Queue-style matches the parse-mode/entities text methods (info success + warning on 403 with
+    /// "queueing" verbiage + network-aware error). Media-style matches the media/keyboard variants
+    /// (success logged internally by the sendAction + info on 403 with "blocked bot DMs" verbiage
+    /// + custom error wording).
+    /// </summary>
+    private enum DmLogStyle
+    {
+        Queue,
+        Media
+    }
+
+    /// <summary>
+    /// Shared try/catch/403/queue skeleton for DM send methods.
+    /// Handles user lookup, success flag flip, 403 → queue, and generic error logging so each
+    /// public overload only has to supply the actual send action.
+    /// </summary>
+    /// <param name="sendAction">
+    /// Delegate that performs the actual Telegram API call. For Media-style callers, this delegate
+    /// is also responsible for logging the success message (since the message differs per path —
+    /// photo vs video vs text-only). For Queue-style callers, the helper logs a single generic
+    /// success message.
+    /// </param>
+    /// <param name="mediaErrorVariant">
+    /// Required when <paramref name="logStyle"/> is Media — the wording inserted into the generic
+    /// error log, e.g. "media" → "Failed to send DM with media to {User}".
+    /// </param>
+    private async Task<DmDeliveryResult> TrySendWithQueueAsync(
+        long telegramUserId,
+        string notificationType,
+        string queuedText,
+        Func<Task> sendAction,
+        CancellationToken cancellationToken,
+        DmLogStyle logStyle,
+        string? mediaErrorVariant = null,
+        bool networkErrorAware = false)
+    {
+        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
+
+        try
+        {
+            await sendAction();
+
+            if (logStyle == DmLogStyle.Queue)
+            {
+                logger.LogInformation(
+                    "DM sent successfully to {User} (notification type: {NotificationType})",
+                    user.ToLogInfo(telegramUserId),
+                    notificationType);
+            }
+            // Media-style logs success inside sendAction (different message per photo/video/text path).
 
             await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
 
@@ -627,17 +619,26 @@ public class BotDmService(
         }
         catch (ApiRequestException ex) when (ex.ErrorCode == 403)
         {
-            logger.LogWarning(
-                "DM blocked for {User} - queueing {NotificationType} notification for later delivery",
-                user.ToLogDebug(telegramUserId),
-                notificationType);
+            if (logStyle == DmLogStyle.Queue)
+            {
+                logger.LogWarning(
+                    "DM blocked for {User} - queueing {NotificationType} notification for later delivery",
+                    user.ToLogDebug(telegramUserId),
+                    notificationType);
+            }
+            else
+            {
+                logger.LogInformation(
+                    "{User} has blocked bot DMs (403), queuing notification",
+                    user.ToLogInfo(telegramUserId));
+            }
 
             await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
 
             await pendingNotificationsRepository.AddPendingNotificationAsync(
                 telegramUserId,
                 notificationType,
-                text,
+                queuedText,
                 cancellationToken: cancellationToken);
 
             return new DmDeliveryResult
@@ -645,19 +646,21 @@ public class BotDmService(
                 DmSent = false,
                 FallbackUsed = false,
                 Failed = true,
-                ErrorMessage = "User has not enabled DMs - notification queued for later delivery"
+                ErrorMessage = logStyle == DmLogStyle.Queue
+                    ? "User has not enabled DMs - notification queued for later delivery"
+                    : "User has blocked bot DMs - notification queued for later delivery"
             };
         }
         catch (Exception ex)
         {
-            if (IsNetworkError(ex))
+            if (networkErrorAware && IsNetworkError(ex))
             {
                 logger.LogWarning(
                     "Failed to send DM to {User} - network unavailable (notification type: {NotificationType})",
                     user.ToLogDebug(telegramUserId),
                     notificationType);
             }
-            else
+            else if (logStyle == DmLogStyle.Queue)
             {
                 logger.LogError(
                     ex,
@@ -665,117 +668,26 @@ public class BotDmService(
                     user.ToLogDebug(telegramUserId),
                     notificationType);
             }
-
-            return new DmDeliveryResult
-            {
-                DmSent = false,
-                FallbackUsed = false,
-                Failed = true,
-                ErrorMessage = ex.Message
-            };
-        }
-    }
-
-    /// <inheritdoc />
-    public async Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
-        long telegramUserId,
-        string notificationType,
-        string text,
-        IReadOnlyList<MessageEntity> entities,
-        string? photoPath = null,
-        string? videoPath = null,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup? keyboard = null,
-        CancellationToken cancellationToken = default)
-    {
-        var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
-
-        try
-        {
-            if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
-            {
-                await using var photoStream = File.OpenRead(photoPath);
-                await messageHandler.SendPhotoAsync(
-                    chatId: telegramUserId,
-                    photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
-                    caption: text,
-                    parseMode: null,
-                    replyMarkup: keyboard,
-                    captionEntities: entities,
-                    ct: cancellationToken);
-
-                logger.LogInformation(
-                    "DM with photo/entities/keyboard sent successfully to {User}",
-                    user.ToLogInfo(telegramUserId));
-            }
-            else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
-            {
-                await using var videoStream = File.OpenRead(videoPath);
-                await messageHandler.SendVideoAsync(
-                    chatId: telegramUserId,
-                    video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
-                    caption: text,
-                    parseMode: null,
-                    replyMarkup: keyboard,
-                    captionEntities: entities,
-                    ct: cancellationToken);
-
-                logger.LogInformation(
-                    "DM with video/entities/keyboard sent successfully to {User}",
-                    user.ToLogInfo(telegramUserId));
-            }
             else
             {
-                await messageHandler.SendAsync(
-                    chatId: telegramUserId,
-                    text: text,
-                    parseMode: null,
-                    replyMarkup: keyboard,
-                    entities: entities,
-                    ct: cancellationToken);
-
-                logger.LogInformation(
-                    "DM with entities/keyboard sent successfully to {User}",
-                    user.ToLogInfo(telegramUserId));
+                // Preserve original literal error templates (one per media variant) so structured
+                // log consumers see the same template strings as before the refactor.
+                switch (mediaErrorVariant)
+                {
+                    case "media":
+                        logger.LogError(ex, "Failed to send DM with media to {User}", user.ToLogDebug(telegramUserId));
+                        break;
+                    case "keyboard":
+                        logger.LogError(ex, "Failed to send DM with keyboard to {User}", user.ToLogDebug(telegramUserId));
+                        break;
+                    case "entities/media/keyboard":
+                        logger.LogError(ex, "Failed to send DM with entities/media/keyboard to {User}", user.ToLogDebug(telegramUserId));
+                        break;
+                    default:
+                        logger.LogError(ex, "Failed to send DM to {User}", user.ToLogDebug(telegramUserId));
+                        break;
+                }
             }
-
-            await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
-
-            return new DmDeliveryResult
-            {
-                DmSent = true,
-                FallbackUsed = false,
-                Failed = false
-            };
-        }
-        catch (ApiRequestException ex) when (ex.ErrorCode == 403)
-        {
-            logger.LogInformation(
-                "{User} has blocked bot DMs (403), queuing notification",
-                user.ToLogInfo(telegramUserId));
-
-            await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
-
-            // Queue notification for later delivery (text only, no buttons/media/entities)
-            await pendingNotificationsRepository.AddPendingNotificationAsync(
-                telegramUserId,
-                notificationType,
-                text,
-                cancellationToken: cancellationToken);
-
-            return new DmDeliveryResult
-            {
-                DmSent = false,
-                FallbackUsed = false,
-                Failed = true,
-                ErrorMessage = "User has blocked bot DMs - notification queued for later delivery"
-            };
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(
-                ex,
-                "Failed to send DM with entities/media/keyboard to {User}",
-                user.ToLogDebug(telegramUserId));
 
             return new DmDeliveryResult
             {

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/BotModerationService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/BotModerationService.cs
@@ -632,7 +632,7 @@ public class BotModerationService : IBotModerationService
                 return;
             }
 
-            await _reportService.CreateReportAsync(report, intent.TelegramMessage, isAutomated: true, cancellationToken);
+            await _reportService.CreateReportAsync(report, intent.TelegramMessage, Actor.FileScanner, cancellationToken);
         }, "Create malware report");
 
         // Step 4: Notify admins via system notification

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/DmLogStyle.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/DmLogStyle.cs
@@ -1,0 +1,14 @@
+namespace TelegramGroupsAdmin.Telegram.Services.Bot;
+
+/// <summary>
+/// Log-message style for the shared DM send helper in <see cref="BotDmService"/>.
+/// Queue-style matches the parse-mode/entities text methods (info success + warning on 403 with
+/// "queueing" verbiage + network-aware error). Media-style matches the media/keyboard variants
+/// (success logged internally by the sendAction + info on 403 with "blocked bot DMs" verbiage
+/// + variant-specific error wording).
+/// </summary>
+internal enum DmLogStyle
+{
+    Queue,
+    Media
+}

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/DmMediaLogVariant.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/DmMediaLogVariant.cs
@@ -1,0 +1,13 @@
+namespace TelegramGroupsAdmin.Telegram.Services.Bot;
+
+/// <summary>
+/// Identifies which media-style DM send method is running so the shared helper can preserve
+/// the original per-method error log template (structured log consumers see the same template
+/// string they did before the helper was extracted).
+/// </summary>
+internal enum DmMediaLogVariant
+{
+    Media,
+    Keyboard,
+    EntitiesMediaKeyboard
+}

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/BotMessageHandler.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/BotMessageHandler.cs
@@ -17,6 +17,7 @@ public class BotMessageHandler(ITelegramBotClientFactory botClientFactory) : IBo
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? entities = null,
         CancellationToken ct = default)
     {
         var apiClient = await botClientFactory.GetApiClientAsync();
@@ -26,6 +27,7 @@ public class BotMessageHandler(ITelegramBotClientFactory botClientFactory) : IBo
             parseMode: parseMode,
             replyParameters: replyParameters,
             replyMarkup: replyMarkup,
+            entities: entities,
             ct: ct);
     }
 
@@ -36,6 +38,7 @@ public class BotMessageHandler(ITelegramBotClientFactory botClientFactory) : IBo
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
         CancellationToken ct = default)
     {
         var apiClient = await botClientFactory.GetApiClientAsync();
@@ -46,6 +49,7 @@ public class BotMessageHandler(ITelegramBotClientFactory botClientFactory) : IBo
             parseMode: parseMode,
             replyParameters: replyParameters,
             replyMarkup: replyMarkup,
+            captionEntities: captionEntities,
             ct: ct);
     }
 
@@ -56,6 +60,7 @@ public class BotMessageHandler(ITelegramBotClientFactory botClientFactory) : IBo
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
         CancellationToken ct = default)
     {
         var apiClient = await botClientFactory.GetApiClientAsync();
@@ -66,6 +71,7 @@ public class BotMessageHandler(ITelegramBotClientFactory botClientFactory) : IBo
             parseMode: parseMode,
             replyParameters: replyParameters,
             replyMarkup: replyMarkup,
+            captionEntities: captionEntities,
             ct: ct);
     }
 

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/IBotMessageHandler.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/IBotMessageHandler.cs
@@ -18,6 +18,7 @@ public interface IBotMessageHandler
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? entities = null,
         CancellationToken ct = default);
 
     /// <summary>Send a photo with optional caption.</summary>
@@ -28,6 +29,7 @@ public interface IBotMessageHandler
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
         CancellationToken ct = default);
 
     /// <summary>Send a video with optional caption.</summary>
@@ -38,6 +40,7 @@ public interface IBotMessageHandler
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
         CancellationToken ct = default);
 
     /// <summary>Send an animation (GIF) with optional caption.</summary>

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs
@@ -87,7 +87,7 @@ public interface IBotDmService
         string messageText,
         string? photoPath = null,
         string? videoPath = null,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup? keyboard = null,
+        InlineKeyboardMarkup? keyboard = null,
         ParseMode parseMode = ParseMode.MarkdownV2,
         CancellationToken cancellationToken = default);
 
@@ -95,22 +95,22 @@ public interface IBotDmService
     /// Edit a DM text message with optional inline keyboard change.
     /// Used for updating review notification DMs after admin action (removes buttons, shows result).
     /// </summary>
-    Task<global::Telegram.Bot.Types.Message> EditDmTextAsync(
+    Task<Message> EditDmTextAsync(
         long dmChatId,
         int messageId,
         string text,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup? replyMarkup = null,
+        InlineKeyboardMarkup? replyMarkup = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Edit a DM media message caption with optional inline keyboard change.
     /// Used for updating review notification DMs with photos/videos after admin action.
     /// </summary>
-    Task<global::Telegram.Bot.Types.Message> EditDmCaptionAsync(
+    Task<Message> EditDmCaptionAsync(
         long dmChatId,
         int messageId,
         string? caption,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup? replyMarkup = null,
+        InlineKeyboardMarkup? replyMarkup = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -135,7 +135,7 @@ public interface IBotDmService
     Task<DmDeliveryResult> SendDmWithKeyboardAsync(
         long telegramUserId,
         string messageText,
-        global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup keyboard,
+        InlineKeyboardMarkup keyboard,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs
@@ -1,6 +1,7 @@
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
+using TelegramGroupsAdmin.Core.Models;
 
 namespace TelegramGroupsAdmin.Telegram.Services.Bot;
 
@@ -8,6 +9,10 @@ namespace TelegramGroupsAdmin.Telegram.Services.Bot;
 /// Centralized DM delivery service with consistent bot_dm_enabled tracking and fallback handling.
 /// Used by: NotificationSystem, WelcomeService, and any other feature that needs DM delivery.
 /// This service is in the Bot layer and can use IBotMessageHandler directly.
+///
+/// Callers pass a <see cref="UserIdentity"/> so the service never needs to fetch the user for
+/// logging — identity flows through from the call site (build via <c>UserIdentity.FromAsync</c>
+/// when only an ID is available).
 /// </summary>
 public interface IBotDmService
 {
@@ -15,14 +20,14 @@ public interface IBotDmService
     /// Attempt to send a DM to a user. Updates bot_dm_enabled flag automatically.
     /// If DM fails and fallbackChatId is provided, posts message in chat with optional auto-delete.
     /// </summary>
-    /// <param name="telegramUserId">Telegram user ID to send DM to</param>
+    /// <param name="user">Target user identity (used for logging; Id is the DM chat)</param>
     /// <param name="messageText">Message text to send</param>
     /// <param name="fallbackChatId">Optional chat ID to post fallback message if DM fails (403)</param>
     /// <param name="autoDeleteSeconds">Optional seconds to auto-delete fallback message (uses Quartz.NET)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result indicating success, fallback usage, or failure</returns>
     Task<DmDeliveryResult> SendDmAsync(
-        long telegramUserId,
+        UserIdentity user,
         string messageText,
         long? fallbackChatId = null,
         int? autoDeleteSeconds = null,
@@ -32,14 +37,8 @@ public interface IBotDmService
     /// Attempt to send a DM to a user. If DM fails (403), queues notification for later delivery.
     /// Updates bot_dm_enabled flag automatically.
     /// </summary>
-    /// <param name="telegramUserId">Telegram user ID to send DM to</param>
-    /// <param name="notificationType">Type of notification (e.g., "warning", "mystatus")</param>
-    /// <param name="messageText">Message text to send</param>
-    /// <param name="parseMode">Telegram parse mode (default: MarkdownV2). Use Html for HTML-formatted messages.</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Result indicating success or failure (queued notifications are considered failures)</returns>
     Task<DmDeliveryResult> SendDmWithQueueAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string messageText,
         ParseMode parseMode = ParseMode.MarkdownV2,
@@ -48,18 +47,9 @@ public interface IBotDmService
     /// <summary>
     /// Attempt to send a DM with optional media (photo or video) to a user.
     /// If DM fails (403), queues notification for later delivery.
-    /// Updates bot_dm_enabled flag automatically.
-    /// Phase 5.2: Enhanced spam notifications with media support
     /// </summary>
-    /// <param name="telegramUserId">Telegram user ID to send DM to</param>
-    /// <param name="notificationType">Type of notification (e.g., "spam_banned")</param>
-    /// <param name="messageText">Message text to send (or caption if media present)</param>
-    /// <param name="photoPath">Optional local path to photo file</param>
-    /// <param name="videoPath">Optional local path to video file</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Result indicating success or failure (queued notifications are considered failures)</returns>
     Task<DmDeliveryResult> SendDmWithMediaAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string messageText,
         string? photoPath = null,
@@ -69,20 +59,9 @@ public interface IBotDmService
     /// <summary>
     /// Attempt to send a DM with optional media and inline keyboard buttons.
     /// If DM fails (403), queues notification for later delivery (without buttons).
-    /// Updates bot_dm_enabled flag automatically.
-    /// Phase X: Report moderation DM support with action buttons
     /// </summary>
-    /// <param name="telegramUserId">Telegram user ID to send DM to</param>
-    /// <param name="notificationType">Type of notification (e.g., "report")</param>
-    /// <param name="messageText">Message text to send (or caption if media present)</param>
-    /// <param name="photoPath">Optional local path to photo file</param>
-    /// <param name="videoPath">Optional local path to video file</param>
-    /// <param name="keyboard">Optional inline keyboard markup with action buttons</param>
-    /// <param name="parseMode">Telegram parse mode (default: MarkdownV2). Use Html for HTML-formatted messages.</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Result indicating success or failure</returns>
     Task<DmDeliveryResult> SendDmWithMediaAndKeyboardAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string messageText,
         string? photoPath = null,
@@ -127,13 +106,8 @@ public interface IBotDmService
     /// Does NOT queue on failure (keyboards can't be queued).
     /// Used for exam questions with answer buttons.
     /// </summary>
-    /// <param name="telegramUserId">Telegram user ID to send DM to</param>
-    /// <param name="messageText">Message text to send</param>
-    /// <param name="keyboard">Inline keyboard markup with buttons</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Result indicating success or failure, with MessageId if successful</returns>
     Task<DmDeliveryResult> SendDmWithKeyboardAsync(
-        long telegramUserId,
+        UserIdentity user,
         string messageText,
         InlineKeyboardMarkup keyboard,
         CancellationToken cancellationToken = default);
@@ -145,7 +119,7 @@ public interface IBotDmService
     /// If DM fails (403), queues the message for later delivery (text only; entities dropped).
     /// </summary>
     Task<DmDeliveryResult> SendDmWithEntitiesAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string text,
         IReadOnlyList<MessageEntity> entities,
@@ -156,7 +130,7 @@ public interface IBotDmService
     /// If DM fails (403), queues the text for later delivery (without media/buttons/entities).
     /// </summary>
     Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
-        long telegramUserId,
+        UserIdentity user,
         string notificationType,
         string text,
         IReadOnlyList<MessageEntity> entities,

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs
@@ -1,4 +1,6 @@
+using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
 
 namespace TelegramGroupsAdmin.Telegram.Services.Bot;
 
@@ -134,5 +136,32 @@ public interface IBotDmService
         long telegramUserId,
         string messageText,
         global::Telegram.Bot.Types.ReplyMarkups.InlineKeyboardMarkup keyboard,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempt to send a DM using pre-rendered text + entities (no parse_mode).
+    /// For admin notifications that need text_mention entities so user mentions are
+    /// clickable even when the recipient has never interacted with the mentioned user.
+    /// If DM fails (403), queues the message for later delivery (text only; entities dropped).
+    /// </summary>
+    Task<DmDeliveryResult> SendDmWithEntitiesAsync(
+        long telegramUserId,
+        string notificationType,
+        string text,
+        IReadOnlyList<MessageEntity> entities,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempt to send a DM with media, entities, and optional inline keyboard (no parse_mode).
+    /// If DM fails (403), queues the text for later delivery (without media/buttons/entities).
+    /// </summary>
+    Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
+        long telegramUserId,
+        string notificationType,
+        string text,
+        IReadOnlyList<MessageEntity> entities,
+        string? photoPath = null,
+        string? videoPath = null,
+        InlineKeyboardMarkup? keyboard = null,
         CancellationToken cancellationToken = default);
 }

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/ITelegramApiClient.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/ITelegramApiClient.cs
@@ -56,6 +56,7 @@ public interface ITelegramApiClient
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? entities = null,
         CancellationToken ct = default);
 
     /// <summary>Send a photo.</summary>
@@ -66,6 +67,7 @@ public interface ITelegramApiClient
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
         CancellationToken ct = default);
 
     /// <summary>Send a video.</summary>
@@ -76,6 +78,7 @@ public interface ITelegramApiClient
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
         CancellationToken ct = default);
 
     /// <summary>Send an animation (GIF).</summary>

--- a/TelegramGroupsAdmin.Telegram/Services/Bot/TelegramApiClient.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Bot/TelegramApiClient.cs
@@ -60,8 +60,9 @@ public class TelegramApiClient : ITelegramApiClient
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? entities = null,
         CancellationToken ct = default)
-        => _client.SendMessage(chatId, text, parseMode: parseMode ?? default, replyParameters: replyParameters, replyMarkup: replyMarkup, cancellationToken: ct);
+        => _client.SendMessage(chatId, text, parseMode: parseMode ?? default, replyParameters: replyParameters, replyMarkup: replyMarkup, entities: entities, cancellationToken: ct);
 
     public Task<Message> SendPhotoAsync(
         long chatId,
@@ -70,8 +71,9 @@ public class TelegramApiClient : ITelegramApiClient
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
         CancellationToken ct = default)
-        => _client.SendPhoto(chatId, photo, caption: caption, parseMode: parseMode ?? default, replyParameters: replyParameters, replyMarkup: replyMarkup, cancellationToken: ct);
+        => _client.SendPhoto(chatId, photo, caption: caption, parseMode: parseMode ?? default, replyParameters: replyParameters, replyMarkup: replyMarkup, captionEntities: captionEntities, cancellationToken: ct);
 
     public Task<Message> SendVideoAsync(
         long chatId,
@@ -80,8 +82,9 @@ public class TelegramApiClient : ITelegramApiClient
         ParseMode? parseMode = null,
         ReplyParameters? replyParameters = null,
         InlineKeyboardMarkup? replyMarkup = null,
+        IReadOnlyList<MessageEntity>? captionEntities = null,
         CancellationToken ct = default)
-        => _client.SendVideo(chatId, video, caption: caption, parseMode: parseMode ?? default, replyParameters: replyParameters, replyMarkup: replyMarkup, cancellationToken: ct);
+        => _client.SendVideo(chatId, video, caption: caption, parseMode: parseMode ?? default, replyParameters: replyParameters, replyMarkup: replyMarkup, captionEntities: captionEntities, cancellationToken: ct);
 
     public Task<Message> SendAnimationAsync(
         long chatId,

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/ReportCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/ReportCommand.cs
@@ -82,10 +82,13 @@ public class ReportCommand(
             AdminNotes: null
         );
 
+        var reporterActor = Actor.FromTelegramUser(
+            reporter.Id, reporter.Username, reporter.FirstName, reporter.LastName);
+
         var result = await reportService.CreateReportAsync(
             report,
             reportedMessage,
-            isAutomated: false,
+            reporterActor,
             cancellationToken);
 
         logger.LogInformation(

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/StartCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/StartCommand.cs
@@ -304,7 +304,7 @@ public class StartCommand : IBotCommand
                 try
                 {
                     var result = await _dmService.SendDmAsync(
-                        telegramUserId: telegramUserId,
+                        user: Core.Models.UserIdentity.FromId(telegramUserId),
                         messageText: notification.MessageText,
                         cancellationToken: cancellationToken);
 

--- a/TelegramGroupsAdmin.Telegram/Services/ExamFlowService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ExamFlowService.cs
@@ -171,7 +171,7 @@ public class ExamFlowService : IExamFlowService
                         "User {User} already has active exam session in {Chat}, skipping duplicate creation",
                         user.ToLogInfo(), chat.ToLogInfo());
 
-                    await _dmService.SendDmAsync(dmChatId,
+                    await _dmService.SendDmAsync(UserIdentity.From(user),
                         "📝 You already have an active exam session. Please scroll up to find your current question.",
                         cancellationToken: cancellationToken);
 
@@ -194,7 +194,7 @@ public class ExamFlowService : IExamFlowService
             var chatName = chat.ChatName ?? "the group";
 
             var introText = WelcomeMessageBuilder.FormatExamIntro(config, username, chatName);
-            await _dmService.SendDmAsync(dmChatId, introText, cancellationToken: cancellationToken);
+            await _dmService.SendDmAsync(UserIdentity.From(user), introText, cancellationToken: cancellationToken);
 
             // Then send first question to DM
             int messageId;
@@ -571,7 +571,7 @@ public class ExamFlowService : IExamFlowService
 
         // Send pending message to user in DM
         await _dmService.SendDmAsync(
-            messageChatId,
+            UserIdentity.From(user),
             "⏳ Your answers are being reviewed by an admin. Please wait.",
             cancellationToken: cancellationToken);
 
@@ -608,7 +608,7 @@ public class ExamFlowService : IExamFlowService
         var keyboard = new InlineKeyboardMarkup(buttons);
 
         // Exam questions are always sent to DMs with keyboard
-        var result = await _dmService.SendDmWithKeyboardAsync(dmChatId, text, keyboard, cancellationToken);
+        var result = await _dmService.SendDmWithKeyboardAsync(UserIdentity.From(user), text, keyboard, cancellationToken);
         return result.MessageId ?? throw new InvalidOperationException("Failed to send exam question - no MessageId returned");
     }
 
@@ -622,7 +622,7 @@ public class ExamFlowService : IExamFlowService
         var text = ExamMessageBuilder.FormatOpenEndedQuestion(username, examConfig.OpenEndedQuestion!);
 
         // Exam questions are always sent to DMs (no keyboard for open-ended)
-        var result = await _dmService.SendDmAsync(dmChatId, text, cancellationToken: cancellationToken);
+        var result = await _dmService.SendDmAsync(UserIdentity.From(user), text, cancellationToken: cancellationToken);
         return result.MessageId ?? throw new InvalidOperationException("Failed to send exam question - no MessageId returned");
     }
 
@@ -768,7 +768,7 @@ public class ExamFlowService : IExamFlowService
             // Profile gate still pending — notify user exam passed but awaiting review
             try
             {
-                await _dmService.SendDmAsync(user.Id,
+                await _dmService.SendDmAsync(user,
                     $"✅ You've passed the entrance exam for {chatName}! ⏳ Your profile is under admin review — you'll be able to participate once approved.",
                     cancellationToken: cancellationToken);
             }
@@ -815,11 +815,11 @@ public class ExamFlowService : IExamFlowService
         {
             if (keyboard != null)
             {
-                await _dmService.SendDmWithKeyboardAsync(user.Id, messageText, keyboard, cancellationToken);
+                await _dmService.SendDmWithKeyboardAsync(user, messageText, keyboard, cancellationToken);
             }
             else
             {
-                await _dmService.SendDmAsync(user.Id, messageText, cancellationToken: cancellationToken);
+                await _dmService.SendDmAsync(user, messageText, cancellationToken: cancellationToken);
             }
         }
         catch (Exception ex)
@@ -945,7 +945,7 @@ public class ExamFlowService : IExamFlowService
         try
         {
             await _dmService.SendDmAsync(
-                user.Id, // DM chat ID = user ID
+                user,
                 notificationText,
                 cancellationToken: cancellationToken);
         }

--- a/TelegramGroupsAdmin.Telegram/Services/IReportService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/IReportService.cs
@@ -14,12 +14,16 @@ public interface IReportService
     /// </summary>
     /// <param name="report">The report to create</param>
     /// <param name="originalMessage">The Telegram message being reported (for context in notifications)</param>
-    /// <param name="isAutomated">True if this is an automated detection, false if user-submitted</param>
+    /// <param name="reporter">
+    /// The actor submitting the report. Pass <see cref="Actor.AutoDetection"/> (or another
+    /// system actor such as <see cref="Actor.Cas"/>) for automated reports, or
+    /// <see cref="Actor.FromTelegramUser(long, string?, string?, string?)"/> for user-submitted reports.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Result containing report ID and notification counts</returns>
     Task<ReportCreationResult> CreateReportAsync(
         Report report,
         Message originalMessage,
-        bool isAutomated,
+        Actor reporter,
         CancellationToken cancellationToken = default);
 }

--- a/TelegramGroupsAdmin.Telegram/Services/Notifications/TelegramDmChannel.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/Notifications/TelegramDmChannel.cs
@@ -37,7 +37,7 @@ public class TelegramDmChannel : INotificationChannel
         // Delegate to DmDeliveryService with queue-on-failure behavior
         // NotificationHandler formats messages in HTML (<b>, EscapeHtml), so use Html parse mode
         var result = await _dmDeliveryService.SendDmWithQueueAsync(
-            telegramUserId,
+            Core.Models.UserIdentity.FromId(telegramUserId),
             notification.Type,
             notification.Message,
             ParseMode.Html,

--- a/TelegramGroupsAdmin.Telegram/Services/ReportActions/ContentReportHandler.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportActions/ContentReportHandler.cs
@@ -23,7 +23,6 @@ internal sealed class ContentReportHandler(
     IBotModerationService moderationService,
     IAuditService auditService,
     IBotMessageService botMessageService,
-    IReportCallbackContextRepository callbackContextRepo,
     ILogger<ContentReportHandler> logger) : IContentReportHandler
 {
     private sealed record ContentFetchData(Report Report, MessageRecord Message);
@@ -279,9 +278,6 @@ internal sealed class ContentReportHandler(
                 logger.LogDebug(ex, "Could not reply to reported message {MessageId} (may be deleted)", report.MessageId);
             }
         }
-
-        // Cleanup stale DM callback contexts
-        await callbackContextRepo.DeleteByReportIdAsync(report.Id, cancellationToken);
     }
 
 }

--- a/TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs
@@ -3,7 +3,6 @@ using TelegramGroupsAdmin.Core.Extensions;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Repositories;
 using TelegramGroupsAdmin.Telegram.Extensions;
-using TelegramGroupsAdmin.Telegram.Repositories;
 
 namespace TelegramGroupsAdmin.Telegram.Services.ReportActions;
 
@@ -14,7 +13,6 @@ namespace TelegramGroupsAdmin.Telegram.Services.ReportActions;
 internal sealed class ExamHandler(
     IReportsRepository reportsRepository,
     IExamFlowService examFlowService,
-    IReportCallbackContextRepository callbackContextRepo,
     ILogger<ExamHandler> logger) : IExamHandler
 {
     public async Task<ReviewActionResult> ApproveAsync(long examId, Actor executor, CancellationToken cancellationToken)
@@ -46,8 +44,6 @@ internal sealed class ExamHandler(
 
         logger.LogInformation("Exam review {ExamId}: User {User} approved by {Executor}, permissions restored",
             examId, exam.User.ToLogInfo(), executor.DisplayName);
-
-        await callbackContextRepo.DeleteByReportIdAsync(examId, cancellationToken);
 
         return new ReviewActionResult(true,
             "User approved - permissions restored, teaser deleted",
@@ -84,8 +80,6 @@ internal sealed class ExamHandler(
         logger.LogInformation("Exam review {ExamId}: User {User} denied (kicked) by {Executor}",
             examId, exam.User.ToLogInfo(), executor.DisplayName);
 
-        await callbackContextRepo.DeleteByReportIdAsync(examId, cancellationToken);
-
         return new ReviewActionResult(true,
             "User denied - kicked from chat, teaser deleted",
             ActionName: "Deny");
@@ -120,8 +114,6 @@ internal sealed class ExamHandler(
 
         logger.LogInformation("Exam review {ExamId}: User {User} denied and banned by {Executor}",
             examId, exam.User.ToLogInfo(), executor.DisplayName);
-
-        await callbackContextRepo.DeleteByReportIdAsync(examId, cancellationToken);
 
         return new ReviewActionResult(true,
             "User denied and banned, teaser deleted",

--- a/TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs
@@ -20,7 +20,6 @@ internal sealed class ProfileScanHandler(
     IBotModerationService moderationService,
     IWelcomeResponsesRepository welcomeResponsesRepository,
     IWelcomeAdmissionHandler welcomeAdmissionHandler,
-    IReportCallbackContextRepository callbackContextRepo,
     ILogger<ProfileScanHandler> logger) : IProfileScanHandler
 {
     public async Task<ReviewActionResult> BanAsync(long alertId, Actor executor, CancellationToken cancellationToken)
@@ -61,7 +60,6 @@ internal sealed class ProfileScanHandler(
             alertId, alert.User.ToLogInfo(), executor.DisplayName);
 
         await CleanupSiblingAlertsAsync(alert, "Ban", cancellationToken);
-        await callbackContextRepo.DeleteByReportIdAsync(alertId, cancellationToken);
 
         return new ReviewActionResult(true,
             $"User banned from {result.ChatsAffected} chat(s)",
@@ -113,7 +111,6 @@ internal sealed class ProfileScanHandler(
             alertId, alert.User.ToLogInfo(), executor.DisplayName);
 
         await CleanupSiblingAlertsAsync(alert, "Kick", cancellationToken);
-        await callbackContextRepo.DeleteByReportIdAsync(alertId, cancellationToken);
 
         var message = alert.Chat.Id == 0
             ? "Alert resolved (no chat to kick from)"
@@ -170,7 +167,6 @@ internal sealed class ProfileScanHandler(
         if (statusResult != null) return statusResult;
 
         await CleanupSiblingAlertsAsync(alert, "Allow", cancellationToken);
-        await callbackContextRepo.DeleteByReportIdAsync(alertId, cancellationToken);
 
         return new ReviewActionResult(true, message, ActionName: "Allow");
     }

--- a/TelegramGroupsAdmin.Telegram/Services/ReportCallbackService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportCallbackService.cs
@@ -82,8 +82,9 @@ public sealed class ReportCallbackService(
         // Update DM message to show result (removes buttons)
         await UpdateMessageWithResultAsync(callbackQuery, result.Message, dmService, cancellationToken);
 
-        // Delete callback context (the service handles report-level cleanup)
-        await callbackContextRepo.DeleteAsync(contextId, cancellationToken);
+        // Note: callback context is NOT deleted here. Orphan-based cleanup
+        // (DataCleanupJob) removes it when the underlying report is gone,
+        // avoiding a race where another admin is mid-click on the same context.
     }
 
     private async Task<ReviewActionResult> RouteToServiceAsync(

--- a/TelegramGroupsAdmin.Telegram/Services/ReportService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/ReportService.cs
@@ -25,7 +25,7 @@ public class ReportService(
     public async Task<ReportCreationResult> CreateReportAsync(
         Report report,
         Message originalMessage,
-        bool isAutomated,
+        Actor reporter,
         CancellationToken cancellationToken = default)
     {
         // Guard: every report must have a known sender for moderation actions to work
@@ -36,26 +36,21 @@ public class ReportService(
             return new ReportCreationResult(0);
         }
 
+        var isAutomated = reporter.Type == ActorType.System;
+
         // 1. Insert report into database
         var reportId = await reportsRepository.InsertContentReportAsync(report, cancellationToken);
 
         reportMetrics.RecordReportCreated("content", isAutomated ? "auto" : "user");
 
         logger.LogInformation(
-            "Report {ReportId} created: ChatId={ChatId}, MessageId={MessageId}, IsAutomated={IsAutomated}, ReportedBy={ReportedBy}",
+            "Report {ReportId} created: ChatId={ChatId}, MessageId={MessageId}, Reporter={Reporter}",
             reportId,
             report.Chat.Id,
             report.MessageId,
-            isAutomated,
-            report.ReportedByUserName ?? "Auto-Detection");
+            reporter.GetDisplayText());
 
-        // 2. Log audit event
-        var actor = isAutomated
-            ? Actor.AutoDetection
-            : report.ReportedByUserId.HasValue
-                ? Actor.FromTelegramUser(report.ReportedByUserId.Value, report.ReportedByUserName)
-                : Actor.Unknown;
-
+        // 2. Log audit event — reporter actor is already built, pass directly
         var target = Actor.FromTelegramUser(
             originalMessage.From.Id,
             originalMessage.From.Username,
@@ -64,7 +59,7 @@ public class ReportService(
 
         await auditService.LogEventAsync(
             AuditEventType.ReportCreated,
-            actor,
+            reporter,
             target,
             value: $"Report #{reportId} for message {report.MessageId} in chat {report.Chat.Id}",
             cancellationToken: cancellationToken);
@@ -87,9 +82,7 @@ public class ReportService(
         _ = notificationService.SendReportNotificationAsync(
             chat: report.Chat,
             reportedUser: reportedUser,
-            reporterUserId: report.ReportedByUserId,
-            reporterName: report.ReportedByUserName,
-            isAutomated: isAutomated,
+            reporter: reporter,
             messagePreview: messagePreview,
             photoPath: photoPath,
             reportId: reportId,

--- a/TelegramGroupsAdmin.Telegram/Services/UserMessagingService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UserMessagingService.cs
@@ -47,7 +47,7 @@ public class UserMessagingService : IUserMessagingService
         {
             // Try DM via IBotDmService (no fallback - we'll handle mention fallback ourselves)
             var dmResult = await _dmService.SendDmAsync(
-                telegramUserId: userId,
+                user: user != null ? Core.Models.UserIdentity.From(user) : Core.Models.UserIdentity.FromId(userId),
                 messageText: messageText,
                 fallbackChatId: null,
                 cancellationToken: cancellationToken);
@@ -92,7 +92,7 @@ public class UserMessagingService : IUserMessagingService
             {
                 // Try DM via IBotDmService
                 var dmResult = await _dmService.SendDmAsync(
-                    telegramUserId: userId,
+                    user: user != null ? Core.Models.UserIdentity.From(user) : Core.Models.UserIdentity.FromId(userId),
                     messageText: messageText,
                     fallbackChatId: null,
                     cancellationToken: cancellationToken);

--- a/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/WelcomeService.cs
@@ -1208,7 +1208,7 @@ public class WelcomeService(
                 groupChat.ToLogDebug());
 
             // Send error to user in DM
-            await dmDeliveryService.SendDmAsync(user.Id, ErrorNoWelcomeRecord, cancellationToken: cancellationToken);
+            await dmDeliveryService.SendDmAsync(UserIdentity.From(user), ErrorNoWelcomeRecord, cancellationToken: cancellationToken);
             return;
         }
 
@@ -1246,7 +1246,7 @@ public class WelcomeService(
             var holdText = WelcomeMessageBuilder.FormatProfileHoldMessage(
                 TelegramDisplayName.FormatMention(user));
             await TryEditMessageAsync(groupChatId, welcomeResponse.WelcomeMessageId, holdText, cancellationToken);
-            await dmDeliveryService.SendDmAsync(user.Id,
+            await dmDeliveryService.SendDmAsync(UserIdentity.From(user),
                 "⏳ Your profile is under admin review. You'll be able to participate once approved.",
                 cancellationToken: cancellationToken);
 
@@ -1296,7 +1296,7 @@ public class WelcomeService(
             }
 
             var confirmationText = WelcomeMessageBuilder.FormatDmAcceptanceConfirmation(chatName);
-            await dmDeliveryService.SendDmAsync(user.Id, confirmationText, cancellationToken: cancellationToken);
+            await dmDeliveryService.SendDmAsync(UserIdentity.From(user), confirmationText, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {
@@ -1321,7 +1321,7 @@ public class WelcomeService(
 
         // Delegate to DmDeliveryService with chat fallback and 30-second auto-delete
         var result = await dmDeliveryService.SendDmAsync(
-            telegramUserId: user.Id,
+            user: UserIdentity.From(user),
             messageText: dmText,
             fallbackChatId: chat.Id,
             autoDeleteSeconds: 30,

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/Jobs/DataCleanupJobTests.cs
@@ -126,8 +126,8 @@ public class DataCleanupJobTests
             Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
         await _reportsRepo.Received(1).DeleteOldReportsAsync(
             Arg.Any<DateTimeOffset>(), type: null, Arg.Any<CancellationToken>());
-        await _callbackContextRepo.Received(1).DeleteExpiredAsync(
-            Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        await _callbackContextRepo.Received(1).DeleteOrphanedAsync(
+            Arg.Any<CancellationToken>());
         await _notificationRepo.Received(1).DeleteOldReadNotificationsAsync(
             Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
         await _fileScanResultRepo.Received(1).CleanupExpiredResultsAsync(

--- a/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationPayloadBuilderTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationPayloadBuilderTests.cs
@@ -48,51 +48,52 @@ public class NotificationPayloadBuilderTests
         Assert.That(fieldList.Fields, Has.Count.EqualTo(1));
         Assert.That(fieldList.Fields[0].Label, Is.EqualTo("Name"));
         Assert.That(fieldList.Fields[0].Value, Is.EqualTo("Alice"));
-        Assert.That(fieldList.Fields[0].TelegramUserId, Is.Null);
+        Assert.That(fieldList.Fields[0].User, Is.Null);
     }
 
     [Test]
-    public void WithField_TelegramUserId_SetsOnField()
+    public void WithField_UserIdentity_StoresFieldWithEmbeddedUser()
     {
+        var user = new UserIdentity(
+            Id: 12345,
+            FirstName: "Alice",
+            LastName: "Smith",
+            Username: "alice_s");
+
+        var payload = NotificationPayloadBuilder.Create("Alert")
+            .WithField("User", user)
+            .Build();
+
+        var field = payload.Blocks
+            .OfType<FieldList>()
+            .Single()
+            .Fields
+            .Single();
+
+        Assert.That(field.Label, Is.EqualTo("User"));
+        Assert.That(field.Value, Is.EqualTo(user.DisplayName));
+        Assert.That(field.User, Is.SameAs(user));
+    }
+
+    [Test]
+    public void WithField_UserIdentity_RoundTripsAllIdentityFields()
+    {
+        var user = new UserIdentity(
+            Id: 987654321,
+            FirstName: "Bob",
+            LastName: "Jones",
+            Username: "bobj");
+
         var payload = NotificationPayloadBuilder.Create("Subject")
-            .WithField("User", "SpammerBob", telegramUserId: 12345)
+            .WithField("User", user)
             .Build();
 
         var field = ((FieldList)payload.Blocks[0]).Fields[0];
-        Assert.That(field.TelegramUserId, Is.EqualTo(12345));
-    }
-
-    [Test]
-    public void WithFieldIf_ConditionTrue_AddsField()
-    {
-        var payload = NotificationPayloadBuilder.Create("Subject")
-            .WithFieldIf(true, "Reason", "Spam detected")
-            .Build();
-
-        Assert.That(payload.Blocks, Has.Count.EqualTo(1));
-        var field = ((FieldList)payload.Blocks[0]).Fields[0];
-        Assert.That(field.Label, Is.EqualTo("Reason"));
-        Assert.That(field.Value, Is.EqualTo("Spam detected"));
-    }
-
-    [Test]
-    public void WithFieldIf_ConditionFalse_DoesNotAddBlock()
-    {
-        var payload = NotificationPayloadBuilder.Create("Subject")
-            .WithFieldIf(false, "Reason", "Spam detected")
-            .Build();
-
-        Assert.That(payload.Blocks, Is.Empty);
-    }
-
-    [Test]
-    public void WithFieldIf_ConditionTrue_NullValue_DoesNotAddBlock()
-    {
-        var payload = NotificationPayloadBuilder.Create("Subject")
-            .WithFieldIf(true, "Reason", null)
-            .Build();
-
-        Assert.That(payload.Blocks, Is.Empty);
+        Assert.That(field.User, Is.Not.Null);
+        Assert.That(field.User!.Id, Is.EqualTo(987654321));
+        Assert.That(field.User.FirstName, Is.EqualTo("Bob"));
+        Assert.That(field.User.LastName, Is.EqualTo("Jones"));
+        Assert.That(field.User.Username, Is.EqualTo("bobj"));
     }
 
     [Test]
@@ -112,20 +113,6 @@ public class NotificationPayloadBuilderTests
         Assert.That(section.Content, Has.Count.EqualTo(2));
         Assert.That(section.Content[0], Is.InstanceOf<FieldList>());
         Assert.That(section.Content[1], Is.InstanceOf<TextBlock>());
-    }
-
-    [Test]
-    public void WithSection_WithFieldIf_ConditionalsWorkInsideSection()
-    {
-        var payload = NotificationPayloadBuilder.Create("Subject")
-            .WithSection("Details", s => s
-                .WithFieldIf(true, "Visible", "yes")
-                .WithFieldIf(false, "Hidden", "no"))
-            .Build();
-
-        var section = (SectionBlock)payload.Blocks[0];
-        Assert.That(section.Content, Has.Count.EqualTo(1));
-        Assert.That(((FieldList)section.Content[0]).Fields[0].Label, Is.EqualTo("Visible"));
     }
 
     [Test]
@@ -149,16 +136,6 @@ public class NotificationPayloadBuilderTests
     }
 
     [Test]
-    public void WithPhoto_NullPath_SetsNull()
-    {
-        var payload = NotificationPayloadBuilder.Create("Subject")
-            .WithPhoto(null)
-            .Build();
-
-        Assert.That(payload.PhotoPath, Is.Null);
-    }
-
-    [Test]
     public void WithKeyboard_SetsKeyboardContext()
     {
         var keyboard = new ActionKeyboardContext(EntityId: 42, ChatId: 100, UserId: 200, KeyboardType: ReportType.ContentReport);
@@ -175,8 +152,10 @@ public class NotificationPayloadBuilderTests
     [Test]
     public void Build_ComplexPayload_PreservesBlockOrder()
     {
+        var user = new UserIdentity(Id: 111, FirstName: "Alice", LastName: null, Username: null);
+
         var payload = NotificationPayloadBuilder.Create("Spam Banned")
-            .WithField("User", "Alice", telegramUserId: 111)
+            .WithField("User", user)
             .WithText("Banned from all managed chats")
             .WithSection("Detection", s => s
                 .WithField("Confidence", "95%"))
@@ -189,6 +168,7 @@ public class NotificationPayloadBuilderTests
         Assert.That(payload.Blocks[1], Is.InstanceOf<TextBlock>());
         Assert.That(payload.Blocks[2], Is.InstanceOf<SectionBlock>());
         Assert.That(payload.Blocks[3], Is.InstanceOf<FieldList>());
+        Assert.That(((FieldList)payload.Blocks[0]).Fields[0].User?.Id, Is.EqualTo(111));
         Assert.That(payload.PhotoPath, Is.EqualTo("/data/media/spam.jpg"));
     }
 

--- a/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationRendererTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationRendererTests.cs
@@ -1,3 +1,6 @@
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Services.Notifications;
 
 namespace TelegramGroupsAdmin.UnitTests.Services.Notifications;
@@ -5,125 +8,109 @@ namespace TelegramGroupsAdmin.UnitTests.Services.Notifications;
 [TestFixture]
 public class NotificationRendererTests
 {
-    #region ToTelegramHtml Tests
+    #region ToTelegramMessage Tests
 
     [Test]
-    public void ToTelegramHtml_SubjectOnly_RendersBoldSubject()
+    public void ToTelegramMessage_SubjectIsBoldOnFirstLine()
     {
-        var payload = NotificationPayloadBuilder.Create("Test Alert").Build();
+        var payload = NotificationPayloadBuilder.Create("Alert Title").Build();
 
-        var html = NotificationRenderer.ToTelegramHtml(payload);
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
 
-        Assert.That(html, Does.StartWith("<b>Test Alert</b>"));
+        Assert.That(rendered.Text, Does.StartWith("Alert Title"));
+        Assert.That(rendered.Entities, Has.Some.Matches<MessageEntity>(e =>
+            e.Type == MessageEntityType.Bold &&
+            e.Offset == 0 &&
+            e.Length == "Alert Title".Length));
     }
 
     [Test]
-    public void ToTelegramHtml_TextBlock_RendersEscapedText()
+    public void ToTelegramMessage_FieldWithoutUser_EmitsBoldLabelAndPlainValue()
     {
         var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithText("User <script> injected & broke things")
+            .WithField("Chat", "MyGroup")
             .Build();
 
-        var html = NotificationRenderer.ToTelegramHtml(payload);
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
 
-        Assert.That(html, Does.Contain("User &lt;script&gt; injected &amp; broke things"));
+        // Label is bold
+        var labelEntity = rendered.Entities.FirstOrDefault(e =>
+            e.Type == MessageEntityType.Bold &&
+            rendered.Text.Substring(e.Offset, e.Length) == "Chat:");
+        Assert.That(labelEntity, Is.Not.Null);
+
+        // No TextMention anywhere
+        Assert.That(rendered.Entities, Has.None.Matches<MessageEntity>(e =>
+            e.Type == MessageEntityType.TextMention));
+
+        Assert.That(rendered.Text, Does.Contain("Chat: MyGroup"));
     }
 
     [Test]
-    public void ToTelegramHtml_Field_RendersBoldLabel()
+    public void ToTelegramMessage_FieldWithUser_EmitsTextMentionWithEmbeddedUser()
+    {
+        var user = new UserIdentity(
+            Id: 12345,
+            FirstName: "Alice",
+            LastName: "Smith",
+            Username: "alice_s");
+        var payload = NotificationPayloadBuilder.Create("Alert")
+            .WithField("User", user)
+            .Build();
+
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+        var mention = rendered.Entities.FirstOrDefault(e =>
+            e.Type == MessageEntityType.TextMention);
+        Assert.That(mention, Is.Not.Null, "user field should produce TextMention");
+        Assert.That(mention!.User, Is.Not.Null);
+        Assert.That(mention.User!.Id, Is.EqualTo(12345));
+        Assert.That(mention.User.FirstName, Is.EqualTo("Alice"));
+        Assert.That(mention.User.LastName, Is.EqualTo("Smith"));
+        Assert.That(mention.User.Username, Is.EqualTo("alice_s"));
+
+        var span = rendered.Text.Substring(mention.Offset, mention.Length);
+        Assert.That(span, Is.EqualTo(user.DisplayName));
+    }
+
+    [Test]
+    public void ToTelegramMessage_SectionHeaderIsBold()
     {
         var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithField("Confidence", "95%")
+            .WithSection("Analysis", s => s.WithField("Score", "1.0"))
             .Build();
 
-        var html = NotificationRenderer.ToTelegramHtml(payload);
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
 
-        Assert.That(html, Does.Contain("<b>Confidence:</b> 95%"));
+        var headerEntity = rendered.Entities.FirstOrDefault(e =>
+            e.Type == MessageEntityType.Bold &&
+            rendered.Text.Substring(e.Offset, e.Length) == "Analysis");
+        Assert.That(headerEntity, Is.Not.Null);
     }
 
     [Test]
-    public void ToTelegramHtml_FieldWithTelegramUserId_RendersTgUserLink()
+    public void ToTelegramMessage_EntityOffsetsMatchTextForNonBmpCharacters()
     {
+        // UserIdentity display name will include the emoji; offset/length must be correct
+        var user = new UserIdentity(Id: 1, FirstName: "\U0001F464User", LastName: null, Username: null);
         var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithField("User", "SpammerBob", telegramUserId: 12345)
+            .WithField("User", user)
             .Build();
 
-        var html = NotificationRenderer.ToTelegramHtml(payload);
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
 
-        Assert.That(html, Does.Contain("<a href=\"tg://user?id=12345\">SpammerBob</a>"));
-        Assert.That(html, Does.Contain("<b>User:</b>"));
+        var mention = rendered.Entities.Single(e =>
+            e.Type == MessageEntityType.TextMention);
+        var span = rendered.Text.Substring(mention.Offset, mention.Length);
+        Assert.That(span, Is.EqualTo(user.DisplayName));
     }
 
     [Test]
-    public void ToTelegramHtml_FieldWithoutTelegramUserId_NoLink()
+    public void ToTelegramMessage_ComplexPayload_OrderPreserved()
     {
-        var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithField("Chat", "Test Group")
-            .Build();
-
-        var html = NotificationRenderer.ToTelegramHtml(payload);
-
-        Assert.That(html, Does.Not.Contain("tg://user"));
-        Assert.That(html, Does.Contain("<b>Chat:</b> Test Group"));
-    }
-
-    [Test]
-    public void ToTelegramHtml_Section_RendersBoldHeaderAndContent()
-    {
-        var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithSection("Detection", s => s
-                .WithField("Method", "OpenAI")
-                .WithText("High confidence detection"))
-            .Build();
-
-        var html = NotificationRenderer.ToTelegramHtml(payload);
-
-        Assert.That(html, Does.Contain("<b>Detection</b>"));
-        Assert.That(html, Does.Contain("<b>Method:</b> OpenAI"));
-        Assert.That(html, Does.Contain("High confidence detection"));
-    }
-
-    [Test]
-    public void ToTelegramHtml_HtmlSpecialCharsInSubject_AreEscaped()
-    {
-        var payload = NotificationPayloadBuilder.Create("Alert: <User> & \"Details\"").Build();
-
-        var html = NotificationRenderer.ToTelegramHtml(payload);
-
-        Assert.That(html, Does.Contain("Alert: &lt;User&gt; &amp; &quot;Details&quot;"));
-        Assert.That(html, Does.Not.Contain("<User>"));
-    }
-
-    [Test]
-    public void ToTelegramHtml_FieldValueWithSpecialChars_EscapesCorrectly()
-    {
-        var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithField("Reason", "Contains <script>alert('xss')</script>")
-            .Build();
-
-        var html = NotificationRenderer.ToTelegramHtml(payload);
-
-        Assert.That(html, Does.Not.Contain("<script>"));
-        Assert.That(html, Does.Contain("&lt;script&gt;"));
-    }
-
-    [Test]
-    public void ToTelegramHtml_TgUserLink_EscapesDisplayName()
-    {
-        var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithField("User", "<Evil> & Name", telegramUserId: 999)
-            .Build();
-
-        var html = NotificationRenderer.ToTelegramHtml(payload);
-
-        Assert.That(html, Does.Contain("<a href=\"tg://user?id=999\">&lt;Evil&gt; &amp; Name</a>"));
-    }
-
-    [Test]
-    public void ToTelegramHtml_ComplexPayload_OrderPreserved()
-    {
+        var alice = new UserIdentity(Id: 111, FirstName: "Alice", LastName: null, Username: null);
         var payload = NotificationPayloadBuilder.Create("Spam Banned")
-            .WithField("User", "Alice", telegramUserId: 111)
+            .WithField("User", alice)
             .WithField("Chat", "Test Group")
             .WithSection("Detection", s => s
                 .WithField("Confidence", "95%")
@@ -132,17 +119,18 @@ public class NotificationRendererTests
                 .WithText("Banned from 3 chats"))
             .Build();
 
-        var html = NotificationRenderer.ToTelegramHtml(payload);
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
 
         // Verify structural ordering
-        var userIdx = html.IndexOf("Alice", StringComparison.Ordinal);
-        var chatIdx = html.IndexOf("Test Group", StringComparison.Ordinal);
-        var detectionIdx = html.IndexOf("Detection", StringComparison.Ordinal);
-        var actionIdx = html.IndexOf("Action", StringComparison.Ordinal);
+        var userIdx = rendered.Text.IndexOf(alice.DisplayName, StringComparison.Ordinal);
+        var chatIdx = rendered.Text.IndexOf("Test Group", StringComparison.Ordinal);
+        var detectionIdx = rendered.Text.IndexOf("Detection", StringComparison.Ordinal);
+        var actionIdx = rendered.Text.IndexOf("Action", StringComparison.Ordinal);
 
-        Assert.That(userIdx, Is.LessThan(chatIdx));
-        Assert.That(chatIdx, Is.LessThan(detectionIdx));
-        Assert.That(detectionIdx, Is.LessThan(actionIdx));
+        Assert.That(userIdx, Is.GreaterThanOrEqualTo(0));
+        Assert.That(chatIdx, Is.GreaterThan(userIdx));
+        Assert.That(detectionIdx, Is.GreaterThan(chatIdx));
+        Assert.That(actionIdx, Is.GreaterThan(detectionIdx));
     }
 
     #endregion
@@ -200,10 +188,11 @@ public class NotificationRendererTests
     }
 
     [Test]
-    public void ToEmailHtml_FieldWithTelegramUserId_NoTgLink()
+    public void ToEmailHtml_FieldWithUser_NoTgLink()
     {
+        var user = new UserIdentity(Id: 12345, FirstName: "Alice", LastName: null, Username: null);
         var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithField("User", "Alice", telegramUserId: 12345)
+            .WithField("User", user)
             .Build();
 
         var html = NotificationRenderer.ToEmailHtml(payload);
@@ -290,16 +279,18 @@ public class NotificationRendererTests
     }
 
     [Test]
-    public void ToPlainText_FieldWithTelegramUserId_NoLink()
+    public void ToPlainText_FieldWithUser_NoLink()
     {
+        var user = new UserIdentity(Id: 12345, FirstName: "Alice", LastName: null, Username: null);
         var payload = NotificationPayloadBuilder.Create("Alert")
-            .WithField("User", "Alice", telegramUserId: 12345)
+            .WithField("User", user)
             .Build();
 
         var text = NotificationRenderer.ToPlainText(payload);
 
         Assert.That(text, Does.Not.Contain("tg://user"));
-        Assert.That(text, Does.Contain("User: Alice"));
+        Assert.That(text, Does.Contain("User: "));
+        Assert.That(text, Does.Contain("Alice"));
     }
 
     [Test]

--- a/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationRendererTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationRendererTests.cs
@@ -133,6 +133,52 @@ public class NotificationRendererTests
         Assert.That(actionIdx, Is.GreaterThan(detectionIdx));
     }
 
+    [Test]
+    public void ToTelegramMessage_ReporterFromTelegramActor_RendersClickableMention()
+    {
+        // NotificationService.SendReportNotificationAsync builds a UserIdentity from an Actor
+        // using Actor.DisplayName as the UserIdentity.FirstName so TelegramDisplayName.Format
+        // returns the actor's display name via the full-name branch. The rendered TextMention
+        // needs Actor.TelegramUserId for profile linking and the displayed text at the entity's
+        // offset/length window must equal the actor's display name.
+        var reporterActor = Actor.FromTelegramUser(54321L, "alice_a", "Alice", "Anderson");
+        var reporterAsIdentity = new UserIdentity(
+            reporterActor.TelegramUserId!.Value,
+            FirstName: reporterActor.DisplayName,
+            LastName: null,
+            Username: null);
+
+        var payload = NotificationPayloadBuilder.Create("Message Reported")
+            .WithField("Reported by", reporterAsIdentity)
+            .Build();
+
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+        var mention = rendered.Entities.Single(e => e.Type == MessageEntityType.TextMention);
+        Assert.That(mention.User, Is.Not.Null);
+        Assert.That(mention.User!.Id, Is.EqualTo(54321L));
+
+        var span = rendered.Text.Substring(mention.Offset, mention.Length);
+        Assert.That(span, Is.EqualTo("Alice Anderson"), "mention text must equal actor display name");
+    }
+
+    [Test]
+    public void ToTelegramMessage_ReporterFromSystemActor_RendersPlainTextNotClickable()
+    {
+        // Automated reporter (Auto-Detection, CAS, etc.) should NOT render as a clickable mention.
+        // NotificationService calls builder.WithField("Reported by", actor.GetDisplayText()) for
+        // non-Telegram actor types, which produces a plain label+value field.
+        var payload = NotificationPayloadBuilder.Create("Message Reported")
+            .WithField("Reported by", Actor.AutoDetection.GetDisplayText())
+            .Build();
+
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+        Assert.That(rendered.Text, Does.Contain("Auto-Detection"));
+        Assert.That(rendered.Entities, Has.None.Matches<MessageEntity>(e =>
+            e.Type == MessageEntityType.TextMention));
+    }
+
     #endregion
 
     #region ToEmailHtml Tests

--- a/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationServiceRoutingTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationServiceRoutingTests.cs
@@ -26,6 +26,7 @@ public class NotificationServiceRoutingTests
     private IBotDmService _mockDmService = null!;
     private IWebPushNotificationService _mockWebPushService = null!;
     private ITelegramUserMappingRepository _mockTelegramMappingRepo = null!;
+    private ITelegramUserRepository _mockTelegramUserRepo = null!;
     private IChatAdminsRepository _mockChatAdminsRepo = null!;
     private IUserRepository _mockUserRepo = null!;
     private IReportCallbackContextRepository _mockCallbackContextRepo = null!;
@@ -41,6 +42,7 @@ public class NotificationServiceRoutingTests
         _mockDmService = Substitute.For<IBotDmService>();
         _mockWebPushService = Substitute.For<IWebPushNotificationService>();
         _mockTelegramMappingRepo = Substitute.For<ITelegramUserMappingRepository>();
+        _mockTelegramUserRepo = Substitute.For<ITelegramUserRepository>();
         _mockChatAdminsRepo = Substitute.For<IChatAdminsRepository>();
         _mockUserRepo = Substitute.For<IUserRepository>();
         _mockCallbackContextRepo = Substitute.For<IReportCallbackContextRepository>();
@@ -52,7 +54,7 @@ public class NotificationServiceRoutingTests
 
         // Default: DM delivery succeeds (prevents NRE from null DmDeliveryResult)
         _mockDmService.SendDmWithEntitiesAsync(
-                Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<UserIdentity>(), Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
                 Arg.Any<CancellationToken>())
             .Returns(new DmDeliveryResult { DmSent = true });
@@ -68,6 +70,7 @@ public class NotificationServiceRoutingTests
             _mockDmService,
             _mockWebPushService,
             _mockTelegramMappingRepo,
+            _mockTelegramUserRepo,
             _mockChatAdminsRepo,
             _mockUserRepo,
             _mockCallbackContextRepo,
@@ -196,7 +199,7 @@ public class NotificationServiceRoutingTests
 
         // Assert — DM sent to unlinked admin via SendDmWithEntitiesAsync (plain text, no media/keyboard)
         await _mockDmService.Received(1).SendDmWithEntitiesAsync(
-            555L,
+            Arg.Is<UserIdentity>(u => u.Id == 555L),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
@@ -228,7 +231,7 @@ public class NotificationServiceRoutingTests
 
         // Assert — no DM sent to admin (already in pool 1 via web account)
         await _mockDmService.DidNotReceive().SendDmWithEntitiesAsync(
-            555L,
+            Arg.Is<UserIdentity>(u => u.Id == 555L),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
@@ -255,7 +258,7 @@ public class NotificationServiceRoutingTests
 
         // Assert — no DM sent (bot DM not enabled)
         await _mockDmService.DidNotReceive().SendDmWithEntitiesAsync(
-            555L,
+            Arg.Is<UserIdentity>(u => u.Id == 555L),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
@@ -288,7 +291,7 @@ public class NotificationServiceRoutingTests
 
         // Assert — no DM sent (deduped by Telegram ID from pool 1)
         await _mockDmService.DidNotReceive().SendDmWithEntitiesAsync(
-            555L,
+            Arg.Is<UserIdentity>(u => u.Id == 555L),
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),

--- a/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationServiceRoutingTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationServiceRoutingTests.cs
@@ -7,7 +7,6 @@ using TelegramGroupsAdmin.Services;
 using TelegramGroupsAdmin.Services.Email;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
-using Telegram.Bot.Types.Enums;
 using TelegramGroupsAdmin.Telegram.Services;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
 
@@ -52,9 +51,10 @@ public class NotificationServiceRoutingTests
             .Returns(new NotificationConfig());
 
         // Default: DM delivery succeeds (prevents NRE from null DmDeliveryResult)
-        _mockDmService.SendDmWithQueueAsync(
+        _mockDmService.SendDmWithEntitiesAsync(
                 Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(),
-                Arg.Any<ParseMode>(), Arg.Any<CancellationToken>())
+                Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
+                Arg.Any<CancellationToken>())
             .Returns(new DmDeliveryResult { DmSent = true });
 
         // Default: no telegram mappings (prevents N+1 from returning unexpected data)
@@ -194,9 +194,13 @@ public class NotificationServiceRoutingTests
         // Act
         await _service.SendMalwareDetectedAsync(chat, user, "Trojan.GenericKD", CancellationToken.None);
 
-        // Assert — DM sent to unlinked admin via SendDmWithQueueAsync (plain text, no media/keyboard)
-        await _mockDmService.Received(1).SendDmWithQueueAsync(
-            555L, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ParseMode>(), Arg.Any<CancellationToken>());
+        // Assert — DM sent to unlinked admin via SendDmWithEntitiesAsync (plain text, no media/keyboard)
+        await _mockDmService.Received(1).SendDmWithEntitiesAsync(
+            555L,
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -223,8 +227,12 @@ public class NotificationServiceRoutingTests
         await _service.SendMalwareDetectedAsync(chat, user, "Trojan.GenericKD", CancellationToken.None);
 
         // Assert — no DM sent to admin (already in pool 1 via web account)
-        await _mockDmService.DidNotReceive().SendDmWithQueueAsync(
-            555L, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ParseMode>(), Arg.Any<CancellationToken>());
+        await _mockDmService.DidNotReceive().SendDmWithEntitiesAsync(
+            555L,
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -246,8 +254,12 @@ public class NotificationServiceRoutingTests
         await _service.SendMalwareDetectedAsync(chat, user, "Trojan.GenericKD", CancellationToken.None);
 
         // Assert — no DM sent (bot DM not enabled)
-        await _mockDmService.DidNotReceive().SendDmWithQueueAsync(
-            555L, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ParseMode>(), Arg.Any<CancellationToken>());
+        await _mockDmService.DidNotReceive().SendDmWithEntitiesAsync(
+            555L,
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -275,7 +287,11 @@ public class NotificationServiceRoutingTests
         await _service.SendMalwareDetectedAsync(chat, user, "Trojan.GenericKD", CancellationToken.None);
 
         // Assert — no DM sent (deduped by Telegram ID from pool 1)
-        await _mockDmService.DidNotReceive().SendDmWithQueueAsync(
-            555L, Arg.Any<string>(), Arg.Any<string>(), Arg.Any<ParseMode>(), Arg.Any<CancellationToken>());
+        await _mockDmService.DidNotReceive().SendDmWithEntitiesAsync(
+            555L,
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyList<global::Telegram.Bot.Types.MessageEntity>>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/TelegramGroupsAdmin.UnitTests/Services/ReportActions/ContentReportHandlerTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/ReportActions/ContentReportHandlerTests.cs
@@ -61,7 +61,6 @@ public class ContentReportHandlerTests
             _mockModerationService,
             _mockAuditService,
             _mockBotMessageService,
-            _mockCallbackContextRepo,
             NullLogger<ContentReportHandler>.Instance);
     }
 
@@ -167,7 +166,7 @@ public class ContentReportHandlerTests
     }
 
     [Test]
-    public async Task SpamAsync_Success_CleansUpCallbackContext()
+    public async Task SpamAsync_Success_DoesNotDeleteCallbackContextsByReportId()
     {
         var report = CreateTestReport();
         var message = CreateTestMessage();
@@ -176,8 +175,56 @@ public class ContentReportHandlerTests
 
         await _handler.SpamAsync(TestReportId, TestExecutor, CancellationToken.None);
 
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteByReportIdAsync(TestReportId, Arg.Any<CancellationToken>());
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task BanAsync_Success_DoesNotDeleteCallbackContextsByReportId()
+    {
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.BanUserAsync(
+                Arg.Any<BanIntent>(), Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, ChatsAffected = 3 });
+
+        await _handler.BanAsync(TestReportId, TestExecutor, CancellationToken.None);
+
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task WarnAsync_Success_DoesNotDeleteCallbackContextsByReportId()
+    {
+        var report = CreateTestReport();
+        var message = CreateTestMessage();
+        SetupReportAndMessage(report, message);
+
+        _mockModerationService.WarnUserAsync(
+                Arg.Any<WarnIntent>(), Arg.Any<CancellationToken>())
+            .Returns(new ModerationResult { Success = true, WarningCount = 1 });
+
+        await _handler.WarnAsync(TestReportId, TestExecutor, CancellationToken.None);
+
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task DismissAsync_Success_DoesNotDeleteCallbackContextsByReportId()
+    {
+        var report = CreateTestReport();
+        _mockReportsRepo.GetContentReportAsync(TestReportId, Arg.Any<CancellationToken>())
+            .Returns(report);
+
+        var result = await _handler.DismissAsync(TestReportId, TestExecutor, null, CancellationToken.None);
+
+        Assert.That(result.Success, Is.True);
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/TelegramGroupsAdmin.UnitTests/Services/ReportActions/ExamHandlerTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/ReportActions/ExamHandlerTests.cs
@@ -41,14 +41,13 @@ public class ExamHandlerTests
         _handler = new ExamHandler(
             _mockReportsRepo,
             _mockExamFlowService,
-            _mockCallbackContextRepo,
             NullLogger<ExamHandler>.Instance);
     }
 
     #region ApproveAsync Tests
 
     [Test]
-    public async Task ApproveAsync_Success_ReturnsSuccessAndCleansUp()
+    public async Task ApproveAsync_Success_ReturnsSuccessAndDoesNotDeleteCallbackContextsByReportId()
     {
         var exam = CreateTestExam();
         _mockReportsRepo.GetExamFailureAsync(TestExamId, Arg.Any<CancellationToken>())
@@ -64,8 +63,8 @@ public class ExamHandlerTests
         Assert.That(result.ActionName, Is.EqualTo("Approve"));
         Assert.That(result.Message, Does.Contain("permissions restored"));
 
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteByReportIdAsync(TestExamId, Arg.Any<CancellationToken>());
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -117,7 +116,7 @@ public class ExamHandlerTests
     #region DenyAsync Tests
 
     [Test]
-    public async Task DenyAsync_Success_ReturnsSuccess()
+    public async Task DenyAsync_Success_ReturnsSuccessAndDoesNotDeleteCallbackContextsByReportId()
     {
         var exam = CreateTestExam();
         _mockReportsRepo.GetExamFailureAsync(TestExamId, Arg.Any<CancellationToken>())
@@ -132,6 +131,9 @@ public class ExamHandlerTests
         Assert.That(result.Success, Is.True);
         Assert.That(result.ActionName, Is.EqualTo("Deny"));
         Assert.That(result.Message, Does.Contain("kicked"));
+
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -169,7 +171,7 @@ public class ExamHandlerTests
     #region DenyAndBanAsync Tests
 
     [Test]
-    public async Task DenyAndBanAsync_Success_ReturnsSuccess()
+    public async Task DenyAndBanAsync_Success_ReturnsSuccessAndDoesNotDeleteCallbackContextsByReportId()
     {
         var exam = CreateTestExam();
         _mockReportsRepo.GetExamFailureAsync(TestExamId, Arg.Any<CancellationToken>())
@@ -184,6 +186,9 @@ public class ExamHandlerTests
         Assert.That(result.Success, Is.True);
         Assert.That(result.ActionName, Is.EqualTo("DenyAndBan"));
         Assert.That(result.Message, Does.Contain("banned"));
+
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -300,44 +305,6 @@ public class ExamHandlerTests
         Assert.That(result.Success, Is.False);
         Assert.That(result.Message, Does.Contain("Already handled"));
         Assert.That(result.IsAlreadyHandled, Is.True);
-    }
-
-    #endregion
-
-    #region Cleanup Tests
-
-    [Test]
-    public async Task DenyAsync_Success_CleansUpCallbackContext()
-    {
-        var exam = CreateTestExam();
-        _mockReportsRepo.GetExamFailureAsync(TestExamId, Arg.Any<CancellationToken>())
-            .Returns(exam);
-        _mockExamFlowService.DenyExamFailureAsync(
-                Arg.Any<UserIdentity>(), Arg.Any<ChatIdentity>(),
-                Arg.Any<Actor>(), Arg.Any<CancellationToken>())
-            .Returns(new ModerationResult { Success = true });
-
-        await _handler.DenyAsync(TestExamId, TestExecutor, CancellationToken.None);
-
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteByReportIdAsync(TestExamId, Arg.Any<CancellationToken>());
-    }
-
-    [Test]
-    public async Task DenyAndBanAsync_Success_CleansUpCallbackContext()
-    {
-        var exam = CreateTestExam();
-        _mockReportsRepo.GetExamFailureAsync(TestExamId, Arg.Any<CancellationToken>())
-            .Returns(exam);
-        _mockExamFlowService.DenyAndBanExamFailureAsync(
-                Arg.Any<UserIdentity>(), Arg.Any<ChatIdentity>(),
-                Arg.Any<Actor>(), Arg.Any<CancellationToken>())
-            .Returns(new ModerationResult { Success = true });
-
-        await _handler.DenyAndBanAsync(TestExamId, TestExecutor, CancellationToken.None);
-
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteByReportIdAsync(TestExamId, Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/TelegramGroupsAdmin.UnitTests/Services/ReportActions/ProfileScanHandlerTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/ReportActions/ProfileScanHandlerTests.cs
@@ -54,7 +54,6 @@ public class ProfileScanHandlerTests
             _mockModerationService,
             _mockWelcomeRepo,
             _mockAdmissionHandler,
-            _mockCallbackContextRepo,
             NullLogger<ProfileScanHandler>.Instance);
     }
 
@@ -454,7 +453,7 @@ public class ProfileScanHandlerTests
     #region Cleanup Tests
 
     [Test]
-    public async Task BanAsync_Success_CleansUpCallbackContext()
+    public async Task BanAsync_Success_DoesNotDeleteCallbackContextsByReportId()
     {
         var alert = CreateTestAlert();
         _mockReportsRepo.GetProfileScanAlertAsync(TestAlertId, Arg.Any<CancellationToken>())
@@ -462,14 +461,15 @@ public class ProfileScanHandlerTests
         _mockModerationService.BanUserAsync(Arg.Any<BanIntent>(), Arg.Any<CancellationToken>())
             .Returns(new ModerationResult { Success = true, ChatsAffected = 1 });
 
-        await _handler.BanAsync(TestAlertId, TestExecutor, CancellationToken.None);
+        var result = await _handler.BanAsync(TestAlertId, TestExecutor, CancellationToken.None);
 
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteByReportIdAsync(TestAlertId, Arg.Any<CancellationToken>());
+        Assert.That(result.Success, Is.True);
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
-    public async Task KickAsync_Success_CleansUpCallbackContext()
+    public async Task KickAsync_Success_DoesNotDeleteCallbackContextsByReportId()
     {
         var alert = CreateTestAlert();
         _mockReportsRepo.GetProfileScanAlertAsync(TestAlertId, Arg.Any<CancellationToken>())
@@ -477,14 +477,15 @@ public class ProfileScanHandlerTests
         _mockModerationService.KickUserFromChatAsync(Arg.Any<KickIntent>(), Arg.Any<CancellationToken>())
             .Returns(new ModerationResult { Success = true });
 
-        await _handler.KickAsync(TestAlertId, TestExecutor, CancellationToken.None);
+        var result = await _handler.KickAsync(TestAlertId, TestExecutor, CancellationToken.None);
 
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteByReportIdAsync(TestAlertId, Arg.Any<CancellationToken>());
+        Assert.That(result.Success, Is.True);
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
-    public async Task AllowAsync_Success_CleansUpCallbackContext()
+    public async Task AllowAsync_Success_DoesNotDeleteCallbackContextsByReportId()
     {
         var alert = CreateTestAlert();
         _mockReportsRepo.GetProfileScanAlertAsync(TestAlertId, Arg.Any<CancellationToken>())
@@ -496,10 +497,11 @@ public class ProfileScanHandlerTests
                 Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(AdmissionResult.Admitted);
 
-        await _handler.AllowAsync(TestAlertId, TestExecutor, CancellationToken.None);
+        var result = await _handler.AllowAsync(TestAlertId, TestExecutor, CancellationToken.None);
 
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteByReportIdAsync(TestAlertId, Arg.Any<CancellationToken>());
+        Assert.That(result.Success, Is.True);
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/ReportCallbackServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/ReportCallbackServiceTests.cs
@@ -531,11 +531,12 @@ public class ReportCallbackServiceTests
                 Arg.Any<CancellationToken>())
             .ThrowsAsync(new Exception("DM edit failed"));
 
+        // Should complete without throwing
         await _service.HandleCallbackAsync(CreateCallbackQuery(data: $"rev:{TestContextId}:0"));
 
-        // Should complete without throwing
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteAsync(TestContextId, Arg.Any<CancellationToken>());
+        // Action should still have been routed despite the DM failure
+        await _mockReportActionsService.Received(1)
+            .HandleContentSpamAsync(TestReportId, Arg.Any<Actor>(), Arg.Any<CancellationToken>());
     }
 
     #endregion
@@ -543,16 +544,19 @@ public class ReportCallbackServiceTests
     #region Context Cleanup Tests
 
     [Test]
-    public async Task HandleCallbackAsync_Success_DeletesCallbackContext()
+    public async Task HandleCallbackAsync_DoesNotDeleteContextById_AfterSuccessfulAction()
     {
+        // Orphan-based cleanup handles callback context lifecycle - do not eagerly
+        // delete after a successful action (avoids a race where another admin is
+        // mid-click on the same context ID).
         SetupContext(ReportType.ContentReport);
         _mockReportActionsService.HandleContentSpamAsync(TestReportId, Arg.Any<Actor>(), Arg.Any<CancellationToken>())
             .Returns(new ReviewActionResult(true, "Done"));
 
         await _service.HandleCallbackAsync(CreateCallbackQuery(data: $"rev:{TestContextId}:0"));
 
-        await _mockCallbackContextRepo.Received(1)
-            .DeleteAsync(TestContextId, Arg.Any<CancellationToken>());
+        await _mockCallbackContextRepo.DidNotReceive()
+            .DeleteAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/Moderation/BotModerationServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/Moderation/BotModerationServiceTests.cs
@@ -1619,11 +1619,11 @@ public class BotModerationServiceTests
                 Reason = malwareDetails
             });
 
-        // Assert - Report was created with isAutomated=true
+        // Assert - Report was created with the FileScanner system actor
         await _mockReportService.Received(1).CreateReportAsync(
             Arg.Is<Report>(r => r.MessageId == messageId && r.Chat.Id == chatId),
             telegramMessage,
-            true,
+            Arg.Is<Actor>(a => a.Type == ActorType.System && a.SystemIdentifier == SystemActorIds.FileScanner),
             Arg.Any<CancellationToken>());
     }
 

--- a/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
@@ -64,7 +64,22 @@
                 }
 
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                    <b>Reported by:</b> @GetReporterDisplay()
+                    <b>Reported by:</b>
+                    @if (Report.ReportedByUserId == null && Report.WebUserId == null)
+                    {
+                        @(Report.ReportedByUserName ?? "System")
+                    }
+                    else if (Report.ReportedByUserId != null)
+                    {
+                        <UserDetailLink UserId="@Report.ReportedByUserId.Value" Typo="Typo.caption">
+                            @(Report.ReportedByUserName ?? "Unknown")
+                        </UserDetailLink>
+                        @:(ID: @Report.ReportedByUserId)
+                    }
+                    else
+                    {
+                        @($"{Report.ReportedByUserName ?? "Web Admin"} (Web User)")
+                    }
                 </MudText>
             </MudStack>
         }
@@ -234,28 +249,4 @@
             _message.Chat.ChatName);
     }
 
-    private string GetReporterDisplay()
-    {
-        // System-generated report (auto-detection)
-        if (Report.ReportedByUserId == null && Report.WebUserId == null)
-        {
-            // Return the system identifier without showing "()"
-            return Report.ReportedByUserName ?? "System";
-        }
-
-        // Telegram user report
-        if (Report.ReportedByUserId != null)
-        {
-            var username = Report.ReportedByUserName ?? "Unknown";
-            return $"{username} (ID: {Report.ReportedByUserId})";
-        }
-
-        // Web user report
-        if (Report.WebUserId != null)
-        {
-            return $"{Report.ReportedByUserName ?? "Web Admin"} (Web User)";
-        }
-
-        return "Unknown";
-    }
 }

--- a/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
+++ b/TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
@@ -74,7 +74,7 @@
                         <UserDetailLink UserId="@Report.ReportedByUserId.Value" Typo="Typo.caption">
                             @(Report.ReportedByUserName ?? "Unknown")
                         </UserDetailLink>
-                        @:(ID: @Report.ReportedByUserId)
+                        @:&nbsp;(ID: @Report.ReportedByUserId)
                     }
                     else
                     {

--- a/TelegramGroupsAdmin/Components/Shared/Settings/BackgroundJobs.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/BackgroundJobs.razor
@@ -171,13 +171,6 @@
                                  Error="@(!ValidateRetention(_editReportRetention))"
                                  ErrorText="Invalid format" />
 
-                    <MudTextField @bind-Value="_editContextRetention"
-                                 Label="DM Button Contexts"
-                                 Variant="Variant.Outlined"
-                                 HelperText="e.g., 7d, 2w (expired callback buttons)"
-                                 Error="@(!ValidateRetention(_editContextRetention))"
-                                 ErrorText="Invalid format" />
-
                     <MudTextField @bind-Value="_editNotificationRetention"
                                  Label="Read Web Notifications"
                                  Variant="Variant.Outlined"
@@ -256,7 +249,6 @@
     // Data Cleanup retention settings (duration strings)
     private string _editMessageRetention = "30d";
     private string _editReportRetention = "30d";
-    private string _editContextRetention = "7d";
     private string _editNotificationRetention = "7d";
     private string _editFileScanResultRetention = "24h";
 
@@ -368,7 +360,6 @@
             var settings = job.DataCleanup ?? new DataCleanupSettings();
             _editMessageRetention = settings.MessageRetention;
             _editReportRetention = settings.ReportRetention;
-            _editContextRetention = settings.CallbackContextRetention;
             _editNotificationRetention = settings.WebNotificationRetention;
             _editFileScanResultRetention = settings.FileScanResultRetention;
         }
@@ -424,7 +415,6 @@
                 // Validate all retention values before saving
                 if (!ValidateRetention(_editMessageRetention) ||
                     !ValidateRetention(_editReportRetention) ||
-                    !ValidateRetention(_editContextRetention) ||
                     !ValidateRetention(_editNotificationRetention) ||
                     !ValidateRetention(_editFileScanResultRetention))
                 {
@@ -436,7 +426,6 @@
                 {
                     MessageRetention = _editMessageRetention,
                     ReportRetention = _editReportRetention,
-                    CallbackContextRetention = _editContextRetention,
                     WebNotificationRetention = _editNotificationRetention,
                     FileScanResultRetention = _editFileScanResultRetention
                 };

--- a/TelegramGroupsAdmin/Services/NotificationService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationService.cs
@@ -485,7 +485,9 @@ public sealed class NotificationService : INotificationService
                 return false;
             }
 
-            var htmlMessage = NotificationRenderer.ToTelegramHtml(payload);
+            // Task 19 will wire this to entity-based DM sending; for now use text path (unstyled)
+            var rendered = NotificationRenderer.ToTelegramMessage(payload);
+            var messageText = rendered.Text;
 
             // Build keyboard if payload has action context
             InlineKeyboardMarkup? keyboard = null;
@@ -503,11 +505,11 @@ public sealed class NotificationService : INotificationService
                 result = await _dmDeliveryService.SendDmWithMediaAndKeyboardAsync(
                     mapping.TelegramId,
                     "notification",
-                    htmlMessage,
+                    messageText,
                     photoPath: payload.PhotoPath,
                     videoPath: payload.VideoPath,
                     keyboard: keyboard,
-                    parseMode: ParseMode.Html,
+                    parseMode: ParseMode.None,
                     cancellationToken: ct);
             }
             else
@@ -515,8 +517,8 @@ public sealed class NotificationService : INotificationService
                 result = await _dmDeliveryService.SendDmWithQueueAsync(
                     mapping.TelegramId,
                     "notification",
-                    htmlMessage,
-                    parseMode: ParseMode.Html,
+                    messageText,
+                    parseMode: ParseMode.None,
                     cancellationToken: ct);
             }
 
@@ -546,7 +548,9 @@ public sealed class NotificationService : INotificationService
     {
         try
         {
-            var htmlMessage = NotificationRenderer.ToTelegramHtml(payload);
+            // Task 19 will wire this to entity-based DM sending; for now use text path (unstyled)
+            var rendered = NotificationRenderer.ToTelegramMessage(payload);
+            var messageText = rendered.Text;
 
             // Build keyboard if payload has action context
             InlineKeyboardMarkup? keyboard = null;
@@ -561,11 +565,11 @@ public sealed class NotificationService : INotificationService
                 await _dmDeliveryService.SendDmWithMediaAndKeyboardAsync(
                     telegramId,
                     "notification",
-                    htmlMessage,
+                    messageText,
                     photoPath: payload.PhotoPath,
                     videoPath: payload.VideoPath,
                     keyboard: keyboard,
-                    parseMode: ParseMode.Html,
+                    parseMode: ParseMode.None,
                     cancellationToken: ct);
             }
             else
@@ -573,8 +577,8 @@ public sealed class NotificationService : INotificationService
                 await _dmDeliveryService.SendDmWithQueueAsync(
                     telegramId,
                     "notification",
-                    htmlMessage,
-                    parseMode: ParseMode.Html,
+                    messageText,
+                    parseMode: ParseMode.None,
                     cancellationToken: ct);
             }
         }

--- a/TelegramGroupsAdmin/Services/NotificationService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationService.cs
@@ -26,6 +26,7 @@ public sealed class NotificationService : INotificationService
     private readonly IBotDmService _dmDeliveryService;
     private readonly IWebPushNotificationService _webPushService;
     private readonly ITelegramUserMappingRepository _telegramMappingRepo;
+    private readonly ITelegramUserRepository _telegramUserRepo;
     private readonly IChatAdminsRepository _chatAdminsRepo;
     private readonly IUserRepository _userRepo;
     private readonly IReportCallbackContextRepository _callbackContextRepo;
@@ -37,6 +38,7 @@ public sealed class NotificationService : INotificationService
         IBotDmService dmDeliveryService,
         IWebPushNotificationService webPushService,
         ITelegramUserMappingRepository telegramMappingRepo,
+        ITelegramUserRepository telegramUserRepo,
         IChatAdminsRepository chatAdminsRepo,
         IUserRepository userRepo,
         IReportCallbackContextRepository callbackContextRepo,
@@ -47,6 +49,7 @@ public sealed class NotificationService : INotificationService
         _dmDeliveryService = dmDeliveryService;
         _webPushService = webPushService;
         _telegramMappingRepo = telegramMappingRepo;
+        _telegramUserRepo = telegramUserRepo;
         _chatAdminsRepo = chatAdminsRepo;
         _userRepo = userRepo;
         _callbackContextRepo = callbackContextRepo;
@@ -108,27 +111,34 @@ public sealed class NotificationService : INotificationService
     public Task<Dictionary<string, bool>> SendReportNotificationAsync(
         ChatIdentity chat,
         UserIdentity reportedUser,
-        long? reporterUserId,
-        string? reporterName,
-        bool isAutomated,
+        Actor reporter,
         string messagePreview,
         string? photoPath,
         long reportId,
         ReportType reportType,
         CancellationToken ct = default)
     {
-        var reporterAsUser = !isAutomated && reporterUserId.HasValue
-            ? new UserIdentity(reporterUserId.Value, FirstName: null, LastName: null, Username: reporterName)
-            : null;
-
         var builder = NotificationPayloadBuilder.Create("Message Reported")
             .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
             .WithField("Reported user", reportedUser);
 
-        if (reporterAsUser != null)
-            builder.WithField("Reported by", reporterAsUser);
+        // Reporter rendering: TelegramUser → clickable TextMention via UserIdentity,
+        // System / WebUser / Unknown → plain text with the actor's display name.
+        // (TextMention only needs Actor.TelegramUserId for profile linking; the rendered
+        // text comes from the message body at the entity offset, so we seed FirstName
+        // with the actor's DisplayName.)
+        if (reporter.Type == ActorType.TelegramUser && reporter.TelegramUserId is { } telegramId)
+        {
+            builder.WithField("Reported by", new UserIdentity(
+                telegramId,
+                FirstName: reporter.DisplayName,
+                LastName: null,
+                Username: null));
+        }
         else
-            builder.WithField("Reported by", isAutomated ? "System (automated)" : reporterName ?? "Unknown");
+        {
+            builder.WithField("Reported by", reporter.GetDisplayText());
+        }
 
         builder
             .WithSection("Message", s => s.WithText(messagePreview))
@@ -533,6 +543,7 @@ public sealed class NotificationService : INotificationService
         CancellationToken ct)
     {
         var rendered = NotificationRenderer.ToTelegramMessage(payload);
+        var recipient = await UserIdentity.FromAsync(telegramId, _telegramUserRepo, ct);
 
         InlineKeyboardMarkup? keyboard = null;
         if (payload.Keyboard is { } kb)
@@ -544,7 +555,7 @@ public sealed class NotificationService : INotificationService
         if (keyboard != null || !string.IsNullOrWhiteSpace(payload.PhotoPath) || !string.IsNullOrWhiteSpace(payload.VideoPath))
         {
             return await _dmDeliveryService.SendDmWithMediaAndKeyboardEntitiesAsync(
-                telegramId,
+                recipient,
                 "notification",
                 rendered.Text,
                 rendered.Entities,
@@ -555,7 +566,7 @@ public sealed class NotificationService : INotificationService
         }
 
         return await _dmDeliveryService.SendDmWithEntitiesAsync(
-            telegramId,
+            recipient,
             "notification",
             rendered.Text,
             rendered.Entities,

--- a/TelegramGroupsAdmin/Services/NotificationService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationService.cs
@@ -129,7 +129,7 @@ public sealed class NotificationService : INotificationService
         if (reporterAsUser != null)
             builder.WithField("Reported by", reporterAsUser);
         else
-            builder.WithField("Reported by", "System (automated)");
+            builder.WithField("Reported by", isAutomated ? "System (automated)" : reporterName ?? "Unknown");
 
         builder
             .WithSection("Message", s => s.WithText(messagePreview))

--- a/TelegramGroupsAdmin/Services/NotificationService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationService.cs
@@ -1,4 +1,3 @@
-using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 using TelegramGroupsAdmin.Core.Extensions;
 using TelegramGroupsAdmin.Core.Models;
@@ -485,9 +484,7 @@ public sealed class NotificationService : INotificationService
                 return false;
             }
 
-            // Task 19 will wire this to entity-based DM sending; for now use text path (unstyled)
             var rendered = NotificationRenderer.ToTelegramMessage(payload);
-            var messageText = rendered.Text;
 
             // Build keyboard if payload has action context
             InlineKeyboardMarkup? keyboard = null;
@@ -502,23 +499,23 @@ public sealed class NotificationService : INotificationService
             // Use rich method if we have media or keyboard
             if (keyboard != null || !string.IsNullOrWhiteSpace(payload.PhotoPath) || !string.IsNullOrWhiteSpace(payload.VideoPath))
             {
-                result = await _dmDeliveryService.SendDmWithMediaAndKeyboardAsync(
+                result = await _dmDeliveryService.SendDmWithMediaAndKeyboardEntitiesAsync(
                     mapping.TelegramId,
                     "notification",
-                    messageText,
+                    rendered.Text,
+                    rendered.Entities,
                     photoPath: payload.PhotoPath,
                     videoPath: payload.VideoPath,
                     keyboard: keyboard,
-                    parseMode: ParseMode.None,
                     cancellationToken: ct);
             }
             else
             {
-                result = await _dmDeliveryService.SendDmWithQueueAsync(
+                result = await _dmDeliveryService.SendDmWithEntitiesAsync(
                     mapping.TelegramId,
                     "notification",
-                    messageText,
-                    parseMode: ParseMode.None,
+                    rendered.Text,
+                    rendered.Entities,
                     cancellationToken: ct);
             }
 
@@ -548,9 +545,7 @@ public sealed class NotificationService : INotificationService
     {
         try
         {
-            // Task 19 will wire this to entity-based DM sending; for now use text path (unstyled)
             var rendered = NotificationRenderer.ToTelegramMessage(payload);
-            var messageText = rendered.Text;
 
             // Build keyboard if payload has action context
             InlineKeyboardMarkup? keyboard = null;
@@ -562,23 +557,23 @@ public sealed class NotificationService : INotificationService
 
             if (keyboard != null || !string.IsNullOrWhiteSpace(payload.PhotoPath) || !string.IsNullOrWhiteSpace(payload.VideoPath))
             {
-                await _dmDeliveryService.SendDmWithMediaAndKeyboardAsync(
+                await _dmDeliveryService.SendDmWithMediaAndKeyboardEntitiesAsync(
                     telegramId,
                     "notification",
-                    messageText,
+                    rendered.Text,
+                    rendered.Entities,
                     photoPath: payload.PhotoPath,
                     videoPath: payload.VideoPath,
                     keyboard: keyboard,
-                    parseMode: ParseMode.None,
                     cancellationToken: ct);
             }
             else
             {
-                await _dmDeliveryService.SendDmWithQueueAsync(
+                await _dmDeliveryService.SendDmWithEntitiesAsync(
                     telegramId,
                     "notification",
-                    messageText,
-                    parseMode: ParseMode.None,
+                    rendered.Text,
+                    rendered.Entities,
                     cancellationToken: ct);
             }
         }

--- a/TelegramGroupsAdmin/Services/NotificationService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationService.cs
@@ -76,21 +76,32 @@ public sealed class NotificationService : INotificationService
         var title = bannedBy?.GetDisplayText() is { } name
             ? $"Spam Banned by {name}" : "Spam Auto-Banned";
 
-        var payload = NotificationPayloadBuilder.Create(title)
-            .WithField("User", user.DisplayName, telegramUserId: user.Id)
+        var builder = NotificationPayloadBuilder.Create(title)
+            .WithField("User", user)
             .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
             .WithSection("Message", s => s
                 .WithText(messagePreview ?? "[No text]"))
-            .WithSection("Detection", s => s
-                .WithField("Net Score", $"{netScore:F2}")
-                .WithField("Score", $"{score:F2}")
-                .WithFieldIf(detectionReason != null, "Reason", detectionReason))
-            .WithSection("Action Taken", s => s
-                .WithField("Banned from", $"{chatsAffected} managed chats")
-                .WithFieldIf(messageDeleted, "Message deleted", $"ID: {messageId}"))
-            .WithPhoto(photoPath)
-            .WithVideo(videoPath)
-            .Build();
+            .WithSection("Detection", s =>
+            {
+                s.WithField("Net Score", $"{netScore:F2}");
+                s.WithField("Score", $"{score:F2}");
+                if (detectionReason != null)
+                    s.WithField("Reason", detectionReason);
+            })
+            .WithSection("Action Taken", s =>
+            {
+                s.WithField("Banned from", $"{chatsAffected} managed chats");
+                if (messageDeleted)
+                    s.WithField("Message deleted", $"ID: {messageId}");
+            });
+
+        if (photoPath != null)
+            builder.WithPhoto(photoPath);
+
+        if (videoPath != null)
+            builder.WithVideo(videoPath);
+
+        var payload = builder.Build();
 
         return SendToChatAudienceAsync(chat, NotificationEventType.UserBanned, payload, ct);
     }
@@ -107,17 +118,27 @@ public sealed class NotificationService : INotificationService
         ReportType reportType,
         CancellationToken ct = default)
     {
-        var reporterDisplay = isAutomated ? "System (automated)" : reporterName ?? "Unknown";
+        var reporterAsUser = !isAutomated && reporterUserId.HasValue
+            ? new UserIdentity(reporterUserId.Value, FirstName: null, LastName: null, Username: reporterName)
+            : null;
 
-        var payload = NotificationPayloadBuilder.Create("Message Reported")
+        var builder = NotificationPayloadBuilder.Create("Message Reported")
             .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
-            .WithField("Reported user", reportedUser.DisplayName, telegramUserId: reportedUser.Id)
-            .WithField("Reported by", reporterDisplay, telegramUserId: isAutomated ? null : reporterUserId)
-            .WithSection("Message", s => s
-                .WithText(messagePreview))
-            .WithPhoto(photoPath)
-            .WithKeyboard(new ActionKeyboardContext(reportId, chat.Id, reportedUser.Id, reportType))
-            .Build();
+            .WithField("Reported user", reportedUser);
+
+        if (reporterAsUser != null)
+            builder.WithField("Reported by", reporterAsUser);
+        else
+            builder.WithField("Reported by", "System (automated)");
+
+        builder
+            .WithSection("Message", s => s.WithText(messagePreview))
+            .WithKeyboard(new ActionKeyboardContext(reportId, chat.Id, reportedUser.Id, reportType));
+
+        if (photoPath != null)
+            builder.WithPhoto(photoPath);
+
+        var payload = builder.Build();
 
         return SendToChatAudienceAsync(chat, NotificationEventType.MessageReported, payload, ct);
     }
@@ -132,12 +153,15 @@ public sealed class NotificationService : INotificationService
         CancellationToken ct = default)
     {
         var payload = NotificationPayloadBuilder.Create("Profile Scan Alert")
-            .WithField("User", user.DisplayName, telegramUserId: user.Id)
+            .WithField("User", user)
             .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
-            .WithSection("Analysis", s => s
-                .WithField("Score", $"{score:F1}")
-                .WithField("Signals", signals)
-                .WithFieldIf(aiReason != null, "AI Reasoning", aiReason))
+            .WithSection("Analysis", s =>
+            {
+                s.WithField("Score", $"{score:F1}");
+                s.WithField("Signals", signals);
+                if (aiReason != null)
+                    s.WithField("AI Reasoning", aiReason);
+            })
             .WithKeyboard(new ActionKeyboardContext(reportId, chat.Id, user.Id, ReportType.ProfileScanAlert))
             .Build();
 
@@ -158,15 +182,19 @@ public sealed class NotificationService : INotificationService
         CancellationToken ct = default)
     {
         var payload = NotificationPayloadBuilder.Create("Entrance Exam Review Required")
-            .WithField("User", user.DisplayName, telegramUserId: user.Id)
+            .WithField("User", user)
             .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
-            .WithSection("Results", s => s
-                .WithField("Answered", $"{mcCorrectCount}/{mcTotal} correct")
-                .WithField("Score", $"{mcScore}% (Required: {mcPassingThreshold}%)"))
-            .WithSection("Open-Ended Response", s => s
-                .WithFieldIf(openEndedQuestion != null, "Question", openEndedQuestion)
-                .WithFieldIf(openEndedAnswer != null, "Answer", openEndedAnswer)
-                .WithFieldIf(aiReasoning != null, "AI Reasoning", aiReasoning))
+            .WithSection("Results", s =>
+            {
+                s.WithField("Answered", $"{mcCorrectCount}/{mcTotal} correct");
+                s.WithField("Score", $"{mcScore}% (Required: {mcPassingThreshold}%)");
+            })
+            .WithSection("Open-Ended Response", s =>
+            {
+                if (openEndedQuestion != null) s.WithField("Question", openEndedQuestion);
+                if (openEndedAnswer != null) s.WithField("Answer", openEndedAnswer);
+                if (aiReasoning != null) s.WithField("AI Reasoning", aiReasoning);
+            })
             .WithKeyboard(new ActionKeyboardContext(examFailureId, chat.Id, user.Id, ReportType.ExamFailure))
             .Build();
 
@@ -181,13 +209,15 @@ public sealed class NotificationService : INotificationService
         CancellationToken ct = default)
     {
         var payload = NotificationPayloadBuilder.Create($"User Banned: {user.DisplayName}")
-            .WithField("User", user.DisplayName, telegramUserId: user.Id)
+            .WithField("User", user)
             .WithText(chat != null
                 ? $"Banned from {chat.ChatName ?? chat.Id.ToString()}"
                 : "Banned globally")
-            .WithSection("Details", s => s
-                .WithField("Reason", reason ?? "No reason provided")
-                .WithField("Banned by", executor.GetDisplayText()))
+            .WithSection("Details", s =>
+            {
+                s.WithField("Reason", reason ?? "No reason provided");
+                s.WithField("Banned by", executor.GetDisplayText());
+            })
             .Build();
 
         return SendToChatAudienceAsync(chat, NotificationEventType.UserBanned, payload, ct);
@@ -200,7 +230,7 @@ public sealed class NotificationService : INotificationService
         CancellationToken ct = default)
     {
         var payload = NotificationPayloadBuilder.Create("Malware Detected")
-            .WithField("User", user.DisplayName, telegramUserId: user.Id)
+            .WithField("User", user)
             .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
             .WithSection("Details", s => s
                 .WithText(malwareDetails))
@@ -220,7 +250,7 @@ public sealed class NotificationService : INotificationService
         var role = isCreator ? "creator" : "admin";
 
         var payload = NotificationPayloadBuilder.Create($"Admin {action}: {user.DisplayName}")
-            .WithField("User", user.DisplayName, telegramUserId: user.Id)
+            .WithField("User", user)
             .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
             .WithField("Action", $"{action} as {role}")
             .Build();

--- a/TelegramGroupsAdmin/Services/NotificationService.cs
+++ b/TelegramGroupsAdmin/Services/NotificationService.cs
@@ -484,40 +484,7 @@ public sealed class NotificationService : INotificationService
                 return false;
             }
 
-            var rendered = NotificationRenderer.ToTelegramMessage(payload);
-
-            // Build keyboard if payload has action context
-            InlineKeyboardMarkup? keyboard = null;
-            if (payload.Keyboard is { } kb)
-            {
-                keyboard = await BuildReportActionKeyboardAsync(
-                    kb.EntityId, kb.ChatId, kb.UserId, kb.KeyboardType, ct);
-            }
-
-            DmDeliveryResult result;
-
-            // Use rich method if we have media or keyboard
-            if (keyboard != null || !string.IsNullOrWhiteSpace(payload.PhotoPath) || !string.IsNullOrWhiteSpace(payload.VideoPath))
-            {
-                result = await _dmDeliveryService.SendDmWithMediaAndKeyboardEntitiesAsync(
-                    mapping.TelegramId,
-                    "notification",
-                    rendered.Text,
-                    rendered.Entities,
-                    photoPath: payload.PhotoPath,
-                    videoPath: payload.VideoPath,
-                    keyboard: keyboard,
-                    cancellationToken: ct);
-            }
-            else
-            {
-                result = await _dmDeliveryService.SendDmWithEntitiesAsync(
-                    mapping.TelegramId,
-                    "notification",
-                    rendered.Text,
-                    rendered.Entities,
-                    cancellationToken: ct);
-            }
+            var result = await DispatchEntityDmAsync(mapping.TelegramId, payload, ct);
 
             if (result.DmSent)
             {
@@ -545,37 +512,7 @@ public sealed class NotificationService : INotificationService
     {
         try
         {
-            var rendered = NotificationRenderer.ToTelegramMessage(payload);
-
-            // Build keyboard if payload has action context
-            InlineKeyboardMarkup? keyboard = null;
-            if (payload.Keyboard is { } kb)
-            {
-                keyboard = await BuildReportActionKeyboardAsync(
-                    kb.EntityId, kb.ChatId, kb.UserId, kb.KeyboardType, ct);
-            }
-
-            if (keyboard != null || !string.IsNullOrWhiteSpace(payload.PhotoPath) || !string.IsNullOrWhiteSpace(payload.VideoPath))
-            {
-                await _dmDeliveryService.SendDmWithMediaAndKeyboardEntitiesAsync(
-                    telegramId,
-                    "notification",
-                    rendered.Text,
-                    rendered.Entities,
-                    photoPath: payload.PhotoPath,
-                    videoPath: payload.VideoPath,
-                    keyboard: keyboard,
-                    cancellationToken: ct);
-            }
-            else
-            {
-                await _dmDeliveryService.SendDmWithEntitiesAsync(
-                    telegramId,
-                    "notification",
-                    rendered.Text,
-                    rendered.Entities,
-                    cancellationToken: ct);
-            }
+            await DispatchEntityDmAsync(telegramId, payload, ct);
         }
         catch (Exception ex)
         {
@@ -583,6 +520,46 @@ public sealed class NotificationService : INotificationService
             // Any other error is unexpected but not worth failing the whole notification for.
             _logger.LogDebug(ex, "Failed to send DM to unlinked admin {TelegramId}", telegramId);
         }
+    }
+
+    /// <summary>
+    /// Render payload and dispatch via the appropriate entity-based DM overload.
+    /// Picks the media+keyboard variant when media or keyboard is present, otherwise the
+    /// text-only entities variant. Used by both the linked-web-user and unlinked-admin paths.
+    /// </summary>
+    private async Task<DmDeliveryResult> DispatchEntityDmAsync(
+        long telegramId,
+        NotificationPayload payload,
+        CancellationToken ct)
+    {
+        var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+        InlineKeyboardMarkup? keyboard = null;
+        if (payload.Keyboard is { } kb)
+        {
+            keyboard = await BuildReportActionKeyboardAsync(
+                kb.EntityId, kb.ChatId, kb.UserId, kb.KeyboardType, ct);
+        }
+
+        if (keyboard != null || !string.IsNullOrWhiteSpace(payload.PhotoPath) || !string.IsNullOrWhiteSpace(payload.VideoPath))
+        {
+            return await _dmDeliveryService.SendDmWithMediaAndKeyboardEntitiesAsync(
+                telegramId,
+                "notification",
+                rendered.Text,
+                rendered.Entities,
+                photoPath: payload.PhotoPath,
+                videoPath: payload.VideoPath,
+                keyboard: keyboard,
+                cancellationToken: ct);
+        }
+
+        return await _dmDeliveryService.SendDmWithEntitiesAsync(
+            telegramId,
+            "notification",
+            rendered.Text,
+            rendered.Entities,
+            cancellationToken: ct);
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin/Services/Notifications/Field.cs
+++ b/TelegramGroupsAdmin/Services/Notifications/Field.cs
@@ -1,7 +1,10 @@
+using TelegramGroupsAdmin.Core.Models;
+
 namespace TelegramGroupsAdmin.Services.Notifications;
 
 /// <summary>
-/// A single labeled field. When TelegramUserId is set, the value renders as a
-/// clickable tg://user deep link in Telegram DMs.
+/// A single labeled field. When User is set, the value renders as a
+/// text_mention entity in Telegram DMs — clickable regardless of whether
+/// the user has interacted with the bot before.
 /// </summary>
-internal sealed record Field(string Label, string Value, long? TelegramUserId = null);
+internal sealed record Field(string Label, string Value, UserIdentity? User = null);

--- a/TelegramGroupsAdmin/Services/Notifications/NotificationPayloadBuilder.cs
+++ b/TelegramGroupsAdmin/Services/Notifications/NotificationPayloadBuilder.cs
@@ -1,8 +1,10 @@
+using TelegramGroupsAdmin.Core.Models;
+
 namespace TelegramGroupsAdmin.Services.Notifications;
 
 /// <summary>
 /// Fluent builder for constructing immutable NotificationPayload records.
-/// Call sites use WithText/WithField/WithSection/WithFieldIf for clean, readable payload construction.
+/// Each With* method adds content; conditional logic lives at the call site.
 /// </summary>
 internal sealed class NotificationPayloadBuilder
 {
@@ -20,15 +22,15 @@ internal sealed class NotificationPayloadBuilder
         return this;
     }
 
-    public NotificationPayloadBuilder WithField(string label, string value, long? telegramUserId = null)
+    public NotificationPayloadBuilder WithField(string label, string value)
     {
-        _blocks.Add(new FieldList([new(label, value, telegramUserId)]));
+        _blocks.Add(new FieldList([new(label, value)]));
         return this;
     }
 
-    public NotificationPayloadBuilder WithFieldIf(bool condition, string label, string? value, long? telegramUserId = null)
+    public NotificationPayloadBuilder WithField(string label, UserIdentity user)
     {
-        if (condition && value != null) WithField(label, value, telegramUserId);
+        _blocks.Add(new FieldList([new(label, user.DisplayName, user)]));
         return this;
     }
 
@@ -40,13 +42,13 @@ internal sealed class NotificationPayloadBuilder
         return this;
     }
 
-    public NotificationPayloadBuilder WithPhoto(string? path)
+    public NotificationPayloadBuilder WithPhoto(string path)
     {
         _photoPath = path;
         return this;
     }
 
-    public NotificationPayloadBuilder WithVideo(string? path)
+    public NotificationPayloadBuilder WithVideo(string path)
     {
         _videoPath = path;
         return this;

--- a/TelegramGroupsAdmin/Services/Notifications/NotificationRenderer.cs
+++ b/TelegramGroupsAdmin/Services/Notifications/NotificationRenderer.cs
@@ -1,4 +1,7 @@
 using System.Text;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Utilities;
 
 namespace TelegramGroupsAdmin.Services.Notifications;
@@ -6,28 +9,35 @@ namespace TelegramGroupsAdmin.Services.Notifications;
 /// <summary>
 /// Centralized multi-channel renderer for notification payloads.
 /// Renders the same content blocks differently per delivery channel:
-/// - Telegram HTML: bold headers, tg://user deep links, HTML entities
+/// - Telegram: bold/mention entities (parse_mode-free)
 /// - Email HTML: full CSS-styled layout with container and footer
 /// - Plain text: for web push notifications (no formatting)
 /// </summary>
 internal static class NotificationRenderer
 {
     /// <summary>
-    /// Render payload as Telegram HTML (ParseMode.Html).
-    /// Fields with TelegramUserId get clickable tg://user deep links.
+    /// Render payload as entity-based Telegram message.
+    /// Emits Bold entities for subject, field labels, and section headers;
+    /// TextMention entities with full User object for clickable user mentions.
+    /// No HTML — uses the entities parameter which is mutually exclusive with parse_mode.
     /// </summary>
-    public static string ToTelegramHtml(NotificationPayload payload)
+    public static TelegramMessage ToTelegramMessage(NotificationPayload payload)
     {
         var sb = new StringBuilder();
-        sb.AppendLine($"<b>{TelegramHtmlEncoder.Encode(payload.Subject)}</b>");
+        var entities = new List<MessageEntity>();
+
+        AppendBold(sb, entities, payload.Subject);
         sb.AppendLine();
-        RenderBlocksTelegram(sb, payload.Blocks, indent: false);
-        return sb.ToString().TrimEnd();
+        sb.AppendLine();
+
+        RenderBlocksTelegram(sb, entities, payload.Blocks);
+
+        return new TelegramMessage(sb.ToString().TrimEnd(), entities);
     }
 
     /// <summary>
     /// Render payload as full HTML email with CSS styling.
-    /// tg://user links render as plain text (not actionable in email clients).
+    /// Email clients don't resolve tg://user links, so user fields render as plain text.
     /// </summary>
     public static string ToEmailHtml(NotificationPayload payload)
     {
@@ -61,7 +71,7 @@ internal static class NotificationRenderer
 
     /// <summary>
     /// Render payload as plain text for web push notifications.
-    /// No formatting, TelegramUserId ignored.
+    /// No formatting, user mentions ignored.
     /// </summary>
     public static string ToPlainText(NotificationPayload payload)
     {
@@ -72,35 +82,73 @@ internal static class NotificationRenderer
         return sb.ToString().TrimEnd();
     }
 
-    // ── Telegram HTML rendering ──
+    // ── Telegram entity-based rendering ──
 
-    private static void RenderBlocksTelegram(StringBuilder sb, IReadOnlyList<ContentBlock> blocks, bool indent)
+    private static void RenderBlocksTelegram(
+        StringBuilder sb, List<MessageEntity> entities, IReadOnlyList<ContentBlock> blocks)
     {
         foreach (var block in blocks)
         {
             switch (block)
             {
                 case TextBlock text:
-                    sb.AppendLine(TelegramHtmlEncoder.Encode(text.Text));
+                    sb.AppendLine(text.Text);
                     break;
 
                 case FieldList fieldList:
                     foreach (var field in fieldList.Fields)
                     {
-                        var value = field.User is { } user
-                            ? $"<a href=\"tg://user?id={user.Id}\">{TelegramHtmlEncoder.Encode(field.Value)}</a>"
-                            : TelegramHtmlEncoder.Encode(field.Value);
-                        sb.AppendLine($"<b>{TelegramHtmlEncoder.Encode(field.Label)}:</b> {value}");
+                        AppendBold(sb, entities, $"{field.Label}:");
+                        sb.Append(' ');
+                        if (field.User is { } u)
+                            AppendUserMention(sb, entities, field.Value, u);
+                        else
+                            sb.Append(field.Value);
+                        sb.AppendLine();
                     }
                     break;
 
                 case SectionBlock section:
                     sb.AppendLine();
-                    sb.AppendLine($"<b>{TelegramHtmlEncoder.Encode(section.Header)}</b>");
-                    RenderBlocksTelegram(sb, section.Content, indent: true);
+                    AppendBold(sb, entities, section.Header);
+                    sb.AppendLine();
+                    RenderBlocksTelegram(sb, entities, section.Content);
                     break;
             }
         }
+    }
+
+    private static void AppendBold(StringBuilder sb, List<MessageEntity> entities, string text)
+    {
+        var offset = sb.Length;
+        sb.Append(text);
+        entities.Add(new MessageEntity
+        {
+            Type = MessageEntityType.Bold,
+            Offset = offset,
+            Length = text.Length
+        });
+    }
+
+    private static void AppendUserMention(
+        StringBuilder sb, List<MessageEntity> entities, string displayText, UserIdentity user)
+    {
+        var offset = sb.Length;
+        sb.Append(displayText);
+        entities.Add(new MessageEntity
+        {
+            Type = MessageEntityType.TextMention,
+            Offset = offset,
+            Length = displayText.Length,
+            User = new User
+            {
+                Id = user.Id,
+                IsBot = false,
+                FirstName = user.FirstName ?? string.Empty,
+                LastName = user.LastName,
+                Username = user.Username
+            }
+        });
     }
 
     // ── Email HTML rendering ──
@@ -118,7 +166,7 @@ internal static class NotificationRenderer
                 case FieldList fieldList:
                     foreach (var field in fieldList.Fields)
                     {
-                        // tg://user links aren't clickable in email — render as plain text
+                        // User mentions aren't clickable in email — render as plain text
                         sb.AppendLine($"        <div class=\"field\"><span class=\"field-label\">{TelegramHtmlEncoder.Encode(field.Label)}:</span> {TelegramHtmlEncoder.Encode(field.Value)}</div>");
                     }
                     break;

--- a/TelegramGroupsAdmin/Services/Notifications/NotificationRenderer.cs
+++ b/TelegramGroupsAdmin/Services/Notifications/NotificationRenderer.cs
@@ -87,8 +87,8 @@ internal static class NotificationRenderer
                 case FieldList fieldList:
                     foreach (var field in fieldList.Fields)
                     {
-                        var value = field.TelegramUserId.HasValue
-                            ? $"<a href=\"tg://user?id={field.TelegramUserId.Value}\">{TelegramHtmlEncoder.Encode(field.Value)}</a>"
+                        var value = field.User is { } user
+                            ? $"<a href=\"tg://user?id={user.Id}\">{TelegramHtmlEncoder.Encode(field.Value)}</a>"
                             : TelegramHtmlEncoder.Encode(field.Value);
                         sb.AppendLine($"<b>{TelegramHtmlEncoder.Encode(field.Label)}:</b> {value}");
                     }

--- a/TelegramGroupsAdmin/Services/Notifications/SectionBuilder.cs
+++ b/TelegramGroupsAdmin/Services/Notifications/SectionBuilder.cs
@@ -1,3 +1,5 @@
+using TelegramGroupsAdmin.Core.Models;
+
 namespace TelegramGroupsAdmin.Services.Notifications;
 
 /// <summary>
@@ -13,15 +15,15 @@ internal sealed class SectionBuilder
         return this;
     }
 
-    public SectionBuilder WithField(string label, string value, long? telegramUserId = null)
+    public SectionBuilder WithField(string label, string value)
     {
-        _blocks.Add(new FieldList([new(label, value, telegramUserId)]));
+        _blocks.Add(new FieldList([new(label, value)]));
         return this;
     }
 
-    public SectionBuilder WithFieldIf(bool condition, string label, string? value, long? telegramUserId = null)
+    public SectionBuilder WithField(string label, UserIdentity user)
     {
-        if (condition && value != null) WithField(label, value, telegramUserId);
+        _blocks.Add(new FieldList([new(label, user.DisplayName, user)]));
         return this;
     }
 

--- a/TelegramGroupsAdmin/Services/Notifications/TelegramMessage.cs
+++ b/TelegramGroupsAdmin/Services/Notifications/TelegramMessage.cs
@@ -1,0 +1,11 @@
+using Telegram.Bot.Types;
+
+namespace TelegramGroupsAdmin.Services.Notifications;
+
+/// <summary>
+/// Rendered Telegram message — plain text plus explicit entities.
+/// Sent with no parse_mode; Telegram renders exactly what the entities specify.
+/// </summary>
+internal sealed record TelegramMessage(
+    string Text,
+    IReadOnlyList<MessageEntity> Entities);

--- a/docs/superpowers/plans/2026-04-23-admin-notification-fixes.md
+++ b/docs/superpowers/plans/2026-04-23-admin-notification-fixes.md
@@ -1,0 +1,2031 @@
+# Admin Notification Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two admin-facing notification bugs in TelegramGroupsAdmin: (1) callback-action buttons in DMs that show "expired" within minutes due to cross-admin deletion, and (2) target-user names rendering as unstyled plain text in Telegram DMs because `tg://user?id=X` links don't work for users with no prior bot interaction. Also restore reporter clickability on the moderation report page.
+
+**Architecture:** Bug A (expiration) is fixed by removing eager `DeleteByReportIdAsync` calls from the four action handlers and replacing age-based callback-context cleanup with an orphan-only sweep (contexts whose report no longer exists). The existing `ReportStatusHelper.CheckAlreadyHandled` pattern already produces a useful "Already handled by X" message on the multi-admin race. Bug B (DM mentions) is fixed by moving admin-notification rendering from `ParseMode.Html` to Telegram's entity-based sending (mutually exclusive per the Bot API). The renderer emits `MessageEntity` objects (`Bold` for titles/labels, `TextMention` with an embedded `User` object for clickable mentions that work even for unknown users). Bug C (UI) is a single Razor file change wrapping the reporter in the existing `<UserDetailLink>` component.
+
+**Tech Stack:** .NET 10, C#, EF Core 10, Postgres 18, Telegram.Bot SDK, Blazor Server + MudBlazor 9, NUnit, Testcontainers.PostgreSQL.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md`
+
+**Branch:** Already on `fix/admin-notification-buttons-and-mentions` (created from `develop`).
+
+---
+
+## Prerequisites / Conventions
+
+Before starting any task, know this about the repo:
+
+- **No direct commits to `master` or `develop`.** All work is on the feature branch above. Per CLAUDE.md: ALWAYS prefer new commits over amending; use heredoc for multi-line commit messages.
+- **Never run the app directly.** Telegram Bot API enforces one connection per token. Use `dotnet run --migrate-only` to verify migrations. Use `dotnet test` for verification.
+- **Central Package Management:** NuGet package versions are in `Directory.Packages.props`. Don't add per-project versions.
+- **Code navigation:** Prefer `find_symbol` / `find_references` (CSharperMcp tools) over grep for C# code. Required before renaming any interface member.
+- **Commit style:** Conventional commits — `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`. Scope in parens, e.g. `fix(notifications): ...`.
+- **Test commands:**
+  - Unit tests: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj --configuration Debug --logger "console;verbosity=minimal"`
+  - Integration tests: `dotnet test TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj --configuration Debug --logger "console;verbosity=minimal"`
+  - Full suite takes ~20 minutes — run in background (`&` + `tee logs/test-run-$(date +%s).log`) when doing full runs; for task-scoped runs use `--filter`.
+- **Fluent API in AppDbContext** is preferred over custom SQL; no migrations are needed for this plan (no schema changes).
+
+### Testing patterns in this repo
+
+- Unit tests under `TelegramGroupsAdmin.UnitTests/`, organized mirroring source tree. NUnit style: `[TestFixture]`, `[Test]`, `Assert.That(x, Is.EqualTo(y))`.
+- Integration tests under `TelegramGroupsAdmin.IntegrationTests/`, use Testcontainers.PostgreSQL for real DB.
+- Mock repositories via `NSubstitute` (`Substitute.For<IFoo>()`).
+- Test doubles for `ILogger<T>`: `Substitute.For<ILogger<MyService>>()`.
+
+### How to run a single test
+
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~NotificationRendererTests.RendersSubjectAsBold" \
+    --logger "console;verbosity=normal"
+```
+
+---
+
+## File Structure
+
+New files and modifications, grouped by phase.
+
+### Phase 1 — Bug A: Button Expiration
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `TelegramGroupsAdmin.Telegram/Services/ReportActions/ContentReportHandler.cs:284` | Modify | Remove `DeleteByReportIdAsync` call |
+| `TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs:64,116,173` | Modify | Remove three `DeleteByReportIdAsync` calls |
+| `TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs:50,87,124` | Modify | Remove three `DeleteByReportIdAsync` calls |
+| `TelegramGroupsAdmin.Telegram/Services/ReportCallbackService.cs:86` | Modify | Remove post-action `DeleteAsync` call |
+| `TelegramGroupsAdmin.Telegram/Repositories/IReportCallbackContextRepository.cs` | Modify | Remove `DeleteExpiredAsync`; add `DeleteOrphanedAsync` |
+| `TelegramGroupsAdmin.Telegram/Repositories/ReportCallbackContextRepository.cs` | Modify | Implement `DeleteOrphanedAsync`; remove `DeleteExpiredAsync` |
+| `TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs` | Modify | Remove `CallbackContextRetention` property |
+| `TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs` | Modify | Use `DeleteOrphanedAsync`; drop retention config read |
+| `TelegramGroupsAdmin.IntegrationTests/Services/BackgroundJobConfigPersistenceTests.cs:119,132` | Modify | Remove `CallbackContextRetention` assertions |
+| `TelegramGroupsAdmin.IntegrationTests/Repositories/ReportCallbackContextRepositoryTests.cs` | Create | Integration test for `DeleteOrphanedAsync` |
+
+### Phase 2 — Bug C: UI Reporter Link
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor` | Modify | Wrap reporter in `<UserDetailLink>` when `ReportedByUserId != null` |
+
+### Phase 3 — Bug B: Entity-Based DM Rendering
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `TelegramGroupsAdmin/Services/Notifications/Field.cs` | Modify | Field carries `UserIdentity?` instead of `long?` |
+| `TelegramGroupsAdmin/Services/Notifications/NotificationPayloadBuilder.cs` | Modify | Non-nullable overloads; drop `WithFieldIf` |
+| `TelegramGroupsAdmin/Services/Notifications/SectionBuilder.cs` | Modify | Non-nullable overloads; drop `WithFieldIf` |
+| `TelegramGroupsAdmin/Services/Notifications/TelegramMessage.cs` | Create | Record `(string Text, IReadOnlyList<MessageEntity> Entities)` |
+| `TelegramGroupsAdmin/Services/Notifications/NotificationRenderer.cs` | Modify | `ToTelegramHtml` → `ToTelegramMessage`, entity-based output |
+| `TelegramGroupsAdmin/Services/NotificationService.cs` | Modify | Update all call sites; use new DM overloads |
+| `TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/IBotMessageHandler.cs` | Modify | Add `entities` / `captionEntities` params |
+| `TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/BotMessageHandler.cs` | Modify | Pass entities to `apiClient.Send*` |
+| `TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs` | Modify | Add `SendDmWithMessageAsync` / `SendDmWithMessageAndKeyboardAsync` overloads |
+| `TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs` | Modify | Implement new overloads (no parseMode, entities only) |
+| `TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationRendererTests.cs` | Modify | Replace HTML assertions with entity-shape assertions |
+| `TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationPayloadBuilderTests.cs` | Modify | Update for non-nullable / UserIdentity signatures |
+
+---
+
+# PHASE 1 — Bug A: Button Expiration
+
+## Task 1: Remove eager `DeleteByReportIdAsync` from `ContentReportHandler`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ReportActions/ContentReportHandler.cs:284`
+- Test: `TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportActions/ContentReportHandlerTests.cs`
+
+**Context:** `ContentReportHandler.HandleContentDismissAsync` currently calls `callbackContextRepo.DeleteByReportIdAsync(report.Id, cancellationToken)` at the end of the method. When admin A dismisses, this wipes callback contexts for admins B, C, D too — producing the cross-admin "expired" bug.
+
+- [ ] **Step 1: Find and read the failing-test file.**
+
+Run: `find TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportActions -name "ContentReportHandlerTests*" -type f`
+Expected: one file path. Read it to understand current test style.
+
+If no test file exists, create `TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportActions/ContentReportHandlerTests.cs` with a basic `[TestFixture]` scaffolding.
+
+- [ ] **Step 2: Add failing test asserting `DeleteByReportIdAsync` is NOT called after dismiss.**
+
+Add this test to `ContentReportHandlerTests.cs`:
+
+```csharp
+[Test]
+public async Task HandleContentDismissAsync_DoesNotDeleteCallbackContextsByReportId()
+{
+    // Arrange
+    var reportsRepo = Substitute.For<IReportsRepository>();
+    var callbackContextRepo = Substitute.For<IReportCallbackContextRepository>();
+    var moderationService = Substitute.For<IBotModerationService>();
+    var botMessageService = Substitute.For<IBotMessageService>();
+    var logger = Substitute.For<ILogger<ContentReportHandler>>();
+
+    reportsRepo.GetContentReportAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+        .Returns(TestReport());
+    reportsRepo.TryUpdateStatusAsync(
+            Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        .Returns(true);
+
+    var sut = new ContentReportHandler(
+        reportsRepo, callbackContextRepo, moderationService, botMessageService, logger);
+
+    // Act
+    var result = await sut.HandleContentDismissAsync(42L, Actor.Unknown, CancellationToken.None);
+
+    // Assert
+    Assert.That(result.Success, Is.True);
+    await callbackContextRepo
+        .DidNotReceive()
+        .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+}
+
+private static Report TestReport() =>
+    new Report
+    {
+        Id = 42,
+        MessageId = 100,
+        Chat = new ChatIdentity(-1001, "TestChat"),
+        Status = ReportStatus.Pending,
+        ReportedAt = DateTimeOffset.UtcNow
+    };
+```
+
+- [ ] **Step 3: Run the test and verify it FAILS.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~ContentReportHandlerTests.HandleContentDismissAsync_DoesNotDeleteCallbackContextsByReportId" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: FAIL — `callbackContextRepo.DeleteByReportIdAsync` received 1 call (because the current implementation still calls it).
+
+- [ ] **Step 4: Remove the `DeleteByReportIdAsync` call from the handler.**
+
+Open `TelegramGroupsAdmin.Telegram/Services/ReportActions/ContentReportHandler.cs`. Find line 284:
+
+```csharp
+        // Cleanup stale DM callback contexts
+        await callbackContextRepo.DeleteByReportIdAsync(report.Id, cancellationToken);
+```
+
+Delete both lines (the comment and the await). This is the last statement in `HandleContentDismissAsync` before the closing brace — the method should now end naturally after the prior block.
+
+Check whether the same pattern exists in `HandleContentSpamAsync`, `HandleContentBanAsync`, `HandleContentWarnAsync` at the bottom of each method — remove those too if present.
+
+- [ ] **Step 5: Remove the now-unused `callbackContextRepo` constructor dependency if it has no other callers.**
+
+Use `grep` inside `ContentReportHandler.cs` to check:
+
+```bash
+grep -n "callbackContextRepo\." TelegramGroupsAdmin.Telegram/Services/ReportActions/ContentReportHandler.cs
+```
+
+If zero hits remain, remove `IReportCallbackContextRepository callbackContextRepo` from the primary constructor parameter list at line 26 and remove the corresponding `using`. Also update the test to stop passing it in `new ContentReportHandler(...)`.
+
+If the test still references `callbackContextRepo`, keep the field (it's a dependency that just isn't called — fine).
+
+- [ ] **Step 6: Run the test and verify it PASSES.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~ContentReportHandlerTests" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/ReportActions/ContentReportHandler.cs \
+        TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportActions/ContentReportHandlerTests.cs
+git commit -F- <<'EOF'
+fix(reports): stop eager callback-context deletion in content report handler
+
+Eagerly deleting callback contexts by report ID wiped contexts for every
+admin who received a DM for the report, producing "Button expired" on
+their buttons the moment one admin acted. Relies on the existing
+CheckAlreadyHandled path for multi-admin resolution instead.
+
+EOF
+```
+
+---
+
+## Task 2: Remove eager deletion from `ProfileScanHandler`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs:64,116,173`
+- Test: `TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportActions/ProfileScanHandlerTests.cs`
+
+**Context:** Three action methods (`BanAsync`, `KickAsync`, `AllowAsync`) each call `callbackContextRepo.DeleteByReportIdAsync(alertId, ct)`. All three need removal.
+
+- [ ] **Step 1: Add failing test for BanAsync.**
+
+Add to `ProfileScanHandlerTests.cs`:
+
+```csharp
+[Test]
+public async Task BanAsync_DoesNotDeleteCallbackContextsByReportId()
+{
+    var reportsRepo = Substitute.For<IReportsRepository>();
+    var callbackContextRepo = Substitute.For<IReportCallbackContextRepository>();
+    var moderationService = Substitute.For<IBotModerationService>();
+    var logger = Substitute.For<ILogger<ProfileScanHandler>>();
+
+    reportsRepo.GetProfileScanAlertAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+        .Returns(TestAlert());
+    reportsRepo.TryUpdateStatusAsync(
+            Arg.Any<long>(), Arg.Any<ReportStatus>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        .Returns(true);
+    moderationService.BanUserAsync(
+            Arg.Any<BanIntent>(), Arg.Any<CancellationToken>())
+        .Returns(BanResult.Succeeded(chatsAffected: 1));
+
+    var sut = new ProfileScanHandler(reportsRepo, callbackContextRepo, moderationService, logger);
+
+    var result = await sut.BanAsync(42L, Actor.Unknown, CancellationToken.None);
+
+    Assert.That(result.Success, Is.True);
+    await callbackContextRepo
+        .DidNotReceive()
+        .DeleteByReportIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+}
+```
+
+Also add identical tests for `KickAsync_DoesNotDeleteCallbackContextsByReportId` and `AllowAsync_DoesNotDeleteCallbackContextsByReportId`.
+
+Lookup `TestAlert()` style in existing tests (use `find_references` for `ProfileScanAlert`) to build a minimal alert that matches.
+
+- [ ] **Step 2: Run tests and verify they FAIL.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~ProfileScanHandlerTests" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: The three new tests FAIL.
+
+- [ ] **Step 3: Remove the three `DeleteByReportIdAsync` calls.**
+
+Open `TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs`. Remove these three statements (lines ~64, ~116, ~173):
+
+```csharp
+await callbackContextRepo.DeleteByReportIdAsync(alertId, cancellationToken);
+```
+
+Do NOT remove `CleanupSiblingAlertsAsync` calls nearby — those handle a different concern (sibling alerts for the same user, not callback contexts).
+
+- [ ] **Step 4: Check whether `callbackContextRepo` is still used.**
+
+```bash
+grep -n "callbackContextRepo\." TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs
+```
+
+If zero hits, remove the constructor parameter and update the test.
+
+- [ ] **Step 5: Run tests; verify PASS.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~ProfileScanHandlerTests" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: All pass.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs \
+        TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportActions/ProfileScanHandlerTests.cs
+git commit -F- <<'EOF'
+fix(reports): stop eager callback-context deletion in profile scan handler
+
+EOF
+```
+
+---
+
+## Task 3: Remove eager deletion from `ExamHandler`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs:50,87,124`
+- Test: `TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportActions/ExamHandlerTests.cs`
+
+**Context:** Three action methods (`ApproveAsync`, `DenyAsync`, `DenyAndBanAsync`) each call `callbackContextRepo.DeleteByReportIdAsync(examId, ct)`.
+
+- [ ] **Step 1: Add three failing tests** (same pattern as Task 2).
+
+For each of `ApproveAsync`, `DenyAsync`, `DenyAndBanAsync`, add a test `<Name>_DoesNotDeleteCallbackContextsByReportId` with the same `DidNotReceive().DeleteByReportIdAsync(...)` assertion.
+
+- [ ] **Step 2: Run tests and verify they FAIL.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~ExamHandlerTests" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: FAIL on the three new tests.
+
+- [ ] **Step 3: Remove the three `DeleteByReportIdAsync` calls** in `ExamHandler.cs` at ~50, ~87, ~124.
+
+- [ ] **Step 4: Check whether `callbackContextRepo` is still used in `ExamHandler`.**
+
+```bash
+grep -n "callbackContextRepo\." TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs
+```
+
+If zero hits, remove the constructor parameter.
+
+- [ ] **Step 5: Run tests; verify PASS.**
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs \
+        TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportActions/ExamHandlerTests.cs
+git commit -F- <<'EOF'
+fix(reports): stop eager callback-context deletion in exam handler
+
+EOF
+```
+
+---
+
+## Task 4: Stop deleting context after successful callback in `ReportCallbackService`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/ReportCallbackService.cs:86`
+- Test: `TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportCallbackServiceTests.cs`
+
+**Context:** After a successful action dispatch, `HandleCallbackAsync` calls `callbackContextRepo.DeleteAsync(contextId)`. With orphan-based cleanup (Task 6), this is unnecessary — the context lives until its report is gone. Removing this simplifies the happy path and avoids the case where a different admin's DM is still referencing this same contextId (rare but possible if contextId is reused — safer to let cleanup handle).
+
+- [ ] **Step 1: Add failing test.**
+
+In `ReportCallbackServiceTests.cs`, add:
+
+```csharp
+[Test]
+public async Task HandleCallbackAsync_DoesNotDeleteContextById_AfterSuccessfulAction()
+{
+    var callbackContextRepo = Substitute.For<IReportCallbackContextRepository>();
+    var dmService = Substitute.For<IBotDmService>();
+    var reportActionsService = Substitute.For<IReportActionsService>();
+    var logger = Substitute.For<ILogger<ReportCallbackService>>();
+    var scopeFactory = BuildScopeFactory(callbackContextRepo, dmService);
+
+    callbackContextRepo.GetByIdAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+        .Returns(new ReportCallbackContext(
+            Id: 7, ReportId: 42, ReportType: ReportType.ContentReport,
+            ChatId: -1001, UserId: 100, CreatedAt: DateTimeOffset.UtcNow));
+
+    reportActionsService.HandleContentDismissAsync(
+            Arg.Any<long>(), Arg.Any<Actor>(), Arg.Any<CancellationToken>())
+        .Returns(new ReviewActionResult(true, "Dismissed"));
+
+    var sut = new ReportCallbackService(logger, scopeFactory, reportActionsService);
+
+    var query = new CallbackQuery
+    {
+        Id = "cq1",
+        Data = $"rev:7:{(int)ReportAction.Dismiss}",
+        From = new User { Id = 999, FirstName = "Admin" },
+        Message = new Message
+        {
+            Chat = new Chat { Id = 1001 },
+            MessageId = 555,
+            Text = "Original"
+        }
+    };
+
+    await sut.HandleCallbackAsync(query, CancellationToken.None);
+
+    await callbackContextRepo
+        .DidNotReceive()
+        .DeleteAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+}
+
+private static IServiceScopeFactory BuildScopeFactory(
+    IReportCallbackContextRepository repo, IBotDmService dm)
+{
+    var scope = Substitute.For<IServiceScope>();
+    var sp = Substitute.For<IServiceProvider>();
+    sp.GetService(typeof(IReportCallbackContextRepository)).Returns(repo);
+    sp.GetService(typeof(IBotDmService)).Returns(dm);
+    scope.ServiceProvider.Returns(sp);
+    var factory = Substitute.For<IServiceScopeFactory>();
+    factory.CreateScope().Returns(scope);
+    return factory;
+}
+```
+
+- [ ] **Step 2: Run test, verify it FAILS.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~ReportCallbackServiceTests.HandleCallbackAsync_DoesNotDeleteContextById_AfterSuccessfulAction" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: FAIL — `DeleteAsync` received 1 call.
+
+- [ ] **Step 3: Remove the `DeleteAsync(contextId)` call.**
+
+In `TelegramGroupsAdmin.Telegram/Services/ReportCallbackService.cs`, find (near line 85):
+
+```csharp
+        // Delete callback context (the service handles report-level cleanup)
+        await callbackContextRepo.DeleteAsync(contextId, cancellationToken);
+```
+
+Remove both lines.
+
+- [ ] **Step 4: Run test, verify PASS.**
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/ReportCallbackService.cs \
+        TelegramGroupsAdmin.UnitTests/Telegram/Services/ReportCallbackServiceTests.cs
+git commit -F- <<'EOF'
+fix(reports): stop deleting callback context after successful action
+
+Orphan-based cleanup handles callback context lifecycle now. Removing
+eager deletion prevents a race where a second admin clicking around
+the same time finds their context gone.
+
+EOF
+```
+
+---
+
+## Task 5: Replace `DeleteExpiredAsync` with `DeleteOrphanedAsync` on the repository
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Repositories/IReportCallbackContextRepository.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Repositories/ReportCallbackContextRepository.cs`
+- Test: `TelegramGroupsAdmin.IntegrationTests/Repositories/ReportCallbackContextRepositoryTests.cs` (create)
+
+**Context:** The new cleanup strategy deletes callback contexts whose `report_id` no longer matches any row in `reports`. This is a single `DELETE ... WHERE NOT EXISTS` query that EF Core translates efficiently using the existing `ix_report_callback_contexts_report_id` index. The old `DeleteExpiredAsync(TimeSpan)` is dead and should be removed.
+
+- [ ] **Step 1: Create the failing integration test.**
+
+Create `TelegramGroupsAdmin.IntegrationTests/Repositories/ReportCallbackContextRepositoryTests.cs`:
+
+```csharp
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Repositories;
+using TelegramGroupsAdmin.Data.Models;
+using TelegramGroupsAdmin.IntegrationTests.Infrastructure;
+using TelegramGroupsAdmin.Telegram.Models;
+using TelegramGroupsAdmin.Telegram.Repositories;
+
+namespace TelegramGroupsAdmin.IntegrationTests.Repositories;
+
+[TestFixture]
+public class ReportCallbackContextRepositoryTests : IntegrationTestBase
+{
+    [Test]
+    public async Task DeleteOrphanedAsync_RemovesContextsForMissingReports_KeepsContextsForExistingReports()
+    {
+        // Arrange
+        var reportsRepo = ServiceProvider.GetRequiredService<IReportsRepository>();
+        var callbackRepo = ServiceProvider.GetRequiredService<IReportCallbackContextRepository>();
+
+        // Seed a managed chat for FK
+        await SeedManagedChatAsync(-1001L, "TestChat");
+
+        // Report 1: exists in DB
+        var report1Id = await reportsRepo.InsertContentReportAsync(new Report
+        {
+            MessageId = 100,
+            Chat = new ChatIdentity(-1001L, "TestChat"),
+            Status = ReportStatus.Pending,
+            ReportedAt = DateTimeOffset.UtcNow,
+            ReportedByUserId = 200,
+            ReportedByUserName = "tester"
+        }, CancellationToken.None);
+
+        // Context 1: tied to an existing report — must be kept
+        var ctx1 = await callbackRepo.CreateAsync(new ReportCallbackContext(
+            Id: 0, ReportId: report1Id, ReportType: ReportType.ContentReport,
+            ChatId: -1001, UserId: 300, CreatedAt: DateTimeOffset.UtcNow),
+            CancellationToken.None);
+
+        // Context 2: ReportId = 9999 (no such report) — must be deleted
+        var ctx2 = await callbackRepo.CreateAsync(new ReportCallbackContext(
+            Id: 0, ReportId: 9999, ReportType: ReportType.ContentReport,
+            ChatId: -1001, UserId: 300, CreatedAt: DateTimeOffset.UtcNow),
+            CancellationToken.None);
+
+        // Act
+        var deleted = await callbackRepo.DeleteOrphanedAsync(CancellationToken.None);
+
+        // Assert
+        Assert.That(deleted, Is.EqualTo(1), "one orphan deleted");
+        Assert.That(
+            await callbackRepo.GetByIdAsync(ctx1, CancellationToken.None),
+            Is.Not.Null, "context tied to existing report stays");
+        Assert.That(
+            await callbackRepo.GetByIdAsync(ctx2, CancellationToken.None),
+            Is.Null, "orphan context was removed");
+    }
+}
+```
+
+Check the existing integration test base class (`IntegrationTestBase`) for the correct way to seed managed chats — mirror an existing test pattern.
+
+- [ ] **Step 2: Run the integration test, verify compile FAIL.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj \
+    --filter "FullyQualifiedName~ReportCallbackContextRepositoryTests" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: COMPILE FAIL — `DeleteOrphanedAsync` not defined on `IReportCallbackContextRepository`.
+
+- [ ] **Step 3: Update the interface.**
+
+Edit `TelegramGroupsAdmin.Telegram/Repositories/IReportCallbackContextRepository.cs`:
+
+Remove:
+```csharp
+/// <summary>
+/// Delete all expired callback contexts (cleanup job).
+/// </summary>
+Task<int> DeleteExpiredAsync(
+    TimeSpan maxAge,
+    CancellationToken cancellationToken = default);
+```
+
+Add:
+```csharp
+/// <summary>
+/// Delete all callback contexts whose associated report no longer exists.
+/// Used by the data cleanup job — contexts live as long as their report does.
+/// </summary>
+Task<int> DeleteOrphanedAsync(CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 4: Update the implementation.**
+
+Edit `TelegramGroupsAdmin.Telegram/Repositories/ReportCallbackContextRepository.cs`:
+
+Remove the whole `DeleteExpiredAsync` method.
+
+Add (inside the same class):
+
+```csharp
+public async Task<int> DeleteOrphanedAsync(CancellationToken cancellationToken = default)
+{
+    await using var dbContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+    return await dbContext.ReportCallbackContexts
+        .Where(rcc => !dbContext.Reports.Any(r => r.Id == rcc.ReportId))
+        .ExecuteDeleteAsync(cancellationToken);
+}
+```
+
+- [ ] **Step 5: Run the integration test, verify PASS.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj \
+    --filter "FullyQualifiedName~ReportCallbackContextRepositoryTests" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Repositories/IReportCallbackContextRepository.cs \
+        TelegramGroupsAdmin.Telegram/Repositories/ReportCallbackContextRepository.cs \
+        TelegramGroupsAdmin.IntegrationTests/Repositories/ReportCallbackContextRepositoryTests.cs
+git commit -F- <<'EOF'
+refactor(reports): replace DeleteExpiredAsync with DeleteOrphanedAsync
+
+Callback contexts now live as long as their associated report. Orphan-
+based cleanup via EF Core NOT EXISTS uses the existing report_id index.
+Removes the 7-day retention window that was wiping live buttons.
+
+EOF
+```
+
+---
+
+## Task 6: Drop `CallbackContextRetention` from `DataCleanupSettings`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs`
+- Modify: `TelegramGroupsAdmin.IntegrationTests/Services/BackgroundJobConfigPersistenceTests.cs:119,132`
+
+**Context:** The `CallbackContextRetention = "7d"` setting is dead — cleanup is now orphan-based, not age-based. Remove the property from settings and any test assertions that use it.
+
+- [ ] **Step 1: Read the current `DataCleanupSettings.cs` to see the exact property to remove.**
+
+Run: `grep -n "CallbackContextRetention" TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs`
+
+- [ ] **Step 2: Remove the `CallbackContextRetention` property and its default constant usage.**
+
+Delete the property (around line 54):
+```csharp
+public string CallbackContextRetention { get; init; } = "7d";
+```
+
+Search for `DefaultShortRetention` within that file — it's still used by `WebNotificationRetention`, leave it.
+
+- [ ] **Step 3: Update `BackgroundJobConfigPersistenceTests.cs`.**
+
+```bash
+grep -n "CallbackContextRetention" TelegramGroupsAdmin.IntegrationTests/Services/BackgroundJobConfigPersistenceTests.cs
+```
+
+Remove lines 119 (`CallbackContextRetention = "14d",` in the object initializer) and 132 (the corresponding assertion). Do NOT delete adjacent lines for other settings.
+
+- [ ] **Step 4: Build the solution to catch any other references.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: clean build. If any other file still references `CallbackContextRetention`, update it (likely none).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.Core/Models/BackgroundJobSettings/DataCleanupSettings.cs \
+        TelegramGroupsAdmin.IntegrationTests/Services/BackgroundJobConfigPersistenceTests.cs
+git commit -F- <<'EOF'
+refactor(config): drop unused CallbackContextRetention setting
+
+Replaced with orphan-based cleanup — retention by age no longer applies.
+
+EOF
+```
+
+---
+
+## Task 7: Switch `DataCleanupJob` to call `DeleteOrphanedAsync`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs:79,94,184-198`
+
+**Context:** `DataCleanupJob` reads `settings.CallbackContextRetention` and calls `DeleteExpiredAsync(retention)`. Both go away; replace with `DeleteOrphanedAsync()`.
+
+- [ ] **Step 1: Update `ExecuteCleanupAsync` to drop retention lookup.**
+
+Open `TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs`. Around line 79, remove:
+
+```csharp
+        var contextRetention = TimeSpanUtilities.ParseDurationOrDefault(settings.CallbackContextRetention, DataCleanupSettings.DefaultShortRetention);
+```
+
+Change the call at line 94:
+
+```csharp
+// Before
+totalDeleted += await CleanupCallbackContextsAsync(sp, contextRetention, cancellationToken);
+
+// After
+totalDeleted += await CleanupCallbackContextsAsync(sp, cancellationToken);
+```
+
+- [ ] **Step 2: Rewrite `CleanupCallbackContextsAsync`.**
+
+Replace the existing method body (lines 184–198):
+
+```csharp
+private async Task<long> CleanupCallbackContextsAsync(IServiceProvider sp, CancellationToken cancellationToken)
+{
+    var callbackContextRepo = sp.GetRequiredService<IReportCallbackContextRepository>();
+    var contextsDeleted = await callbackContextRepo.DeleteOrphanedAsync(cancellationToken);
+
+    if (contextsDeleted > 0)
+    {
+        _logger.LogInformation(
+            "Callback context cleanup: {Count} orphaned contexts deleted (no matching report)",
+            contextsDeleted);
+    }
+
+    return contextsDeleted;
+}
+```
+
+- [ ] **Step 3: Build the solution.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: clean build.
+
+- [ ] **Step 4: Run a migration-only check to ensure the app still boots with these changes.**
+
+Run: `dotnet run --project TelegramGroupsAdmin --migrate-only`
+
+Expected: "Migrations applied" or "No pending migrations" — and the process exits cleanly.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.BackgroundJobs/Jobs/DataCleanupJob.cs
+git commit -F- <<'EOF'
+fix(cleanup): use orphan-based callback-context cleanup
+
+Callback context cleanup now deletes only contexts whose report no longer
+exists, rather than contexts older than a fixed retention window. Live
+reports keep their buttons for their full lifetime.
+
+EOF
+```
+
+---
+
+# PHASE 2 — Bug C: Clickable Reporter on Moderation Report Card
+
+## Task 8: Wrap reporter in `<UserDetailLink>` for Telegram user reports
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor`
+
+**Context:** Currently `@GetReporterDisplay()` returns a flat string — no link for Telegram reporters. The component already injects a `UserDetailLink` for the reported user at line 31, so we follow the same pattern for `Report.ReportedByUserId != null`.
+
+- [ ] **Step 1: Add the new render fragment method to the `@code` block.**
+
+At the end of the `@code` block (before the closing brace), add:
+
+```csharp
+private RenderFragment RenderReporter() => builder =>
+{
+    // System-generated report (auto-detection)
+    if (Report.ReportedByUserId == null && Report.WebUserId == null)
+    {
+        builder.AddContent(0, Report.ReportedByUserName ?? "System");
+        return;
+    }
+
+    // Telegram user report — clickable
+    if (Report.ReportedByUserId != null)
+    {
+        var displayName = Report.ReportedByUserName ?? "Unknown";
+        builder.OpenComponent<UserDetailLink>(0);
+        builder.AddAttribute(1, nameof(UserDetailLink.UserId), Report.ReportedByUserId.Value);
+        builder.AddAttribute(2, nameof(UserDetailLink.ChildContent),
+            (RenderFragment)(b => b.AddContent(0, displayName)));
+        builder.CloseComponent();
+        builder.AddContent(3, $" (ID: {Report.ReportedByUserId})");
+        return;
+    }
+
+    // Web-user report
+    if (Report.WebUserId != null)
+    {
+        builder.AddContent(0, $"{Report.ReportedByUserName ?? "Web Admin"} (Web User)");
+    }
+};
+```
+
+Note: use `RenderFragment` rather than modifying `GetReporterDisplay()` since we now need a component, not a string.
+
+- [ ] **Step 2: Replace the reporter display line.**
+
+Find line 66–68:
+
+```razor
+<MudText Typo="Typo.caption" Color="Color.Secondary">
+    <b>Reported by:</b> @GetReporterDisplay()
+</MudText>
+```
+
+Replace with:
+
+```razor
+<MudText Typo="Typo.caption" Color="Color.Secondary">
+    <b>Reported by:</b> @RenderReporter()
+</MudText>
+```
+
+- [ ] **Step 3: Delete the now-unused `GetReporterDisplay()` method.**
+
+Verify no other file references it:
+
+```bash
+grep -rn "GetReporterDisplay" TelegramGroupsAdmin/ --include="*.razor" --include="*.cs"
+```
+
+If only this file references it, remove the method. Otherwise, keep it (unlikely given the scope).
+
+- [ ] **Step 4: Build and run the app for UI verification.**
+
+```bash
+dotnet build TelegramGroupsAdmin.sln --configuration Debug
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor
+git commit -F- <<'EOF'
+fix(ui): make reporter clickable on moderation report card
+
+Wraps the reporter name in UserDetailLink for Telegram-user-submitted
+reports (/report command), opening the user detail dialog on click.
+System and web-user reports render as plain text.
+
+EOF
+```
+
+---
+
+# PHASE 3 — Bug B: Entity-Based DM Rendering
+
+## Task 9: Change `Field` record to carry `UserIdentity?`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/Notifications/Field.cs`
+
+**Context:** Foundation for entity-based rendering — the renderer needs richer user info (first/last/username for display fallback in `text_mention`), not just an ID.
+
+- [ ] **Step 1: Replace Field record body.**
+
+Open `TelegramGroupsAdmin/Services/Notifications/Field.cs`:
+
+```csharp
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.Services.Notifications;
+
+/// <summary>
+/// A single labeled field. When User is set, the value renders as a
+/// text_mention entity in Telegram DMs — clickable regardless of whether
+/// the user has interacted with the bot before.
+/// </summary>
+internal sealed record Field(string Label, string Value, UserIdentity? User = null);
+```
+
+- [ ] **Step 2: Build, expect compile failures at call sites.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: compile failures in `NotificationPayloadBuilder.cs`, `SectionBuilder.cs`, `NotificationRenderer.cs`, and `NotificationService.cs`. These are the call sites we update in subsequent tasks.
+
+- [ ] **Step 3: Do NOT commit yet.** The solution is in a broken state. Move to Task 10.
+
+---
+
+## Task 10: Update `NotificationPayloadBuilder` — non-nullable, drop `WithFieldIf`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/Notifications/NotificationPayloadBuilder.cs`
+
+**Context:** Non-nullable overloads, caller owns conditionals. Drop `WithFieldIf` entirely.
+
+- [ ] **Step 1: Replace the builder class.**
+
+Open `TelegramGroupsAdmin/Services/Notifications/NotificationPayloadBuilder.cs` and replace its contents with:
+
+```csharp
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.Services.Notifications;
+
+/// <summary>
+/// Fluent builder for constructing immutable NotificationPayload records.
+/// Each With* method adds content; conditional logic lives at the call site.
+/// </summary>
+internal sealed class NotificationPayloadBuilder
+{
+    private string _subject = "";
+    private readonly List<ContentBlock> _blocks = [];
+    private string? _photoPath;
+    private string? _videoPath;
+    private ActionKeyboardContext? _keyboard;
+
+    public static NotificationPayloadBuilder Create(string subject) => new() { _subject = subject };
+
+    public NotificationPayloadBuilder WithText(string text)
+    {
+        _blocks.Add(new TextBlock(text));
+        return this;
+    }
+
+    public NotificationPayloadBuilder WithField(string label, string value)
+    {
+        _blocks.Add(new FieldList([new(label, value)]));
+        return this;
+    }
+
+    public NotificationPayloadBuilder WithField(string label, UserIdentity user)
+    {
+        _blocks.Add(new FieldList([new(label, user.DisplayName, user)]));
+        return this;
+    }
+
+    public NotificationPayloadBuilder WithSection(string header, Action<SectionBuilder> configure)
+    {
+        var sb = new SectionBuilder();
+        configure(sb);
+        _blocks.Add(new SectionBlock(header, sb.Build()));
+        return this;
+    }
+
+    public NotificationPayloadBuilder WithPhoto(string path)
+    {
+        _photoPath = path;
+        return this;
+    }
+
+    public NotificationPayloadBuilder WithVideo(string path)
+    {
+        _videoPath = path;
+        return this;
+    }
+
+    public NotificationPayloadBuilder WithKeyboard(ActionKeyboardContext ctx)
+    {
+        _keyboard = ctx;
+        return this;
+    }
+
+    public NotificationPayload Build() => new()
+    {
+        Subject = _subject,
+        Blocks = _blocks.ToArray(),
+        PhotoPath = _photoPath,
+        VideoPath = _videoPath,
+        Keyboard = _keyboard
+    };
+}
+```
+
+Note: `WithPhoto` / `WithVideo` are now non-nullable too, consistent with the principle.
+
+- [ ] **Step 2: Do NOT build yet** — `SectionBuilder` and call sites still broken. Move to Task 11.
+
+---
+
+## Task 11: Update `SectionBuilder` — non-nullable, drop `WithFieldIf`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/Notifications/SectionBuilder.cs`
+
+- [ ] **Step 1: Replace the class contents.**
+
+```csharp
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.Services.Notifications;
+
+/// <summary>
+/// Builder for content blocks within a section.
+/// </summary>
+internal sealed class SectionBuilder
+{
+    private readonly List<ContentBlock> _blocks = [];
+
+    public SectionBuilder WithText(string text)
+    {
+        _blocks.Add(new TextBlock(text));
+        return this;
+    }
+
+    public SectionBuilder WithField(string label, string value)
+    {
+        _blocks.Add(new FieldList([new(label, value)]));
+        return this;
+    }
+
+    public SectionBuilder WithField(string label, UserIdentity user)
+    {
+        _blocks.Add(new FieldList([new(label, user.DisplayName, user)]));
+        return this;
+    }
+
+    internal IReadOnlyList<ContentBlock> Build() => _blocks.ToArray();
+}
+```
+
+- [ ] **Step 2: Do NOT build yet** — call sites still broken.
+
+---
+
+## Task 12: Update call sites in `NotificationService.cs`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/NotificationService.cs`
+
+**Context:** Every `.WithField(label, displayName, telegramUserId: id)` call becomes `.WithField(label, userIdentity)` or `.WithField(label, plainString)`. Every `.WithFieldIf(condition, ...)` becomes an explicit `if` block. Every `.WithPhoto(x)` / `.WithVideo(x)` stays but only called when `x != null`.
+
+- [ ] **Step 1: Update `SendSpamBanNotificationAsync`.**
+
+In `TelegramGroupsAdmin/Services/NotificationService.cs`, replace the body starting at `var payload = NotificationPayloadBuilder.Create(title)` (around line 79):
+
+```csharp
+var builder = NotificationPayloadBuilder.Create(title)
+    .WithField("User", user)
+    .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
+    .WithSection("Message", s => s
+        .WithText(messagePreview ?? "[No text]"))
+    .WithSection("Detection", s =>
+    {
+        s.WithField("Net Score", $"{netScore:F2}");
+        s.WithField("Score", $"{score:F2}");
+        if (detectionReason != null)
+            s.WithField("Reason", detectionReason);
+    })
+    .WithSection("Action Taken", s =>
+    {
+        s.WithField("Banned from", $"{chatsAffected} managed chats");
+        if (messageDeleted)
+            s.WithField("Message deleted", $"ID: {messageId}");
+    });
+
+if (photoPath != null)
+    builder.WithPhoto(photoPath);
+
+if (videoPath != null)
+    builder.WithVideo(videoPath);
+
+var payload = builder.Build();
+```
+
+- [ ] **Step 2: Update `SendReportNotificationAsync`.**
+
+Find the existing payload-construction block. Rewrite:
+
+```csharp
+var reporterUser = !isAutomated && reporterUserId.HasValue
+    ? new UserIdentity(reporterUserId.Value, FirstName: null, LastName: null, Username: reporterName)
+    : null;
+
+var builder = NotificationPayloadBuilder.Create("Message Reported")
+    .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
+    .WithField("Reported user", reportedUser);
+
+if (reporterUser != null)
+    builder.WithField("Reported by", reporterUser);
+else
+    builder.WithField("Reported by", "System (automated)");
+
+builder
+    .WithSection("Message", s => s.WithText(messagePreview))
+    .WithKeyboard(new ActionKeyboardContext(reportId, chat.Id, reportedUser.Id, reportType));
+
+if (photoPath != null)
+    builder.WithPhoto(photoPath);
+
+var payload = builder.Build();
+```
+
+- [ ] **Step 3: Update `SendProfileScanAlertAsync`.**
+
+```csharp
+var payload = NotificationPayloadBuilder.Create("Profile Scan Alert")
+    .WithField("User", user)
+    .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
+    .WithSection("Analysis", s =>
+    {
+        s.WithField("Score", $"{score:F1}");
+        s.WithField("Signals", signals);
+        if (aiReason != null)
+            s.WithField("AI Reasoning", aiReason);
+    })
+    .WithKeyboard(new ActionKeyboardContext(reportId, chat.Id, user.Id, ReportType.ProfileScanAlert))
+    .Build();
+```
+
+- [ ] **Step 4: Update `SendExamFailureNotificationAsync`.**
+
+```csharp
+var payload = NotificationPayloadBuilder.Create("Entrance Exam Review Required")
+    .WithField("User", user)
+    .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
+    .WithSection("Results", s =>
+    {
+        s.WithField("Answered", $"{mcCorrectCount}/{mcTotal} correct");
+        s.WithField("Score", $"{mcScore}% (Required: {mcPassingThreshold}%)");
+    })
+    .WithSection("Open-Ended Response", s =>
+    {
+        if (openEndedQuestion != null) s.WithField("Question", openEndedQuestion);
+        if (openEndedAnswer != null) s.WithField("Answer", openEndedAnswer);
+        if (aiReasoning != null) s.WithField("AI Reasoning", aiReasoning);
+    })
+    .WithKeyboard(new ActionKeyboardContext(examFailureId, chat.Id, user.Id, ReportType.ExamFailure))
+    .Build();
+```
+
+- [ ] **Step 5: Update `SendBanNotificationAsync`, `SendMalwareDetectedAsync`, `SendAdminChangedAsync`, `SendBackupFailedAsync`, `SendChatHealthWarningAsync` using the same patterns.**
+
+For each:
+- Replace `.WithField(label, user.DisplayName, telegramUserId: user.Id)` → `.WithField(label, user)`.
+- Replace `.WithFieldIf(cond, label, value)` → `if (cond) builder.WithField(label, value);` (converted to imperative).
+- Replace `.WithPhoto(x)` / `.WithVideo(x)` with a guarded `if (x != null) builder.WithPhoto(x);` call.
+
+- [ ] **Step 6: Build the solution.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: clean build if all call sites have been migrated. If compile errors remain, fix each file listed.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add TelegramGroupsAdmin/Services/Notifications/Field.cs \
+        TelegramGroupsAdmin/Services/Notifications/NotificationPayloadBuilder.cs \
+        TelegramGroupsAdmin/Services/Notifications/SectionBuilder.cs \
+        TelegramGroupsAdmin/Services/NotificationService.cs
+git commit -F- <<'EOF'
+refactor(notifications): non-nullable builder, UserIdentity-aware fields
+
+Moves conditional logic out of the builder. Fields carry UserIdentity so
+the renderer can emit text_mention entities with embedded User objects
+for clickable DM mentions (next commit).
+
+EOF
+```
+
+---
+
+## Task 13: Update `NotificationPayloadBuilderTests` for new signatures
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationPayloadBuilderTests.cs`
+
+- [ ] **Step 1: Read the existing test file to understand current structure.**
+
+```bash
+cat TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationPayloadBuilderTests.cs
+```
+
+- [ ] **Step 2: Update each test method that uses the old signatures.**
+
+For each `.WithField(label, value, telegramUserId: id)` test: rewrite to use `.WithField(label, user)` and assert `field.User` instead of `field.TelegramUserId`.
+
+For each `WithFieldIf` test: delete it (the method is gone).
+
+For each `.WithPhoto(null)` test: rewrite to assert the property is null when `WithPhoto` is NOT called.
+
+- [ ] **Step 3: Run tests, verify PASS.**
+
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~NotificationPayloadBuilderTests" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationPayloadBuilderTests.cs
+git commit -F- <<'EOF'
+test(notifications): update builder tests for new signatures
+
+EOF
+```
+
+---
+
+## Task 14: Create `TelegramMessage` record
+
+**Files:**
+- Create: `TelegramGroupsAdmin/Services/Notifications/TelegramMessage.cs`
+
+- [ ] **Step 1: Create the record.**
+
+```csharp
+using Telegram.Bot.Types;
+
+namespace TelegramGroupsAdmin.Services.Notifications;
+
+/// <summary>
+/// Rendered Telegram message — plain text plus explicit entities.
+/// Sent with no parse_mode; Telegram renders exactly what the entities specify.
+/// </summary>
+internal sealed record TelegramMessage(
+    string Text,
+    IReadOnlyList<MessageEntity> Entities);
+```
+
+- [ ] **Step 2: Build.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: clean build.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add TelegramGroupsAdmin/Services/Notifications/TelegramMessage.cs
+git commit -F- <<'EOF'
+feat(notifications): add TelegramMessage record for entity-based output
+
+EOF
+```
+
+---
+
+## Task 15: Rewrite `NotificationRenderer.ToTelegramMessage`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/Notifications/NotificationRenderer.cs`
+
+**Context:** Replace the HTML-producing `ToTelegramHtml` with `ToTelegramMessage` that emits `(text, entities)`. Use `StringBuilder` for text, track `currentOffset` (= `sb.Length`, which in .NET is UTF-16 code units — exactly what Telegram expects).
+
+- [ ] **Step 1: Replace the `ToTelegramHtml` method and its two Telegram helpers.**
+
+Open `TelegramGroupsAdmin/Services/Notifications/NotificationRenderer.cs`. Replace (from the existing `ToTelegramHtml` through `RenderBlocksTelegram` end) with:
+
+```csharp
+/// <summary>
+/// Render payload as entity-based Telegram message.
+/// Emits Bold entities for subject, field labels, and section headers;
+/// TextMention entities with full User object for clickable user mentions.
+/// No HTML — uses the entities parameter which is mutually exclusive with parse_mode.
+/// </summary>
+public static TelegramMessage ToTelegramMessage(NotificationPayload payload)
+{
+    var sb = new StringBuilder();
+    var entities = new List<MessageEntity>();
+
+    // Subject (bold, own line)
+    AppendBold(sb, entities, payload.Subject);
+    sb.AppendLine();
+    sb.AppendLine();
+
+    RenderBlocksTelegram(sb, entities, payload.Blocks);
+
+    return new TelegramMessage(sb.ToString().TrimEnd(), entities);
+}
+
+private static void RenderBlocksTelegram(
+    StringBuilder sb, List<MessageEntity> entities, IReadOnlyList<ContentBlock> blocks)
+{
+    foreach (var block in blocks)
+    {
+        switch (block)
+        {
+            case TextBlock text:
+                sb.AppendLine(text.Text);
+                break;
+
+            case FieldList fieldList:
+                foreach (var field in fieldList.Fields)
+                {
+                    AppendBold(sb, entities, $"{field.Label}:");
+                    sb.Append(' ');
+                    if (field.User is { } u)
+                        AppendUserMention(sb, entities, field.Value, u);
+                    else
+                        sb.Append(field.Value);
+                    sb.AppendLine();
+                }
+                break;
+
+            case SectionBlock section:
+                sb.AppendLine();
+                AppendBold(sb, entities, section.Header);
+                sb.AppendLine();
+                RenderBlocksTelegram(sb, entities, section.Content);
+                break;
+        }
+    }
+}
+
+private static void AppendBold(StringBuilder sb, List<MessageEntity> entities, string text)
+{
+    var offset = sb.Length;
+    sb.Append(text);
+    entities.Add(new MessageEntity
+    {
+        Type = MessageEntityType.Bold,
+        Offset = offset,
+        Length = text.Length
+    });
+}
+
+private static void AppendUserMention(
+    StringBuilder sb, List<MessageEntity> entities, string displayText, UserIdentity user)
+{
+    var offset = sb.Length;
+    sb.Append(displayText);
+    entities.Add(new MessageEntity
+    {
+        Type = MessageEntityType.TextMention,
+        Offset = offset,
+        Length = displayText.Length,
+        User = new User
+        {
+            Id = user.Id,
+            IsBot = false,
+            FirstName = user.FirstName ?? string.Empty,
+            LastName = user.LastName,
+            Username = user.Username
+        }
+    });
+}
+```
+
+Add `using Telegram.Bot.Types;`, `using Telegram.Bot.Types.Enums;`, `using TelegramGroupsAdmin.Core.Models;` at the top of the file if not already present.
+
+- [ ] **Step 2: Build.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: `NotificationService.cs` call sites that used `ToTelegramHtml` will fail to compile. Those are fixed in Task 18.
+
+- [ ] **Step 3: Do NOT commit yet.** Continue to Task 16.
+
+---
+
+## Task 16: Rewrite `NotificationRendererTests` for entities
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationRendererTests.cs`
+
+- [ ] **Step 1: Read the current test file.**
+
+```bash
+cat TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationRendererTests.cs
+```
+
+- [ ] **Step 2: Replace the existing Telegram-rendering tests with entity-based ones.**
+
+Remove all tests that assert on HTML strings (`Does.Contain("<b>")`, `Does.Contain("tg://user")`, etc.). Add:
+
+```csharp
+using Telegram.Bot.Types.Enums;
+
+[Test]
+public void ToTelegramMessage_SubjectIsBoldOnFirstLine()
+{
+    var payload = NotificationPayloadBuilder.Create("Alert Title").Build();
+
+    var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+    Assert.That(rendered.Text, Does.StartWith("Alert Title"));
+    Assert.That(rendered.Entities, Has.Some.Matches<MessageEntity>(e =>
+        e.Type == MessageEntityType.Bold &&
+        e.Offset == 0 &&
+        e.Length == "Alert Title".Length));
+}
+
+[Test]
+public void ToTelegramMessage_FieldWithoutUserEmitsPlainValueAndBoldLabel()
+{
+    var payload = NotificationPayloadBuilder.Create("Alert")
+        .WithField("Chat", "MyGroup")
+        .Build();
+
+    var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+    // Find the label entity
+    var labelEntity = rendered.Entities.FirstOrDefault(e =>
+        e.Type == MessageEntityType.Bold &&
+        rendered.Text.Substring(e.Offset, e.Length) == "Chat:");
+    Assert.That(labelEntity, Is.Not.Null, "label should be bold");
+
+    // Value should not have a TextMention
+    Assert.That(rendered.Entities, Has.None.Matches<MessageEntity>(e =>
+        e.Type == MessageEntityType.TextMention));
+
+    Assert.That(rendered.Text, Does.Contain("Chat: MyGroup"));
+}
+
+[Test]
+public void ToTelegramMessage_FieldWithUserEmitsTextMentionWithEmbeddedUser()
+{
+    var user = new UserIdentity(
+        Id: 12345,
+        FirstName: "Alice",
+        LastName: "Smith",
+        Username: "alice_s");
+    var payload = NotificationPayloadBuilder.Create("Alert")
+        .WithField("User", user)
+        .Build();
+
+    var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+    var mention = rendered.Entities.FirstOrDefault(e =>
+        e.Type == MessageEntityType.TextMention);
+    Assert.That(mention, Is.Not.Null, "user field should produce TextMention");
+    Assert.That(mention!.User, Is.Not.Null);
+    Assert.That(mention.User!.Id, Is.EqualTo(12345));
+    Assert.That(mention.User.FirstName, Is.EqualTo("Alice"));
+    Assert.That(mention.User.LastName, Is.EqualTo("Smith"));
+    Assert.That(mention.User.Username, Is.EqualTo("alice_s"));
+
+    // The span of the TextMention covers only the user display name, not the label
+    var span = rendered.Text.Substring(mention.Offset, mention.Length);
+    Assert.That(span, Is.EqualTo(user.DisplayName));
+}
+
+[Test]
+public void ToTelegramMessage_SectionHeaderIsBold()
+{
+    var payload = NotificationPayloadBuilder.Create("Alert")
+        .WithSection("Analysis", s => s.WithField("Score", "1.0"))
+        .Build();
+
+    var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+    var headerEntity = rendered.Entities.FirstOrDefault(e =>
+        e.Type == MessageEntityType.Bold &&
+        rendered.Text.Substring(e.Offset, e.Length) == "Analysis");
+    Assert.That(headerEntity, Is.Not.Null);
+}
+
+[Test]
+public void ToTelegramMessage_EntityOffsetsMatchTextForNonBmpCharacters()
+{
+    // UserIdentity with an emoji in the first name to verify UTF-16 offset handling.
+    var user = new UserIdentity(Id: 1, FirstName: "👤User", LastName: null, Username: null);
+    var payload = NotificationPayloadBuilder.Create("Alert")
+        .WithField("User", user)
+        .Build();
+
+    var rendered = NotificationRenderer.ToTelegramMessage(payload);
+
+    var mention = rendered.Entities.Single(e =>
+        e.Type == MessageEntityType.TextMention);
+    var span = rendered.Text.Substring(mention.Offset, mention.Length);
+    Assert.That(span, Is.EqualTo(user.DisplayName),
+        "entity offset/length must address the exact display text in UTF-16 code units");
+}
+```
+
+- [ ] **Step 3: Run tests.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --filter "FullyQualifiedName~NotificationRendererTests" \
+    --logger "console;verbosity=normal"
+```
+
+Expected: all new tests PASS. Existing tests that checked HTML-specific behavior should already be removed.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add TelegramGroupsAdmin/Services/Notifications/NotificationRenderer.cs \
+        TelegramGroupsAdmin.UnitTests/Services/Notifications/NotificationRendererTests.cs
+git commit -F- <<'EOF'
+feat(notifications): entity-based Telegram rendering with text_mention
+
+Replaces ToTelegramHtml with ToTelegramMessage returning
+(text, entities). Bold entities for titles/labels/headers; TextMention
+with embedded User object for clickable mentions that work even for
+users with no prior bot interaction.
+
+Email and plain text rendering paths unchanged.
+
+EOF
+```
+
+---
+
+## Task 17: Add `entities` parameter to `IBotMessageHandler`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/IBotMessageHandler.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/BotMessageHandler.cs`
+
+- [ ] **Step 1: Update the interface.**
+
+Open `IBotMessageHandler.cs`. For `SendAsync`, `SendPhotoAsync`, `SendVideoAsync`, add a new optional parameter **after** existing parameters so callers without entities are unaffected:
+
+```csharp
+Task<Message> SendAsync(
+    long chatId,
+    string text,
+    ParseMode? parseMode = null,
+    ReplyParameters? replyParameters = null,
+    InlineKeyboardMarkup? replyMarkup = null,
+    IReadOnlyList<MessageEntity>? entities = null,
+    CancellationToken ct = default);
+
+Task<Message> SendPhotoAsync(
+    long chatId,
+    InputFile photo,
+    string? caption = null,
+    ParseMode? parseMode = null,
+    ReplyParameters? replyParameters = null,
+    InlineKeyboardMarkup? replyMarkup = null,
+    IReadOnlyList<MessageEntity>? captionEntities = null,
+    CancellationToken ct = default);
+
+Task<Message> SendVideoAsync(
+    long chatId,
+    InputFile video,
+    string? caption = null,
+    ParseMode? parseMode = null,
+    ReplyParameters? replyParameters = null,
+    InlineKeyboardMarkup? replyMarkup = null,
+    IReadOnlyList<MessageEntity>? captionEntities = null,
+    CancellationToken ct = default);
+```
+
+(Do not modify `SendAnimationAsync`, `EditTextAsync`, `EditCaptionAsync`, `DeleteAsync`, `AnswerCallbackAsync` — not needed for this change.)
+
+- [ ] **Step 2: Update the implementation.**
+
+In `BotMessageHandler.cs`, thread the new parameter through to the `apiClient.SendMessageAsync` / `SendPhotoAsync` / `SendVideoAsync` calls. Check the Telegram.Bot SDK method signature via an IDE (or `find_symbol` in CSharperMcp) to find the exact parameter name (likely `entities` and `captionEntities`).
+
+Example for `SendAsync`:
+
+```csharp
+public async Task<Message> SendAsync(
+    long chatId,
+    string text,
+    ParseMode? parseMode = null,
+    ReplyParameters? replyParameters = null,
+    InlineKeyboardMarkup? replyMarkup = null,
+    IReadOnlyList<MessageEntity>? entities = null,
+    CancellationToken ct = default)
+{
+    var apiClient = await botClientFactory.GetApiClientAsync();
+    return await apiClient.SendMessageAsync(
+        chatId,
+        text,
+        parseMode: parseMode,
+        replyParameters: replyParameters,
+        replyMarkup: replyMarkup,
+        entities: entities,
+        ct: ct);
+}
+```
+
+If `ITelegramApiClient.SendMessageAsync` doesn't have an `entities` parameter, use `find_symbol` / `get_symbol_info` (CSharperMcp) to locate it and add the parameter. It likely needs to pass through to the underlying Telegram.Bot `TelegramBotClient.SendMessage` call.
+
+- [ ] **Step 3: If `ITelegramApiClient` needs updating too, update it now.**
+
+Open `TelegramGroupsAdmin.Telegram/Services/Bot/ITelegramApiClient.cs` and `TelegramApiClient.cs`. Add the `entities` / `captionEntities` parameter to `SendMessageAsync`, `SendPhotoAsync`, `SendVideoAsync` mirroring the handler. The implementation calls the Telegram.Bot client — look up the exact parameter name on that SDK method.
+
+- [ ] **Step 4: Build.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: clean build.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/IBotMessageHandler.cs \
+        TelegramGroupsAdmin.Telegram/Services/Bot/Handlers/BotMessageHandler.cs \
+        TelegramGroupsAdmin.Telegram/Services/Bot/ITelegramApiClient.cs \
+        TelegramGroupsAdmin.Telegram/Services/Bot/TelegramApiClient.cs
+git commit -F- <<'EOF'
+feat(telegram): add entities parameter to bot message handler
+
+Optional, non-breaking — allows callers to pass explicit MessageEntity
+arrays alongside (or instead of) parse_mode.
+
+EOF
+```
+
+---
+
+## Task 18: Add entity-based overloads to `IBotDmService`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs`
+
+**Context:** Add new overloads that take a `TelegramMessage` (text + entities). The implementation calls the updated handler methods with `parseMode: null` and the entities list. Existing `string + parseMode` overloads stay for non-notification callers.
+
+`TelegramMessage` lives in `TelegramGroupsAdmin.Services.Notifications` (internal to the main project). Since `IBotDmService` is in `TelegramGroupsAdmin.Telegram`, we can't reference `TelegramMessage` there directly without a project dependency inversion.
+
+**Solution:** Take `(string text, IReadOnlyList<MessageEntity> entities)` as separate parameters at the service boundary. `NotificationService` (the caller) unpacks the `TelegramMessage` at the call site.
+
+- [ ] **Step 1: Add the new overloads to the interface.**
+
+In `IBotDmService.cs` add:
+
+```csharp
+/// <summary>
+/// Attempt to send a DM using pre-rendered text + entities (no parse_mode).
+/// For admin notifications that need text_mention entities.
+/// If DM fails (403), queues the message for later delivery (text only, entities dropped).
+/// </summary>
+Task<DmDeliveryResult> SendDmWithEntitiesAsync(
+    long telegramUserId,
+    string notificationType,
+    string text,
+    IReadOnlyList<MessageEntity> entities,
+    CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Attempt to send a DM with media, entities, and inline keyboard buttons (no parse_mode).
+/// If DM fails (403), queues the text for later delivery (without media/buttons/entities).
+/// </summary>
+Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
+    long telegramUserId,
+    string notificationType,
+    string text,
+    IReadOnlyList<MessageEntity> entities,
+    string? photoPath = null,
+    string? videoPath = null,
+    InlineKeyboardMarkup? keyboard = null,
+    CancellationToken cancellationToken = default);
+```
+
+Add `using Telegram.Bot.Types;` and `using Telegram.Bot.Types.ReplyMarkups;` at the top if not already present.
+
+- [ ] **Step 2: Implement the new methods in `BotDmService.cs`.**
+
+Model after the existing `SendDmWithQueueAsync` and `SendDmWithMediaAndKeyboardAsync` methods, but:
+- Pass `parseMode: null`
+- Pass `entities: entities` (text) or `captionEntities: entities` (photo/video caption)
+
+```csharp
+public async Task<DmDeliveryResult> SendDmWithEntitiesAsync(
+    long telegramUserId,
+    string notificationType,
+    string text,
+    IReadOnlyList<MessageEntity> entities,
+    CancellationToken cancellationToken = default)
+{
+    var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
+
+    try
+    {
+        await messageHandler.SendAsync(
+            chatId: telegramUserId,
+            text: text,
+            parseMode: null,
+            entities: entities,
+            ct: cancellationToken);
+
+        logger.LogInformation(
+            "DM sent successfully to {User} (notification type: {NotificationType})",
+            user.ToLogInfo(telegramUserId), notificationType);
+
+        await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
+
+        return new DmDeliveryResult { DmSent = true, FallbackUsed = false, Failed = false };
+    }
+    catch (ApiRequestException ex) when (ex.ErrorCode == 403)
+    {
+        logger.LogWarning(
+            "DM blocked for {User} - queueing {NotificationType} for later delivery",
+            user.ToLogDebug(telegramUserId), notificationType);
+
+        await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
+
+        // Queue text only — entities are lost but we preserve the content for eventual delivery
+        await pendingNotificationsRepository.AddPendingNotificationAsync(
+            telegramUserId, notificationType, text, cancellationToken: cancellationToken);
+
+        return new DmDeliveryResult
+        {
+            DmSent = false, FallbackUsed = false, Failed = true,
+            ErrorMessage = "User has not enabled DMs - notification queued for later delivery"
+        };
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "Failed to send DM to {User}", user.ToLogDebug(telegramUserId));
+        return new DmDeliveryResult
+        {
+            DmSent = false, FallbackUsed = false, Failed = true, ErrorMessage = ex.Message
+        };
+    }
+}
+
+public async Task<DmDeliveryResult> SendDmWithMediaAndKeyboardEntitiesAsync(
+    long telegramUserId,
+    string notificationType,
+    string text,
+    IReadOnlyList<MessageEntity> entities,
+    string? photoPath = null,
+    string? videoPath = null,
+    InlineKeyboardMarkup? keyboard = null,
+    CancellationToken cancellationToken = default)
+{
+    var user = await telegramUserRepository.GetByTelegramIdAsync(telegramUserId, cancellationToken);
+
+    try
+    {
+        if (!string.IsNullOrWhiteSpace(photoPath) && File.Exists(photoPath))
+        {
+            await using var photoStream = File.OpenRead(photoPath);
+            await messageHandler.SendPhotoAsync(
+                chatId: telegramUserId,
+                photo: InputFile.FromStream(photoStream, Path.GetFileName(photoPath)),
+                caption: text,
+                parseMode: null,
+                replyMarkup: keyboard,
+                captionEntities: entities,
+                ct: cancellationToken);
+        }
+        else if (!string.IsNullOrWhiteSpace(videoPath) && File.Exists(videoPath))
+        {
+            await using var videoStream = File.OpenRead(videoPath);
+            await messageHandler.SendVideoAsync(
+                chatId: telegramUserId,
+                video: InputFile.FromStream(videoStream, Path.GetFileName(videoPath)),
+                caption: text,
+                parseMode: null,
+                replyMarkup: keyboard,
+                captionEntities: entities,
+                ct: cancellationToken);
+        }
+        else
+        {
+            await messageHandler.SendAsync(
+                chatId: telegramUserId,
+                text: text,
+                parseMode: null,
+                replyMarkup: keyboard,
+                entities: entities,
+                ct: cancellationToken);
+        }
+
+        logger.LogInformation(
+            "DM with entities/media/keyboard sent to {User}",
+            user.ToLogInfo(telegramUserId));
+
+        await telegramUserRepository.EnableBotDmAsync(telegramUserId, cancellationToken);
+
+        return new DmDeliveryResult { DmSent = true, FallbackUsed = false, Failed = false };
+    }
+    catch (ApiRequestException ex) when (ex.ErrorCode == 403)
+    {
+        logger.LogInformation(
+            "{User} has blocked bot DMs, queuing notification",
+            user.ToLogInfo(telegramUserId));
+
+        await telegramUserRepository.DisableBotDmAsync(telegramUserId, cancellationToken);
+
+        // Queue plain text; entities/media/buttons dropped
+        await pendingNotificationsRepository.AddPendingNotificationAsync(
+            telegramUserId, notificationType, text, cancellationToken: cancellationToken);
+
+        return new DmDeliveryResult
+        {
+            DmSent = false, FallbackUsed = false, Failed = true,
+            ErrorMessage = "User has blocked bot DMs - notification queued for later delivery"
+        };
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "Failed to send DM with entities/media/keyboard to {User}",
+            user.ToLogDebug(telegramUserId));
+        return new DmDeliveryResult
+        {
+            DmSent = false, FallbackUsed = false, Failed = true, ErrorMessage = ex.Message
+        };
+    }
+}
+```
+
+- [ ] **Step 3: Build.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: clean build.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/Bot/IBotDmService.cs \
+        TelegramGroupsAdmin.Telegram/Services/Bot/BotDmService.cs
+git commit -F- <<'EOF'
+feat(dm): add entity-based overloads to IBotDmService
+
+New overloads that send text + MessageEntity arrays with no parse_mode,
+enabling text_mention entities for clickable user mentions.
+
+EOF
+```
+
+---
+
+## Task 19: Wire `NotificationService` to use the new DM overloads
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/NotificationService.cs`
+
+**Context:** Replace the `SendDmWithQueueAsync(..., ParseMode.Html)` and `SendDmWithMediaAndKeyboardAsync(..., parseMode: ParseMode.Html)` calls in `SendTypedTelegramDmAsync` and `SendTelegramDmDirectAsync` with the new `*Entities` overloads.
+
+- [ ] **Step 1: Update `SendTypedTelegramDmAsync`.**
+
+Find the method (around line 441). Replace the render + send block:
+
+```csharp
+// Before
+var htmlMessage = NotificationRenderer.ToTelegramHtml(payload);
+
+InlineKeyboardMarkup? keyboard = null;
+if (payload.Keyboard is { } kb)
+{
+    keyboard = await BuildReportActionKeyboardAsync(
+        kb.EntityId, kb.ChatId, kb.UserId, kb.KeyboardType, ct);
+}
+
+DmDeliveryResult result;
+
+if (keyboard != null || !string.IsNullOrWhiteSpace(payload.PhotoPath) || !string.IsNullOrWhiteSpace(payload.VideoPath))
+{
+    result = await _dmDeliveryService.SendDmWithMediaAndKeyboardAsync(
+        mapping.TelegramId, "notification", htmlMessage,
+        photoPath: payload.PhotoPath, videoPath: payload.VideoPath,
+        keyboard: keyboard, parseMode: ParseMode.Html, cancellationToken: ct);
+}
+else
+{
+    result = await _dmDeliveryService.SendDmWithQueueAsync(
+        mapping.TelegramId, "notification", htmlMessage,
+        parseMode: ParseMode.Html, cancellationToken: ct);
+}
+
+// After
+var telegramMessage = NotificationRenderer.ToTelegramMessage(payload);
+
+InlineKeyboardMarkup? keyboard = null;
+if (payload.Keyboard is { } kb)
+{
+    keyboard = await BuildReportActionKeyboardAsync(
+        kb.EntityId, kb.ChatId, kb.UserId, kb.KeyboardType, ct);
+}
+
+DmDeliveryResult result;
+
+if (keyboard != null || !string.IsNullOrWhiteSpace(payload.PhotoPath) || !string.IsNullOrWhiteSpace(payload.VideoPath))
+{
+    result = await _dmDeliveryService.SendDmWithMediaAndKeyboardEntitiesAsync(
+        mapping.TelegramId, "notification",
+        telegramMessage.Text, telegramMessage.Entities,
+        photoPath: payload.PhotoPath, videoPath: payload.VideoPath,
+        keyboard: keyboard, cancellationToken: ct);
+}
+else
+{
+    result = await _dmDeliveryService.SendDmWithEntitiesAsync(
+        mapping.TelegramId, "notification",
+        telegramMessage.Text, telegramMessage.Entities,
+        cancellationToken: ct);
+}
+```
+
+- [ ] **Step 2: Update `SendTelegramDmDirectAsync` the same way.**
+
+Find the method (around line 512), apply the same `ToTelegramHtml` → `ToTelegramMessage` and `*WithQueue*` → `*WithEntitiesAsync` swaps.
+
+- [ ] **Step 3: Remove the `using Telegram.Bot.Types.Enums;` import if `ParseMode` is no longer referenced in this file.**
+
+```bash
+grep -n "ParseMode" TelegramGroupsAdmin/Services/NotificationService.cs
+```
+
+If zero hits, remove the import.
+
+- [ ] **Step 4: Build.**
+
+Run: `dotnet build TelegramGroupsAdmin.sln --configuration Debug`
+
+Expected: clean build.
+
+- [ ] **Step 5: Run the full unit-test suite.**
+
+Run:
+```bash
+dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj \
+    --configuration Debug \
+    --logger "console;verbosity=minimal"
+```
+
+Expected: all tests pass. Any failures at this point are migration leftovers — fix call sites.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add TelegramGroupsAdmin/Services/NotificationService.cs
+git commit -F- <<'EOF'
+feat(notifications): wire admin DMs to entity-based sending
+
+Admin notifications now send via entities instead of parse_mode=Html.
+User mentions become proper text_mention entities with embedded User
+objects, so they're clickable even when the mentioned user has never
+interacted with the admin's Telegram client.
+
+EOF
+```
+
+---
+
+## Task 20: Run the integration test suite and verify behavior end-to-end
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the integration test suite.**
+
+Run in background (takes ~10 min):
+```bash
+mkdir -p logs
+dotnet test TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj \
+    --configuration Debug \
+    --logger "console;verbosity=minimal" \
+    | tee logs/integration-$(date +%s).log &
+```
+
+Wait for completion, then check the log file.
+
+Expected: all tests pass. The new `ReportCallbackContextRepositoryTests.DeleteOrphanedAsync_*` test is among them.
+
+- [ ] **Step 2: Verify migration sanity.**
+
+Run: `dotnet run --project TelegramGroupsAdmin --migrate-only`
+
+Expected: "No pending migrations" or the normal migration-apply log, and clean exit.
+
+- [ ] **Step 3: Open the design doc and cross-check each non-goal is preserved.**
+
+```bash
+cat docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md | head -80
+```
+
+Walk through the "Non-Goals" list and verify none have been altered:
+- `NotificationBell` / `NotificationItem` untouched
+- Email rendering untouched
+- Web push plain text untouched
+- `Actor.FromWebUser` untouched
+- Other report cards (ProfileScanAlertCard, etc.) untouched
+
+- [ ] **Step 4: Manual verification checklist** (run in dev or whenever the next dev DM occurs — document as a comment in the PR):
+
+1. Trigger a spam detection → admin DM received → target user name is **clickable and styled** (tap opens profile) for a user with no prior interaction.
+2. Submit a `/report` in a managed chat → moderation report card on the web UI shows the reporter name as a clickable link that opens the user detail dialog.
+3. Simulate multi-admin: have two admins receive the same report DM. Admin A clicks "Dismiss". Admin B clicks their button a minute later. Admin B sees `"Already handled by ..."` — not `"Button expired"`.
+4. Leave a report pending for 10 minutes. Admin buttons still work (no 7-day-style expiry).
+
+- [ ] **Step 5: Push the branch and open a PR to `develop`.**
+
+```bash
+git push -u origin fix/admin-notification-buttons-and-mentions
+gh pr create --base develop --title "fix(notifications): cross-admin button expiration and clickable DM mentions" --body "$(cat <<'EOF'
+## Summary
+- Stops eager deletion of DM callback contexts in report action handlers; multi-admin races now resolve to "Already handled by X" instead of "Button expired"
+- Replaces 7-day callback context retention with orphan-based cleanup (tied to report lifetime)
+- Switches admin notification Telegram DMs from parse_mode=Html to entity-based sending, with proper `text_mention` entities for user mentions
+- Wraps the reporter name in `UserDetailLink` on the moderation report card for `/report`-submitted reports
+
+Design: [docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md](docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md)
+Plan: [docs/superpowers/plans/2026-04-23-admin-notification-fixes.md](docs/superpowers/plans/2026-04-23-admin-notification-fixes.md)
+
+## Test plan
+- [x] Unit tests — all passing (handlers + renderer + builder)
+- [x] Integration tests — `ReportCallbackContextRepositoryTests.DeleteOrphanedAsync_*` passing
+- [x] Migration-only run passes
+- [ ] Manual: trigger spam detection, confirm DM target user clickable
+- [ ] Manual: submit /report, confirm reporter clickable on UI
+- [ ] Manual: multi-admin race produces "Already handled by"
+EOF
+)"
+```
+
+- [ ] **Step 6: Commit any last-minute fixes** from manual verification if found.
+
+---
+
+## Self-Review Notes
+
+After writing this plan, I cross-checked it against the spec:
+
+**Spec coverage:**
+- Bug A — covered by Tasks 1–7
+- Bug B (entity rendering) — covered by Tasks 9–19
+- Bug C (UI link) — covered by Task 8
+- Non-goals — preserved (no email, web push, web-user Actor, or other report-card changes)
+
+**Placeholder scan:** No TBDs or vague steps. Every code step has complete code.
+
+**Type consistency:**
+- `Field(string Label, string Value, UserIdentity? User = null)` used consistently (Task 9, 16, tests)
+- `TelegramMessage(string Text, IReadOnlyList<MessageEntity> Entities)` used consistently (Task 14, 15, 19)
+- Method names: `DeleteOrphanedAsync` consistent (Task 5, 7)
+- New DM methods: `SendDmWithEntitiesAsync`, `SendDmWithMediaAndKeyboardEntitiesAsync` consistent (Task 18, 19)
+
+Plan is self-consistent and matches the spec.

--- a/docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md
@@ -1,0 +1,337 @@
+# Admin Notification Fixes — Button Expiration & Clickable Mentions
+
+**Date:** 2026-04-23
+**Scope:** Two related bugs in admin-facing notifications.
+
+## Problem Statement
+
+### Bug A — DM action buttons expire within minutes
+
+Admins receive action buttons (Ban, Warn, Dismiss, Allow, Kick, etc.) in DM
+notifications for reports. In multi-admin deployments these buttons frequently
+show `"Button expired - please use web UI"` within seconds or minutes of the
+report arriving, even though the underlying report is still pending and
+actionable.
+
+**Root cause:** Each admin receiving a DM for a report gets their own
+`report_callback_contexts` row (so short callback IDs stay under Telegram's
+64-byte limit). When admin A clicks any action button, the action handlers
+call `IReportCallbackContextRepository.DeleteByReportIdAsync(reportId)` which
+wipes the callback contexts for **every admin**, not just admin A. The
+remaining admins' button clicks then fail to resolve their context and the
+service returns `"Button expired"` as a blanket fallback.
+
+Call sites of the problematic eager delete:
+
+- `TelegramGroupsAdmin.Telegram/Services/ReportActions/ContentReportHandler.cs:284`
+- `TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs:64`
+- `TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs:116`
+- `TelegramGroupsAdmin.Telegram/Services/ReportActions/ProfileScanHandler.cs:173`
+- `TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs:50`
+- `TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs:87`
+- `TelegramGroupsAdmin.Telegram/Services/ReportActions/ExamHandler.cs:124`
+- `TelegramGroupsAdmin.Telegram/Services/ReportCallbackService.cs:86` (post-action delete of admin A's own context)
+
+A secondary contributor: `DataCleanupJob.CleanupCallbackContextsAsync` deletes
+contexts older than 7 days (`CallbackContextRetention = "7d"`) regardless of
+whether the associated report is still pending. Any report that sits pending
+for more than 7 days loses its buttons while still live.
+
+### Bug B — Target user names aren't clickable in Telegram DMs
+
+Notification DMs render the target user's display name as plain text even
+though `NotificationRenderer.ToTelegramHtml` wraps it in
+`<a href="tg://user?id=X">Name</a>`. Per the
+[Telegram Bot API](https://core.telegram.org/bots/api#formatting-options):
+
+> `tg://user?id=<user_id>` links will only work if the user has contacted the
+> bot in private in the past or has sent a callback query via inline button
+> and doesn't have Forwarded Messages privacy enabled for the bot.
+
+Newly-banned spam users never satisfy that condition, so their names render
+as unstyled, non-clickable plain text — exactly the case where admins need to
+inspect profiles most often.
+
+The docs confirm `text_mention` `MessageEntity` (with a full `User` object
+embedded) is the supported way to mention users that don't meet the prior-
+interaction requirement. Required fields are `id` only; additional fields
+(first/last/username) improve client-side display.
+
+`text_mention` requires the message be sent via the `entities` parameter,
+which is mutually exclusive with `parse_mode` — per the Bot API:
+
+> When provided, the parseMode is ignored.
+
+### Bug C — Reporter name not clickable on the moderation report page
+
+`TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor:67` renders
+the reporter as plain text via `GetReporterDisplay()`. When a user submits a
+report via the `/report` command, `Report.ReportedByUserId` is a real
+Telegram user ID — we can wrap the name in the existing `<UserDetailLink>`
+component (which opens `UserDetailDialog`) just like we already do for the
+reported user on the same card.
+
+Other report cards (ProfileScanAlertCard, ImpersonationAlertCard,
+ExamReviewCard) all wrap user displays in `<UserDetailLink>` — no change
+needed.
+
+## Non-Goals
+
+- No change to web-user actor display names (emails will continue to render
+  as mailto auto-links on Telegram clients; accepted limitation).
+- No change to the `NotificationBell` / `NotificationItem` web UI.
+- No change to web-user-only reviewers on report cards (the `UserDetailLink`
+  component is Telegram-user-ID-based; web-user linking is a separate
+  concern).
+- No change to email rendering (`NotificationRenderer.ToEmailHtml`) — emails
+  are fine as-is.
+- No change to web push plain text (`NotificationRenderer.ToPlainText`).
+
+## Design
+
+### Bug A — Stop eager deletion; rely on already-handled pattern
+
+**Remove eager `DeleteByReportIdAsync` / `DeleteAsync` calls** from all four
+action handlers and from `ReportCallbackService.HandleCallbackAsync`. The
+existing `ReportStatusHelper.CheckAlreadyHandled` pattern already handles the
+concurrency race: when admin B tries to update a report whose status has
+already changed, `TryUpdateStatusAsync` fails, the `onRaceLost` callback
+fetches the current state, and `CheckAlreadyHandled` returns a
+`ReviewActionResult(false, "Already handled by {admin} ({action}) at
+{time}")`. That message is strictly better than `"Button expired"`.
+
+**Change the cleanup strategy**: callback contexts should live as long as
+their underlying report does. Rewrite
+`DataCleanupJob.CleanupCallbackContextsAsync` to delete only orphaned rows
+(contexts whose `report_id` no longer exists in the `reports` table). Since:
+
+- Pending reports are never cleaned up (`DeleteOldReportsAsync` filters
+  `Status != Pending`).
+- Resolved reports are cleaned after 30 days (`ReportRetention`).
+- Orphan callback contexts will be cleaned on the next cleanup run after their
+  report is deleted.
+
+...the buttons stay live for the whole lifetime of the report, matching user
+intent ("if the report is still active in the DB, the buttons should work").
+
+**Drop the age-based `CallbackContextRetention` setting.** It's now
+structurally unused and will confuse operators if left in place.
+`DataCleanupSettings.CallbackContextRetention`, the `DefaultShortRetention`
+reference in the job, and any config test assertions all get removed.
+
+**Delete method cleanup:** `DeleteExpiredAsync(TimeSpan)` on
+`IReportCallbackContextRepository` is now dead code — remove it and its
+implementation. Add a new `DeleteOrphanedAsync()` method that performs the
+anti-join delete.
+
+#### Pseudocode for the new cleanup
+
+```csharp
+public async Task<int> DeleteOrphanedAsync(CancellationToken ct)
+{
+    await using var db = await _contextFactory.CreateDbContextAsync(ct);
+    return await db.ReportCallbackContexts
+        .Where(rcc => !db.Reports.Any(r => r.Id == rcc.ReportId))
+        .ExecuteDeleteAsync(ct);
+}
+```
+
+EF Core translates this to a `DELETE ... WHERE NOT EXISTS (...)` that Postgres
+handles efficiently with the existing `ix_report_callback_contexts_report_id`
+index.
+
+#### Behavioral changes admins will see
+
+| Scenario | Before | After |
+|---|---|---|
+| Admin A acts, admin B clicks later | `"Button expired - please use web UI"` | `"Already handled by Kass (ban) at 10:24 UTC"` |
+| Report still pending after 7 days | `"Button expired"` | Buttons still work |
+| Report deleted (e.g., aged-out resolved) | N/A | `"Button expired - please use web UI"` (correct fallback) |
+
+### Bug B — Entity-based DM rendering
+
+Move DM notifications from `ParseMode.Html` to Telegram's `entities`
+parameter. This enables proper `text_mention` entities for spam users and
+eliminates a whole class of HTML-parse-error issues.
+
+#### Renderer output shape
+
+Rename `NotificationRenderer.ToTelegramHtml` to
+`NotificationRenderer.ToTelegramMessage` and change its return type from
+`string` to a new record:
+
+```csharp
+public sealed record TelegramMessage(
+    string Text,
+    IReadOnlyList<MessageEntity> Entities);
+```
+
+Entity types emitted:
+
+- `MessageEntityType.Bold` for:
+  - The subject line (first line of the message)
+  - Every field label (the `"User:"`, `"Chat:"`, etc. prefix in `FieldList`)
+  - Every section header (the `"Analysis"`, `"Message"`, `"Action Taken"`
+    blocks)
+- `MessageEntityType.TextMention` with a full `User` object for `Field`
+  instances where `TelegramUserId.HasValue` is true.
+- No entity for system actors ("Auto-Detection", "Bot Protection", etc.) and
+  web-user display strings — they stay as plain text (email auto-linking is
+  out of scope, as agreed).
+
+#### Offset tracking
+
+Entities carry `Offset` and `Length` measured in UTF-16 code units (per
+Telegram spec). The renderer threads a `currentOffset` counter as it appends
+to `StringBuilder`, computing `string.GetUtf16CodeUnitLength()` helpers. For
+surrogate-pair-free ASCII/BMP text (the dominant case) this is just
+`string.Length`; we'll add a small utility for correctness on the edge cases
+that include emoji or non-BMP characters (display names may contain these).
+
+#### Embedded `User` object
+
+Per the tdlib documentation, only `User.Id` is required for `text_mention`.
+To improve display fallback on clients, we also populate `FirstName`,
+`LastName`, `Username`, and `IsBot = false`. `UserIdentity` already carries
+these fields — extend `NotificationPayloadBuilder.WithField(...)` to accept
+an optional `UserIdentity` alongside the existing `telegramUserId: long?`
+overload (internally converted) so call sites can pass through names without
+re-plumbing.
+
+Preferred signature:
+
+```csharp
+public NotificationPayloadBuilder WithField(string label, UserIdentity user);
+public NotificationPayloadBuilder WithField(string label, string value,
+    long? telegramUserId = null);  // existing — still used for non-user fields
+```
+
+#### Send-path plumbing
+
+Threading entities through:
+
+1. `TelegramMessage` flows from `NotificationRenderer` out of
+   `NotificationService.SendTypedTelegramDmAsync` and
+   `SendTelegramDmDirectAsync`.
+2. `IBotDmService.SendDmWithQueueAsync`, `SendDmWithMediaAsync`, and
+   `SendDmWithMediaAndKeyboardAsync` need overloads that accept
+   `IReadOnlyList<MessageEntity>? entities`. Since these methods currently
+   also accept `ParseMode parseMode = MarkdownV2`, we add a new overload
+   taking `TelegramMessage` (text + entities) and have the new overload bypass
+   `parseMode` entirely.
+3. `IBotMessageHandler.SendAsync` / `SendPhotoAsync` / `SendVideoAsync` get
+   an `entities` parameter that maps to the Telegram SDK's
+   `messageEntities` / `captionEntities` parameters.
+4. User-facing DM code paths (warning DMs, temp-ban DMs, critical-violation
+   DMs routed through `INotificationOrchestrator`) are untouched. Only admin
+   notifications routed through `NotificationService` → `IBotDmService`
+   switch to entity-based sending. The new overload is additive; existing
+   `string + parseMode` overloads stay.
+
+#### Tests for the renderer
+
+Unit tests in `TelegramGroupsAdmin.UnitTests` verifying:
+
+- Subject line emits a `Bold` entity covering the entire first line.
+- Field label emits a `Bold` entity covering only the label portion
+  (including the colon).
+- A `FieldList` entry with a `TelegramUserId` emits a `TextMention` entity
+  over just the value span, carrying a `User` object with the provided ID and
+  name fields.
+- A `FieldList` entry without `TelegramUserId` emits no entity (plain text).
+- Section headers emit `Bold` entities.
+- Offset arithmetic is correct when display names contain emoji / non-BMP
+  characters (one test case with `"👤 User"`).
+
+### Bug C — Blazor reporter link
+
+`TelegramGroupsAdmin/Components/Reports/ModerationReportCard.razor`:
+
+```razor
+@* Before *@
+<MudText Typo="Typo.caption" Color="Color.Secondary">
+    <b>Reported by:</b> @GetReporterDisplay()
+</MudText>
+
+@* After *@
+<MudText Typo="Typo.caption" Color="Color.Secondary">
+    <b>Reported by:</b> @ReporterFragment
+</MudText>
+```
+
+`ReporterFragment` is a computed `RenderFragment` that returns:
+
+- System report (`ReportedByUserId == null && WebUserId == null`): plain
+  `ReportedByUserName ?? "System"`.
+- Telegram-user report (`ReportedByUserId != null`):
+  `<UserDetailLink UserId="@Report.ReportedByUserId.Value">@ReportedByUserName</UserDetailLink>`
+  followed by plain text `" (ID: {id})"` so the ID stays visible.
+- Web-user report (`WebUserId != null`, no Telegram link possible): plain
+  `"{name} (Web User)"`.
+
+No changes to `ProfileScanAlertCard`, `ImpersonationAlertCard`, or
+`ExamReviewCard` — their user displays already use `<UserDetailLink>`.
+
+## Data Model Changes
+
+- `IReportCallbackContextRepository` loses `DeleteExpiredAsync(TimeSpan)`,
+  gains `DeleteOrphanedAsync()`.
+- `DataCleanupSettings.CallbackContextRetention` removed.
+  `DefaultShortRetention` constant usage reduced (still used by
+  `WebNotificationRetention`).
+- No migrations. No schema changes. The existing `report_callback_contexts`
+  table and indexes are unchanged.
+
+## Error Handling
+
+- Entity sends that fail Telegram validation (e.g., overlapping entities, out-
+  of-bounds offsets) will surface as `ApiRequestException` from the handler.
+  The existing catch blocks in `BotDmService` already log these; the new
+  offset-computation tests should catch bugs pre-prod.
+- Orphaned-context cleanup runs in the existing `DataCleanupJob` scope —
+  failures already log, retry next run.
+- Multi-admin race — covered by the pre-existing
+  `ReportStatusHelper.CheckAlreadyHandled` logic, no new handling needed.
+
+## Testing
+
+### Unit tests
+- `NotificationRendererTests` — entity offset/length correctness, bold
+  coverage, text-mention emission, no-entity for fields without
+  `TelegramUserId`.
+- `ContentReportHandlerTests` / `ProfileScanHandlerTests` /
+  `ExamHandlerTests` — confirm no `DeleteByReportIdAsync` call after
+  successful action (spy on repo mock).
+- `ReportCallbackServiceTests` — confirm no `DeleteAsync` call on success.
+
+### Integration tests
+- Postgres integration test on `ReportCallbackContextRepository` verifying
+  `DeleteOrphanedAsync` removes contexts with missing reports, keeps contexts
+  whose reports exist.
+- Scenario test: admin A acts → admin B's callback still resolves to the
+  resolved report and gets the "Already handled" message (not "Button
+  expired").
+
+### Manual verification
+- Trigger a real spam detection in dev; confirm DM admin-facing mention is
+  clickable and opens the banned user's profile.
+- Trigger a `/report` against a message; confirm the reporter is clickable
+  on the moderation report card in the web UI.
+
+## Rollout
+
+Single PR, single commit sequence following the repo's conventional-commits
+rules. Feature branch off `develop`, PR to `develop`.
+
+No config changes required. Existing deployments that have overridden
+`CallbackContextRetention` in their `background_jobs_config` JSONB will
+simply see the value ignored after the migration — no corrupt state.
+
+## Out of Scope (deferred)
+
+- Generalizing `UserDetailLink` to accept web-user IDs (would enable
+  clickable "Reviewed by" on all report cards). Separate design if desired.
+- Entity-based rendering for user-facing DMs (warnings, temp bans) — keep
+  existing Markdown/HTML rendering; those messages don't need text_mention
+  because they're sent to the user themselves.
+- Any change to email (`ToEmailHtml`) or web push (`ToPlainText`) rendering.

--- a/docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md
@@ -193,18 +193,35 @@ that include emoji or non-BMP characters (display names may contain these).
 Per the tdlib documentation, only `User.Id` is required for `text_mention`.
 To improve display fallback on clients, we also populate `FirstName`,
 `LastName`, `Username`, and `IsBot = false`. `UserIdentity` already carries
-these fields — extend `NotificationPayloadBuilder.WithField(...)` to accept
-an optional `UserIdentity` alongside the existing `telegramUserId: long?`
-overload (internally converted) so call sites can pass through names without
-re-plumbing.
+these fields, so we route linked mentions through a new `UserIdentity`
+overload and drop the existing nullable `telegramUserId` parameter on the
+string overload — a field is either plain text or a linked user mention,
+never a string with an optional ID hanging off it.
 
-Preferred signature:
+Final signatures:
 
 ```csharp
+public NotificationPayloadBuilder WithField(string label, string value);
 public NotificationPayloadBuilder WithField(string label, UserIdentity user);
-public NotificationPayloadBuilder WithField(string label, string value,
-    long? telegramUserId = null);  // existing — still used for non-user fields
+public NotificationPayloadBuilder WithFieldIf(bool condition, string label, string? value);
+public NotificationPayloadBuilder WithFieldIf(bool condition, string label, UserIdentity? user);
 ```
+
+Call sites in `NotificationService.cs` update like:
+
+```csharp
+// Before
+.WithField("User", user.DisplayName, telegramUserId: user.Id)
+.WithField("Chat", chat.ChatName ?? chat.Id.ToString())
+
+// After
+.WithField("User", user)
+.WithField("Chat", chat.ChatName ?? chat.Id.ToString())
+```
+
+The `Field` record on `NotificationPayload` loses `TelegramUserId: long?` in
+favor of `User: UserIdentity?` — the renderer reads the latter when deciding
+whether to emit a `TextMention` entity.
 
 #### Send-path plumbing
 

--- a/docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md
@@ -198,31 +198,44 @@ overload and drop the existing nullable `telegramUserId` parameter on the
 string overload — a field is either plain text or a linked user mention,
 never a string with an optional ID hanging off it.
 
-Final signatures — two overloads, both skip-on-null:
+Final signatures — non-nullable, no conditional logic inside the builder:
 
 ```csharp
-public NotificationPayloadBuilder WithField(string label, string? value);
-public NotificationPayloadBuilder WithField(string label, UserIdentity? user);
+public NotificationPayloadBuilder WithField(string label, string value);
+public NotificationPayloadBuilder WithField(string label, UserIdentity user);
 ```
 
-`WithFieldIf(bool, ...)` is dropped — callers use null to signal skip. For the
-rare bool-guarded case (`messageDeleted` in spam-ban notifications), a
-ternary-to-null is cleaner:
+`WithFieldIf(bool, ...)` is dropped. The builder is a bag of "add this"
+operations — it doesn't decide whether to add; the caller does. When a field
+is conditional, the caller branches imperatively before calling:
 
 ```csharp
-// Before
+// Before (existing code)
 .WithField("User", user.DisplayName, telegramUserId: user.Id)
 .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
 .WithFieldIf(detectionReason != null, "Reason", detectionReason)
 .WithFieldIf(messageDeleted, "Message deleted", $"ID: {messageId}")
 
 // After
-.WithField("User", user)
-.WithField("Chat", chat.ChatName ?? chat.Id.ToString())
-.WithField("Reason", detectionReason)                    // skips if null
-.WithField("Message deleted",
-    messageDeleted ? $"ID: {messageId}" : null)          // ternary-to-null
+var builder = NotificationPayloadBuilder.Create("Spam Banned")
+    .WithField("User", user)
+    .WithField("Chat", chat.ChatName ?? chat.Id.ToString());
+
+if (detectionReason is not null)
+    builder.WithField("Reason", detectionReason);
+
+if (messageDeleted)
+    builder.WithField("Message deleted", $"ID: {messageId}");
+
+var payload = builder.Build();
 ```
+
+Slightly more code, but each method has one job and conditional logic lives
+where the context exists.
+
+The same principle applies to `WithFieldIf` inside `SectionBuilder` (the
+nested builder passed to `WithSection`) — drop it, use `if` inside the
+configure lambda.
 
 The `Field` record on `NotificationPayload` loses `TelegramUserId: long?` in
 favor of `User: UserIdentity?` — the renderer reads the latter when deciding

--- a/docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md
@@ -198,25 +198,30 @@ overload and drop the existing nullable `telegramUserId` parameter on the
 string overload — a field is either plain text or a linked user mention,
 never a string with an optional ID hanging off it.
 
-Final signatures:
+Final signatures — two overloads, both skip-on-null:
 
 ```csharp
-public NotificationPayloadBuilder WithField(string label, string value);
-public NotificationPayloadBuilder WithField(string label, UserIdentity user);
-public NotificationPayloadBuilder WithFieldIf(bool condition, string label, string? value);
-public NotificationPayloadBuilder WithFieldIf(bool condition, string label, UserIdentity? user);
+public NotificationPayloadBuilder WithField(string label, string? value);
+public NotificationPayloadBuilder WithField(string label, UserIdentity? user);
 ```
 
-Call sites in `NotificationService.cs` update like:
+`WithFieldIf(bool, ...)` is dropped — callers use null to signal skip. For the
+rare bool-guarded case (`messageDeleted` in spam-ban notifications), a
+ternary-to-null is cleaner:
 
 ```csharp
 // Before
 .WithField("User", user.DisplayName, telegramUserId: user.Id)
 .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
+.WithFieldIf(detectionReason != null, "Reason", detectionReason)
+.WithFieldIf(messageDeleted, "Message deleted", $"ID: {messageId}")
 
 // After
 .WithField("User", user)
 .WithField("Chat", chat.ChatName ?? chat.Id.ToString())
+.WithField("Reason", detectionReason)                    // skips if null
+.WithField("Message deleted",
+    messageDeleted ? $"ID: {messageId}" : null)          // ternary-to-null
 ```
 
 The `Field` record on `NotificationPayload` loses `TelegramUserId: long?` in


### PR DESCRIPTION
## Summary

Three interconnected fixes for admin moderation notifications:

- **Bug A — Cross-admin button expiration**: Stops eager deletion of DM callback contexts in report action handlers. Previously, when one admin clicked an action button (Ban/Warn/Dismiss/etc.), the handler wiped callback contexts for **every** admin who received the DM — so everyone elses buttons showed "Button expired" within seconds. Now the existing `CheckAlreadyHandled` path produces "Already handled by {admin} ({action}) at {time} UTC" instead. Also replaces the 7-day age-based callback context cleanup with orphan-based cleanup (tied to report lifetime), so pending reports older than 7 days keep working buttons.
- **Bug B — Clickable DM user mentions**: Replaces HTML `tg://user?id=X` links (which dont work for users who havent interacted with the bot, per the Telegram Bot API docs) with proper `text_mention` MessageEntity objects containing an embedded User. This makes banned spammer names clickable in admin DMs — the exact case where admins need to click through to inspect profiles most often. Switches admin notification rendering from `ParseMode.Html` to entity-based sending (mutually exclusive per the API).
- **Bug C — Clickable reporter on moderation report card**: Wraps the reporter name in `<UserDetailLink>` for `/report`-submitted reports, opening the user detail dialog on click. Matches the pattern already used for the reported user.

## Design

[docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md](docs/superpowers/specs/2026-04-23-admin-notification-fixes-design.md)

## Plan

[docs/superpowers/plans/2026-04-23-admin-notification-fixes.md](docs/superpowers/plans/2026-04-23-admin-notification-fixes.md)

## Key Changes

- `BotDmService` gains two entity-based overloads (`SendDmWithEntitiesAsync`, `SendDmWithMediaAndKeyboardEntitiesAsync`)
- `IBotMessageHandler` gains optional `entities` / `captionEntities` params (non-breaking)
- `NotificationPayloadBuilder` / `SectionBuilder` simplified: non-nullable params, `WithFieldIf` removed, caller owns conditionals
- `Field` record now carries `UserIdentity?` instead of `long? TelegramUserId`
- New `NotificationRenderer.ToTelegramMessage` emits `(string Text, IReadOnlyList<MessageEntity> Entities)` — `Bold` entities for subject/labels/section headers, `TextMention` with embedded User for mentions
- `IReportCallbackContextRepository.DeleteExpiredAsync(TimeSpan)` replaced with `DeleteOrphanedAsync()` using an EF Core anti-join
- `DataCleanupSettings.CallbackContextRetention` removed (and corresponding UI field in `BackgroundJobs.razor`)
- Internal refactor: four DM methods consolidated onto a shared `TrySendWithQueueAsync` helper; two `NotificationService` DM routing methods consolidated onto a shared `DispatchEntityDmAsync`

## Test plan

- [x] Unit tests — 1874/1874 passing
- [x] Integration tests — 598/598 passing (Testcontainers PostgreSQL)
- [x] Full solution build — 0 warnings, 0 errors
- [x] Non-goals preserved (NotificationBell/NotificationItem, Actor.FromWebUser, email/plaintext renderer logic, other report cards)
- [ ] Manual: trigger spam detection, confirm DM target user is clickable and opens profile
- [ ] Manual: submit `/report`, confirm reporter name is clickable on the moderation report card (opens user detail dialog)
- [ ] Manual: with two admins, confirm admin B gets "Already handled by {name}" (not "Button expired") when admin A clicks first

## Behavioral Changes

| Scenario | Before | After |
|---|---|---|
| Admin A acts, admin B clicks later | `Button expired - please use web UI` | `Already handled by {admin} ({action}) at {time} UTC` |
| Report still pending after 7 days | `Button expired` | Buttons still work (lifecycle tied to report) |
| Target user name in DM (never interacted with bot) | Plain unstyled text, often not tappable | Styled clickable mention via `text_mention` entity |
| Reporter name on moderation report card (Telegram `/report`) | Plain text | Clickable link opening UserDetailDialog |

## Commits

22 commits (spec + plan + implementation). All tests pass at each commit except the intentional intermediate state between Tasks 9–12 and 13 (documented in the commits themselves).

No corresponding issues filed — these bugs were surfaced directly via screenshots and investigation.
