### PR TITLE
fix(e2e): make auth page-object waits race-resistant (web-first Expect / Commit)

### DIFF
--- a/TelegramGroupsAdmin.E2ETests/PageObjects/LoginVerifyPage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/LoginVerifyPage.cs
@@ -34,11 +34,15 @@ public class LoginVerifyPage
     /// </summary>
     public async Task WaitForPageAsync(int timeoutMs = 10000)
     {
+        // WaitUntil=Commit waits only for the navigation to commit, not the full "Load"
+        // event (all sub-resources). The CodeInput assertion below is the real readiness
+        // signal and auto-retries; waiting for "Load" was the source of CI nav-timeout flakes.
         await _page.WaitForURLAsync("**/login/verify**", new PageWaitForURLOptions
         {
-            Timeout = timeoutMs
+            Timeout = timeoutMs,
+            WaitUntil = WaitUntilState.Commit
         });
-        await _page.WaitForSelectorAsync(CodeInput);
+        await Expect(_page.Locator(CodeInput)).ToBeVisibleAsync(new() { Timeout = timeoutMs });
     }
 
     /// <summary>
@@ -101,9 +105,12 @@ public class LoginVerifyPage
     /// </summary>
     public async Task WaitForRedirectAsync(int timeoutMs = 10000)
     {
+        // Commit, not Load: the redirect is done once the new URL commits; waiting for the
+        // destination's full Load event under contention is what times out.
         await _page.WaitForURLAsync(url => !url.Contains("/login/verify"), new PageWaitForURLOptions
         {
-            Timeout = timeoutMs
+            Timeout = timeoutMs,
+            WaitUntil = WaitUntilState.Commit
         });
     }
 

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/ProfilePage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/ProfilePage.cs
@@ -236,7 +236,7 @@ public class ProfilePage
     /// over IsTotpEnabledAsync() in test assertions: IsVisibleAsync() is a point-in-time
     /// snapshot and races the alert's async (Blazor) render under load.
     /// </summary>
-    public async Task AssertTotpEnabledAsync(float? timeoutMs = null)
+    public async Task AssertTotpEnabledAsync(int? timeoutMs = null)
     {
         var locator = _page.Locator(TotpSection).Locator(TotpEnabledAlert);
         await Expect(locator).ToBeVisibleAsync(timeoutMs is { } t ? new() { Timeout = t } : null);
@@ -246,7 +246,7 @@ public class ProfilePage
     /// Asserts (auto-retrying) that the TOTP section shows the "not enabled" warning.
     /// Prefer this over IsTotpDisabledAsync() in test assertions (see AssertTotpEnabledAsync).
     /// </summary>
-    public async Task AssertTotpDisabledAsync(float? timeoutMs = null)
+    public async Task AssertTotpDisabledAsync(int? timeoutMs = null)
     {
         var locator = _page.Locator(TotpSection).Locator(TotpDisabledAlert);
         await Expect(locator).ToBeVisibleAsync(timeoutMs is { } t ? new() { Timeout = t } : null);

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/ProfilePage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/ProfilePage.cs
@@ -22,6 +22,8 @@ public class ProfilePage
     private const string AccountInfoSection = ".mud-paper:has(.mud-typography-h6:has-text('Account Information'))";
     private const string ChangePasswordSection = ".mud-paper:has(.mud-typography-h6:has-text('Change Password'))";
     private const string TotpSection = ".mud-paper:has(.mud-typography-h6:has-text('Two-Factor Authentication'))";
+    private const string TotpEnabledAlert = ".mud-alert:has-text('2FA is currently enabled')";
+    private const string TotpDisabledAlert = ".mud-alert:has-text('2FA is not enabled')";
     private const string TelegramLinkingSection = ".mud-paper:has(.mud-typography-h6:has-text('Linked Telegram Accounts'))";
 
     public ProfilePage(IPage page)
@@ -218,8 +220,7 @@ public class ProfilePage
     /// </summary>
     public async Task<bool> IsTotpEnabledAsync()
     {
-        var enabledAlert = _page.Locator(TotpSection).Locator(".mud-alert:has-text('2FA is currently enabled')");
-        return await enabledAlert.IsVisibleAsync();
+        return await _page.Locator(TotpSection).Locator(TotpEnabledAlert).IsVisibleAsync();
     }
 
     /// <summary>
@@ -227,8 +228,28 @@ public class ProfilePage
     /// </summary>
     public async Task<bool> IsTotpDisabledAsync()
     {
-        var disabledAlert = _page.Locator(TotpSection).Locator(".mud-alert:has-text('2FA is not enabled')");
-        return await disabledAlert.IsVisibleAsync();
+        return await _page.Locator(TotpSection).Locator(TotpDisabledAlert).IsVisibleAsync();
+    }
+
+    /// <summary>
+    /// Asserts (auto-retrying) that the TOTP section shows the "enabled" alert. Prefer this
+    /// over IsTotpEnabledAsync() in test assertions: IsVisibleAsync() is a point-in-time
+    /// snapshot and races the alert's async (Blazor) render under load.
+    /// </summary>
+    public async Task AssertTotpEnabledAsync(float? timeoutMs = null)
+    {
+        var locator = _page.Locator(TotpSection).Locator(TotpEnabledAlert);
+        await Expect(locator).ToBeVisibleAsync(timeoutMs is { } t ? new() { Timeout = t } : null);
+    }
+
+    /// <summary>
+    /// Asserts (auto-retrying) that the TOTP section shows the "not enabled" warning.
+    /// Prefer this over IsTotpDisabledAsync() in test assertions (see AssertTotpEnabledAsync).
+    /// </summary>
+    public async Task AssertTotpDisabledAsync(float? timeoutMs = null)
+    {
+        var locator = _page.Locator(TotpSection).Locator(TotpDisabledAlert);
+        await Expect(locator).ToBeVisibleAsync(timeoutMs is { } t ? new() { Timeout = t } : null);
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/TotpSetupPage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/TotpSetupPage.cs
@@ -39,9 +39,12 @@ public class TotpSetupPage
     /// </summary>
     public async Task WaitForPageAsync(int timeoutMs = 10000)
     {
+        // Commit, not the full Load event — the setup-steps/error wait below is the real
+        // readiness signal and auto-retries; "Load" waits flake under CI contention.
         await _page.WaitForURLAsync("**/login/setup-2fa**", new PageWaitForURLOptions
         {
-            Timeout = timeoutMs
+            Timeout = timeoutMs,
+            WaitUntil = WaitUntilState.Commit
         });
 
         // Wait for either the setup steps to load or an error message
@@ -165,7 +168,8 @@ public class TotpSetupPage
     {
         await _page.WaitForURLAsync(url => !url.Contains("/login/setup-2fa"), new PageWaitForURLOptions
         {
-            Timeout = timeoutMs
+            Timeout = timeoutMs,
+            WaitUntil = WaitUntilState.Commit
         });
     }
 

--- a/TelegramGroupsAdmin.E2ETests/Tests/Authentication/RecoveryCodesTests.cs
+++ b/TelegramGroupsAdmin.E2ETests/Tests/Authentication/RecoveryCodesTests.cs
@@ -231,9 +231,8 @@ public class RecoveryCodesTests : SharedE2ETestBase
         await _profilePage.NavigateAsync();
         await _profilePage.WaitForLoadAsync();
 
-        // Verify 2FA is disabled initially
-        Assert.That(await _profilePage.IsTotpDisabledAsync(), Is.True,
-            "2FA should be disabled initially");
+        // Verify 2FA is disabled initially (auto-retrying — the alert renders async)
+        await _profilePage.AssertTotpDisabledAsync();
 
         // Act - enable 2FA
         await _profilePage.ClickEnable2FAButtonAsync();


### PR DESCRIPTION
Closes #502

## Summary

Fixes the flaky auth E2E tests by replacing non-auto-retrying waits (which race the render under load) with web-first Playwright patterns.

Two proven flake sources, same root cause family — *waits that don't auto-retry*:

| Symptom | Where | Fix |
|---|---|---|
| `TimeoutException … waiting for navigation … until "Load"` (CI flake, #502) | `LoginVerifyPage.WaitForPageAsync` | `WaitUntil=Commit` + `Expect(codeInput).ToBeVisibleAsync()` |
| `2FA should be disabled / Expected True, But was False` (snapshot race) | `ProfilePage.IsTotpDisabledAsync()` (snapshot) asserted after `WaitForLoadAsync` waits a *different* section | auto-retrying `AssertTotpDisabledAsync()` (web-first `Expect`) |

## Changes

- **`LoginVerifyPage`** — `WaitForPageAsync`/`WaitForRedirectAsync` use `WaitUntil=Commit` (navigation committed, not the full `Load` event); page readiness is asserted via `Expect(...).ToBeVisibleAsync()` on the actual input.
- **`TotpSetupPage`** — same `Commit` treatment on `WaitForPageAsync`/`WaitForRedirectAsync` (hot auth path; the setup-steps/error wait after is the real readiness signal).
- **`ProfilePage`** — adds auto-retrying `AssertTotpEnabledAsync()`/`AssertTotpDisabledAsync()` (prefer over the snapshot `Is*` getters in assertions); alert selectors extracted to consts so snapshot/assert variants can't drift.
- **`RecoveryCodesTests`** — the `Profile_Enable2FA` assertion uses the auto-retrying helper.

## Validation

Loop-ran `RecoveryCodesTests` ×20 on the rebuilt suite (the contention that surfaces these — isolation alone hid them):
- **Original TOTP assertion race: 0 occurrences** (baseline ~33%).
- The 1 remaining failure was an **unrelated** `TRUNCATE`-reset deadlock in the legacy E2E DB harness — tracked separately in #503, *not* a Playwright-wait issue.

## Scope

Deliberately limited to the **auth** page objects / tests (the proven, reproducible flakes). The same `IsVisibleAsync`-in-assertion / `NetworkIdle` patterns exist suite-wide (~300 sites) but are not converted here — that's a separate web-first migration, and the E2E DB-isolation rework is #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
