### PR TITLE
fix: correctness bug sweep (#495, #475, #473, #472)

### DIFF
--- a/TelegramGroupsAdmin.BackgroundJobs/AssemblyInfo.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("TelegramGroupsAdmin.IntegrationTests")]
+[assembly: InternalsVisibleTo("TelegramGroupsAdmin.UnitTests")]

--- a/TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs
@@ -37,6 +37,9 @@ public static class ServiceCollectionExtensions
 
         // Note: RetryJobListener is registered by Quartz via AddJobListener<T>() below
 
+        // Shared wake-up signal decoupling the config writer from the sync worker (replaces the concrete cast).
+        services.AddSingleton<IScheduleResyncSignal, ScheduleResyncSignal>();
+
         // Register the Quartz schedule synchronizer (holds the sync business logic).
         // The hosted worker below is a thin shell that drives this service.
         services.AddSingleton<IQuartzScheduleSynchronizer, QuartzScheduleSynchronizer>();

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/BackgroundJobConfigService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/BackgroundJobConfigService.cs
@@ -19,7 +19,7 @@ public class BackgroundJobConfigService : IBackgroundJobConfigService
     private readonly IDbContextFactory<AppDbContext> _contextFactory;
     private readonly ILogger<BackgroundJobConfigService> _logger;
     private readonly IQuartzScheduleConverter _scheduleConverter;
-    private volatile QuartzSchedulingSyncService? _syncService; // Injected lazily to avoid circular dependency
+    private readonly IScheduleResyncSignal _resyncSignal;
 
     /// <summary>
     /// Event fired when a job's NextRunAt is updated (for UI refresh via SignalR)
@@ -36,20 +36,13 @@ public class BackgroundJobConfigService : IBackgroundJobConfigService
     public BackgroundJobConfigService(
         IDbContextFactory<AppDbContext> contextFactory,
         ILogger<BackgroundJobConfigService> logger,
-        IQuartzScheduleConverter scheduleConverter)
+        IQuartzScheduleConverter scheduleConverter,
+        IScheduleResyncSignal resyncSignal)
     {
         _contextFactory = contextFactory;
         _logger = logger;
         _scheduleConverter = scheduleConverter;
-    }
-
-    /// <summary>
-    /// Set the sync service reference (called by QuartzSchedulingSyncService after it starts)
-    /// Lazy injection to avoid circular dependency during DI registration
-    /// </summary>
-    public void SetSyncService(QuartzSchedulingSyncService syncService)
-    {
-        _syncService = syncService;
+        _resyncSignal = resyncSignal;
     }
 
     public async Task<BackgroundJobConfig?> GetJobConfigAsync(string jobName, CancellationToken cancellationToken = default)
@@ -158,7 +151,7 @@ public class BackgroundJobConfigService : IBackgroundJobConfigService
         if (requiresResync)
         {
             _logger.LogDebug("Triggering Quartz re-sync for {JobName} due to config change", jobName);
-            _syncService?.TriggerResync();
+            _resyncSignal.RequestResync();
         }
 
         // Fire event for UI refresh if NextRunAt changed (Blazor Server SignalR push)

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/IScheduleResyncSignal.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/IScheduleResyncSignal.cs
@@ -1,0 +1,35 @@
+namespace TelegramGroupsAdmin.BackgroundJobs.Services;
+
+/// <summary>
+/// A one-slot wake-up signal decoupling the config writer (producer) from the
+/// schedule-sync worker (consumer). Replaces the former concrete back-reference
+/// (SetSyncService cast). Registered as a singleton so both sides share one instance.
+/// </summary>
+public interface IScheduleResyncSignal
+{
+    /// <summary>
+    /// Request a re-sync. Coalescing: multiple calls before the next WaitAsync
+    /// collapse into a single pending wake-up.
+    /// </summary>
+    void RequestResync();
+
+    /// <summary>Await the next re-sync request (or cancellation).</summary>
+    Task WaitAsync(CancellationToken cancellationToken);
+}
+
+public sealed class ScheduleResyncSignal : IScheduleResyncSignal, IDisposable
+{
+    private readonly SemaphoreSlim _signal = new(0, 1);
+
+    public void RequestResync()
+    {
+        // CurrentCount == 0 means no pending wake-up; release to signal one.
+        // CurrentCount == 1 means a resync is already pending — skip (coalescing).
+        if (_signal.CurrentCount == 0)
+            _signal.Release();
+    }
+
+    public Task WaitAsync(CancellationToken cancellationToken) => _signal.WaitAsync(cancellationToken);
+
+    public void Dispose() => _signal.Dispose();
+}

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/IScheduleResyncSignal.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/IScheduleResyncSignal.cs
@@ -17,16 +17,25 @@ public interface IScheduleResyncSignal
     Task WaitAsync(CancellationToken cancellationToken);
 }
 
-public sealed class ScheduleResyncSignal : IScheduleResyncSignal, IDisposable
+internal sealed class ScheduleResyncSignal : IScheduleResyncSignal, IDisposable
 {
     private readonly SemaphoreSlim _signal = new(0, 1);
 
     public void RequestResync()
     {
-        // CurrentCount == 0 means no pending wake-up; release to signal one.
-        // CurrentCount == 1 means a resync is already pending — skip (coalescing).
-        if (_signal.CurrentCount == 0)
+        // SemaphoreSlim(maxCount=1): Release() throws SemaphoreFullException when already
+        // signaled. That means a resync is already pending — coalescing is the desired
+        // behavior, so the exception is intentionally swallowed. (A CurrentCount check is a
+        // TOCTOU race under concurrent callers, hence try/catch.)
+        try
+        {
             _signal.Release();
+        }
+        // slopwatch-ignore: SW003 Intentional empty catch: SemaphoreFullException means a resync is already pending, so coalescing the duplicate request is the desired behavior.
+        catch (SemaphoreFullException)
+        {
+            // Intentional: resync already pending (coalescing).
+        }
     }
 
     public Task WaitAsync(CancellationToken cancellationToken) => _signal.WaitAsync(cancellationToken);

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/QuartzSchedulingSyncService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/QuartzSchedulingSyncService.cs
@@ -17,7 +17,6 @@ public class QuartzSchedulingSyncService(
     IQuartzScheduleSynchronizer synchronizer,
     IScheduleResyncSignal resyncSignal) : BackgroundService
 {
-
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         logger.LogInformation("QuartzSchedulingSyncService starting...");

--- a/TelegramGroupsAdmin.BackgroundJobs/Services/QuartzSchedulingSyncService.cs
+++ b/TelegramGroupsAdmin.BackgroundJobs/Services/QuartzSchedulingSyncService.cs
@@ -14,9 +14,9 @@ public class QuartzSchedulingSyncService(
     ILogger<QuartzSchedulingSyncService> logger,
     ISchedulerFactory schedulerFactory,
     IBackgroundJobConfigService jobConfigService,
-    IQuartzScheduleSynchronizer synchronizer) : BackgroundService
+    IQuartzScheduleSynchronizer synchronizer,
+    IScheduleResyncSignal resyncSignal) : BackgroundService
 {
-    private readonly SemaphoreSlim _resyncSignal = new(0, 1);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -36,15 +36,6 @@ public class QuartzSchedulingSyncService(
             // Update NextRunAt for all jobs after initial sync
             await synchronizer.UpdateNextRunTimesAsync(scheduler, stoppingToken);
 
-            // Register this service with BackgroundJobConfigService for live re-sync notifications.
-            // Registered after the initial sync so a config change that races startup doesn't
-            // queue a spurious immediate re-sync before the loop is even entered.
-            if (jobConfigService is BackgroundJobConfigService configService)
-            {
-                configService.SetSyncService(this);
-                logger.LogDebug("Registered with BackgroundJobConfigService for live config re-sync");
-            }
-
             logger.LogInformation("QuartzSchedulingSyncService initial sync complete - listening for config changes");
 
             // Wait for config change notifications (event-driven re-sync)
@@ -52,8 +43,8 @@ public class QuartzSchedulingSyncService(
             {
                 try
                 {
-                    // Block until TriggerResync() is called or cancellation requested
-                    await _resyncSignal.WaitAsync(stoppingToken);
+                    // Block until a re-sync is requested or cancellation is requested
+                    await resyncSignal.WaitAsync(stoppingToken);
 
                     logger.LogInformation("Config change detected - re-syncing job schedules");
 
@@ -80,35 +71,9 @@ public class QuartzSchedulingSyncService(
         }
     }
 
-    /// <summary>
-    /// Trigger immediate re-sync of job schedules from database.
-    /// Called by BackgroundJobConfigService after configuration changes.
-    /// </summary>
-    public void TriggerResync()
-    {
-        // Release the semaphore to wake up the monitoring loop
-        // Try-catch handles concurrent calls (semaphore maxCount=1)
-        try
-        {
-            _resyncSignal.Release();
-            logger.LogDebug("Config re-sync triggered");
-        }
-        catch (SemaphoreFullException)
-        {
-            // Resync already pending, no action needed
-            logger.LogDebug("Resync already pending, ignoring duplicate trigger");
-        }
-    }
-
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
         logger.LogInformation("QuartzSchedulingSyncService stopping...");
         await base.StopAsync(cancellationToken);
-    }
-
-    public override void Dispose()
-    {
-        _resyncSignal.Dispose();
-        base.Dispose();
     }
 }

--- a/TelegramGroupsAdmin.ContentDetection/ML/StopWordRecommendationService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/ML/StopWordRecommendationService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TelegramGroupsAdmin.ContentDetection.Constants;
@@ -330,7 +331,17 @@ public class StopWordRecommendationService : IStopWordRecommendationService
 
             foreach (var result in detectionResults)
             {
-                var checkResults = CheckResultsSerializer.Deserialize(result.CheckResultsJson!);
+                List<CheckResult> checkResults;
+                try
+                {
+                    checkResults = CheckResultsSerializer.Deserialize(result.CheckResultsJson!);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse check results JSON during stop word analysis; skipping malformed record");
+                    continue;
+                }
+
                 var stopWordsCheck = checkResults.FirstOrDefault(c => c.CheckName == CheckName.StopWords);
 
                 if (stopWordsCheck == null)

--- a/TelegramGroupsAdmin.ContentDetection/ML/StopWordRecommendationService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/ML/StopWordRecommendationService.cs
@@ -338,7 +338,7 @@ public class StopWordRecommendationService : IStopWordRecommendationService
                 }
                 catch (JsonException ex)
                 {
-                    _logger.LogWarning(ex, "Failed to parse check results JSON during stop word analysis; skipping malformed record");
+                    _logger.LogWarning(ex, "Failed to parse check results JSON for detection result {DetectionResultId} during stop word analysis; skipping malformed record", result.Id);
                     continue;
                 }
 

--- a/TelegramGroupsAdmin.ContentDetection/Services/VideoFrameExtractionService.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Services/VideoFrameExtractionService.cs
@@ -625,9 +625,9 @@ public class VideoFrameExtractionService : IVideoFrameExtractionService
                 return 128.0; // Normal brightness (middle of 0-255 range)
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Default to normal brightness if analysis fails
+            _logger.LogWarning(ex, "Frame brightness analysis failed for {FramePath}; defaulting to 128.0", framePath);
             return 128.0;
         }
     }

--- a/TelegramGroupsAdmin.ContentDetection/Utilities/CheckResultsSerializer.cs
+++ b/TelegramGroupsAdmin.ContentDetection/Utilities/CheckResultsSerializer.cs
@@ -48,15 +48,8 @@ public static class CheckResultsSerializer
         if (string.IsNullOrWhiteSpace(json))
             return [];
 
-        try
-        {
-            var results = JsonSerializer.Deserialize<CheckResults>(json, DeserializeOptions);
+        var results = JsonSerializer.Deserialize<CheckResults>(json, DeserializeOptions);
 
-            return results?.Checks ?? [];
-        }
-        catch
-        {
-            return [];
-        }
+        return results?.Checks ?? [];
     }
 }

--- a/TelegramGroupsAdmin.IntegrationTests/CLAUDE.md
+++ b/TelegramGroupsAdmin.IntegrationTests/CLAUDE.md
@@ -35,7 +35,7 @@ Origin: prod DB snapshot from 2026-04-30. Bootstrap pipeline (full detail in `do
 | 09 | prompt_versions | 1 | Single Main Chat synthetic row; tests build version history via SUT. |
 | 10 | recovery_codes | 0 | Empty by design. |
 | 11 | stop_words | 17 | Reference data. |
-| 12 | tag_definitions | 6 | Reference data. |
+| 12 | tag_definitions | 7 | Reference data (6 prod-derived) + 1 synthetic `power-user` (usage_count 20) for the concurrent-decrement race test. |
 | 13 | username_blacklist | 2 | 1 enabled + 1 disabled, both Exact match. |
 | 14 | domain_filters | 0 | Empty by design. |
 | 15 | image_training_samples | 0 | Empty by design (no payloads carried). |

--- a/TelegramGroupsAdmin.IntegrationTests/ML/StopWordRecommendationServiceMalformedJsonTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/ML/StopWordRecommendationServiceMalformedJsonTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TelegramGroupsAdmin.ContentDetection.ML;
+using TelegramGroupsAdmin.ContentDetection.Repositories;
+using TelegramGroupsAdmin.ContentDetection.Services;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
+
+namespace TelegramGroupsAdmin.IntegrationTests.ML;
+
+/// <summary>
+/// Regression guard for #495 on the second caller of CheckResultsSerializer.Deserialize.
+///
+/// StopWordRecommendationService.GenerateRemovalRecommendationsAsync deserializes every
+/// in-window detection_result's check_results_json inside a per-stop-word loop. A single
+/// row whose JSON no longer binds to the current CheckResults shape must be logged and
+/// skipped (continue) — it must never abort the whole recommendation batch.
+///
+/// Substrate: the full golden template (no Reduce). The service's ValidateDataAvailabilityAsync
+/// gate requires >= 50 spam training samples and >= 100 legit messages, so a narrowed substrate
+/// would short-circuit before the removal loop ever runs. We pass a far-past 'since' so every
+/// frozen canonical timestamp lands in-window, then assert ValidationMessage is null to prove the
+/// gate passed and the removal loop (where the catch lives) actually executed.
+/// </summary>
+[TestFixture]
+public class StopWordRecommendationServiceMalformedJsonTests
+{
+    private MigrationTestHelper _testHelper = null!;
+    private IServiceProvider _serviceProvider = null!;
+    private IServiceScope _scope = null!;
+    private IStopWordRecommendationService _service = null!;
+
+    // Same realistic corruption shape as the AnalyticsRepository guard: a legacy V1-era row
+    // where CheckName is a JSON *string* rather than its integer ordinal. CheckResult.CheckName
+    // is a bare enum and DeserializeOptions registers no JsonStringEnumConverter, so
+    // System.Text.Json rejects the string token with a JsonException. This is the exact shape
+    // migration 20260307182307_FixCheckResultsJsonCheckNameType was written to repair. The
+    // column is JSONB, so the payload must be valid JSON of the wrong shape, not malformed.
+    private const string LegacyStringEnumJson =
+        """{"Checks":[{"CheckName":"Bayes","Score":3.5,"Abstained":false,"Details":"legacy V1 string-enum row","ProcessingTimeMs":1.0}]}""";
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _testHelper = new MigrationTestHelper();
+        await _testHelper.CreateDatabaseFromGoldenTemplateAsync();
+
+        // TEST-DATA RULE EXCEPTION: directly overwrite one canonical detection_result's
+        // check_results_json via raw SQL rather than via a GoldenMutatePlanBuilder verb. The
+        // golden dataset is scrubbed real prod data and cannot carry deserialization-breaking
+        // JSON by construction; a reusable builder verb for a single caller would be YAGNI. No
+        // rows are added or removed — only one existing row's column value is overwritten. The
+        // lowest-id row with non-null JSON is chosen so the removal loop is guaranteed to visit it.
+        await using (var ctx = _testHelper.GetDbContext())
+        {
+            await ctx.Database.ExecuteSqlRawAsync(
+                """
+                UPDATE detection_results
+                SET check_results_json = {0}::jsonb
+                WHERE id = (
+                    SELECT id FROM detection_results
+                    WHERE check_results_json IS NOT NULL
+                    ORDER BY id
+                    LIMIT 1)
+                """,
+                LegacyStringEnumJson);
+        }
+
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>((_, options) => options.UseNpgsql(_testHelper.ConnectionString));
+        services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton<ITokenizerService, TokenizerService>();
+        services.AddScoped<IStopWordsRepository, StopWordsRepository>();
+        services.AddScoped<IStopWordRecommendationService, StopWordRecommendationService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _scope = _serviceProvider.CreateScope();
+        _service = _scope.ServiceProvider.GetRequiredService<IStopWordRecommendationService>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _scope?.Dispose();
+        (_serviceProvider as IDisposable)?.Dispose();
+        _testHelper?.Dispose();
+    }
+
+    [Test]
+    public async Task GenerateRecommendations_WhenRowHasUndeserializableJson_SkipsRowAndCompletesBatch()
+    {
+        // Far-past 'since' so every frozen canonical timestamp counts toward the data gate.
+        var since = DateTimeOffset.UtcNow.AddYears(-5);
+
+        // Act — without the #495 catch, the corrupt row's Deserialize throws JsonException out of
+        // GenerateRemovalRecommendationsAsync and aborts the whole batch. With it, the row is
+        // logged and skipped (continue) and the batch completes normally.
+        var batch = await _service.GenerateRecommendationsAsync(since);
+
+        // Assert
+        Assert.That(batch, Is.Not.Null);
+        Assert.That(batch.ValidationMessage, Is.Null,
+            "Golden template must satisfy the data-availability gate so the removal loop "
+            + "(where the malformed-JSON catch lives) actually runs; a non-null message means "
+            + "the test short-circuited before exercising #495");
+    }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/AnalyticsRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/AnalyticsRepositoryTests.cs
@@ -652,6 +652,54 @@ public class AnalyticsRepositoryTests
             "At least one method should have contributed to FP from correction data");
     }
 
+    [Test]
+    public async Task GetDetectionMethodComparison_WhenRowHasUndeserializableJson_SkipsRowAndStillReturnsStats()
+    {
+        // Regression guard for #495: AnalyticsRepository.ParseCheckResults must catch
+        // JsonException from CheckResultsSerializer.Deserialize, log it, and treat the row
+        // as "no checks" — never let a single corrupt row abort the whole aggregation.
+        //
+        // Realistic corruption shape: a legacy V1-era row where CheckName is a JSON *string*
+        // ("Bayes") rather than its integer ordinal. CheckResult.CheckName is a bare enum and
+        // DeserializeOptions registers no JsonStringEnumConverter, so System.Text.Json rejects
+        // the string token with a JsonException. This is exactly the shape migration
+        // 20260307182307_FixCheckResultsJsonCheckNameType was written to repair, so it stands in
+        // for any pre-migration row that guard missed. (A bare "[1,2,3]" would also throw but is
+        // unreachable — the only writer, CheckResultsSerializer.Serialize, can't emit it.)
+        //
+        // TEST-DATA RULE EXCEPTION: this directly mutates one canonical detection_result's
+        // check_results_json via raw SQL instead of going through a GoldenMutatePlanBuilder verb.
+        // The golden dataset is scrubbed real prod data and so cannot carry deserialization-breaking
+        // JSON by construction; a reusable builder verb for a single caller would be YAGNI. No rows
+        // are added or removed — only one existing in-window row's column value is overwritten.
+        // The column is JSONB, so the payload must be valid JSON of the wrong *shape*, not malformed.
+        const string legacyStringEnumJson =
+            """{"Checks":[{"CheckName":"Bayes","Score":3.5,"Abstained":false,"Details":"legacy V1 string-enum row","ProcessingTimeMs":1.0}]}""";
+
+        await using (var ctx = _testHelper.GetDbContext())
+        {
+            // DrId_FpAuto is an in-window (today 00:01 after the SetUp shift), non-manual row
+            // that carries populated check_results_json — so it is visited by the aggregation loop.
+            await ctx.Database.ExecuteSqlRawAsync(
+                "UPDATE detection_results SET check_results_json = {0}::jsonb WHERE id = {1}",
+                legacyStringEnumJson, GoldenDatasetConstants.Analytics.DrId_FpAuto);
+        }
+
+        var startDate = DateTimeOffset.UtcNow.AddDays(-7);
+        var endDate = DateTimeOffset.UtcNow.AddDays(1);
+
+        // Act — without the #495 catch this throws JsonException; with it, the corrupt row is
+        // skipped and the remaining well-formed rows still aggregate.
+        var stats = await _analyticsRepository.GetDetectionMethodComparisonAsync(
+            startDate, endDate, DefaultTimeZoneId);
+
+        // Assert
+        Assert.That(stats, Is.Not.Null);
+        Assert.That(stats.Count, Is.GreaterThan(0),
+            "Undeserializable JSON in one row must be logged and skipped (not propagated); "
+            + "the other in-window rows must still produce method stats");
+    }
+
     #endregion
 
     #region Welcome System Analytics Tests

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs
@@ -10,11 +10,15 @@ using TelegramGroupsAdmin.Telegram.Repositories;
 namespace TelegramGroupsAdmin.IntegrationTests.Repositories;
 
 /// <summary>
-/// Integration tests for TagDefinitionsRepository concurrent-insert race conditions.
+/// Integration tests for TagDefinitionsRepository concurrent race conditions.
 ///
 /// Verifies that concurrent calls to CreateAsync and IncrementUsageAsync do not throw
 /// DbUpdateException (unique violation on tag_name) and that the resulting database
 /// state is correct (one row, correct count).
+///
+/// Also verifies the concurrent-decrement invariant: parallel DecrementUsageAsync calls
+/// lose no updates (final count == start minus the number of guarded decrements) and the
+/// count is clamped at zero — it never goes negative even when decremented past zero.
 /// </summary>
 [TestFixture]
 public class TagDefinitionsRepositoryRaceTests
@@ -151,17 +155,23 @@ public class TagDefinitionsRepositoryRaceTests
     [Test]
     public async Task DecrementUsageAsync_ConcurrentCalls_FinalCountClampedAtZero()
     {
-        // Arrange — create the tag and raise usage_count to 20
-        await using var setupScope = _serviceProvider!.CreateAsyncScope();
-        var setupRepo = setupScope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
-        var tagName = $"dec-race-{Guid.NewGuid():N}";
-        await setupRepo.CreateAsync(tagName, TagColor.Primary, CancellationToken.None);
-        for (var i = 0; i < 20; i++)
-        {
-            await setupRepo.IncrementUsageAsync(tagName, CancellationToken.None);
-        }
-
+        // Arrange — seed the tag with usage_count = 20
         var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        var tagName = $"dec-race-{Guid.NewGuid():N}";
+
+        // Seed directly (not via SUT write methods): a concurrent-mutation race test needs an
+        // isolated, destructively-mutated row, so canonical extension isn't feasible here.
+        await using (var seedCtx = await contextFactory.CreateDbContextAsync())
+        {
+            seedCtx.TagDefinitions.Add(new Data.Models.TagDefinitionDto
+            {
+                TagName = tagName,
+                Color = Data.Models.TagColor.Primary,
+                UsageCount = 20,
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await seedCtx.SaveChangesAsync();
+        }
 
         const int concurrentCalls = 20;
         var tasks = Enumerable.Range(0, concurrentCalls)
@@ -169,7 +179,7 @@ public class TagDefinitionsRepositoryRaceTests
             {
                 await using var scope = _serviceProvider!.CreateAsyncScope();
                 var scopedRepo = scope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
-                await scopedRepo.DecrementUsageAsync(tagName, CancellationToken.None);
+                await scopedRepo.DecrementUsageAsync(tagName, cancellationToken: CancellationToken.None);
             }))
             .ToArray();
 
@@ -186,16 +196,30 @@ public class TagDefinitionsRepositoryRaceTests
     public async Task DecrementUsageAsync_WhenCountIsZero_StaysAtZero()
     {
         // Arrange — fresh tag, usage_count = 0
-        await using var setupScope = _serviceProvider!.CreateAsyncScope();
-        var setupRepo = setupScope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
+        var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
         var tagName = $"dec-zero-{Guid.NewGuid():N}";
-        await setupRepo.CreateAsync(tagName, TagColor.Primary, CancellationToken.None);
+
+        // Seed directly (not via SUT write methods): a concurrent-mutation race test needs an
+        // isolated, destructively-mutated row, so canonical extension isn't feasible here.
+        await using (var seedCtx = await contextFactory.CreateDbContextAsync())
+        {
+            seedCtx.TagDefinitions.Add(new Data.Models.TagDefinitionDto
+            {
+                TagName = tagName,
+                Color = Data.Models.TagColor.Primary,
+                UsageCount = 0,
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using var scope = _serviceProvider!.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
 
         // Act
-        await setupRepo.DecrementUsageAsync(tagName, CancellationToken.None);
+        await repo.DecrementUsageAsync(tagName, cancellationToken: CancellationToken.None);
 
         // Assert — never goes negative
-        var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
         await using var ctx = await contextFactory.CreateDbContextAsync();
         var def = await ctx.TagDefinitions.AsNoTracking().FirstAsync(t => t.TagName == tagName);
         Assert.That(def.UsageCount, Is.EqualTo(0));

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs
@@ -16,9 +16,10 @@ namespace TelegramGroupsAdmin.IntegrationTests.Repositories;
 /// DbUpdateException (unique violation on tag_name) and that the resulting database
 /// state is correct (one row, correct count).
 ///
-/// Also verifies the concurrent-decrement invariant: parallel DecrementUsageAsync calls
-/// lose no updates (final count == start minus the number of guarded decrements) and the
-/// count is clamped at zero — it never goes negative even when decremented past zero.
+/// Also verifies the DecrementUsageAsync invariants against canonical golden rows:
+/// the no-lost-update guarantee (N concurrent decrements from a seeded high-count tag,
+/// 'power-user' at usage_count = 20, land exactly on 0) and clamp-at-zero (decrementing
+/// the real zero-count canonical tag, 'tester', never drives the count negative).
 /// </summary>
 [TestFixture]
 public class TagDefinitionsRepositoryRaceTests
@@ -30,7 +31,10 @@ public class TagDefinitionsRepositoryRaceTests
     public async Task SetUp()
     {
         _testHelper = new MigrationTestHelper();
-        await _testHelper.CreateDatabaseFromEmptyTemplateAsync();
+        // Golden template: decrement tests assert against canonical tag_definitions rows
+        // ('power-user', 'tester'). The Create/Increment tests use unique Guid tag names,
+        // so the presence of canonical rows does not affect them.
+        await _testHelper.CreateDatabaseFromGoldenTemplateAsync();
 
         var services = new ServiceCollection();
 
@@ -153,28 +157,22 @@ public class TagDefinitionsRepositoryRaceTests
     // ============================================================================
 
     [Test]
-    public async Task DecrementUsageAsync_ConcurrentCalls_FinalCountClampedAtZero()
+    public async Task DecrementUsageAsync_ConcurrentCalls_NoLostUpdates()
     {
-        // Arrange — seed the tag with usage_count = 20
+        // Asserts the no-lost-update invariant against a known canonical row.
+        // 'power-user' is seeded in canonical with usage_count = 20 specifically so the
+        // race window is meaningful; only the count matters here, not row content.
+        const string tagName = "power-user";
         var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
-        var tagName = $"dec-race-{Guid.NewGuid():N}";
 
-        // Seed directly (not via SUT write methods): a concurrent-mutation race test needs an
-        // isolated, destructively-mutated row, so canonical extension isn't feasible here.
-        await using (var seedCtx = await contextFactory.CreateDbContextAsync())
+        int startCount;
+        await using (var readCtx = await contextFactory.CreateDbContextAsync())
         {
-            seedCtx.TagDefinitions.Add(new Data.Models.TagDefinitionDto
-            {
-                TagName = tagName,
-                Color = Data.Models.TagColor.Primary,
-                UsageCount = 20,
-                CreatedAt = DateTimeOffset.UtcNow
-            });
-            await seedCtx.SaveChangesAsync();
+            startCount = (await readCtx.TagDefinitions.AsNoTracking().FirstAsync(t => t.TagName == tagName)).UsageCount;
         }
+        Assert.That(startCount, Is.GreaterThan(0), "canonical seed precondition");
 
-        const int concurrentCalls = 20;
-        var tasks = Enumerable.Range(0, concurrentCalls)
+        var tasks = Enumerable.Range(0, startCount)
             .Select(_ => Task.Run(async () =>
             {
                 await using var scope = _serviceProvider!.CreateAsyncScope();
@@ -183,10 +181,9 @@ public class TagDefinitionsRepositoryRaceTests
             }))
             .ToArray();
 
-        // Act
         await Task.WhenAll(tasks);
 
-        // Assert — 20 increments minus 20 concurrent decrements, no lost updates
+        // startCount concurrent decrements from startCount must land exactly on 0 (no lost updates).
         await using var ctx = await contextFactory.CreateDbContextAsync();
         var def = await ctx.TagDefinitions.AsNoTracking().FirstAsync(t => t.TagName == tagName);
         Assert.That(def.UsageCount, Is.EqualTo(0));
@@ -195,31 +192,16 @@ public class TagDefinitionsRepositoryRaceTests
     [Test]
     public async Task DecrementUsageAsync_WhenCountIsZero_StaysAtZero()
     {
-        // Arrange — fresh tag, usage_count = 0
-        var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
-        var tagName = $"dec-zero-{Guid.NewGuid():N}";
+        // 'tester' is a real canonical tag already at usage_count = 0 — decrementing must clamp, not go negative.
+        const string tagName = "tester";
 
-        // Seed directly (not via SUT write methods): a concurrent-mutation race test needs an
-        // isolated, destructively-mutated row, so canonical extension isn't feasible here.
-        await using (var seedCtx = await contextFactory.CreateDbContextAsync())
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
         {
-            seedCtx.TagDefinitions.Add(new Data.Models.TagDefinitionDto
-            {
-                TagName = tagName,
-                Color = Data.Models.TagColor.Primary,
-                UsageCount = 0,
-                CreatedAt = DateTimeOffset.UtcNow
-            });
-            await seedCtx.SaveChangesAsync();
+            var repo = scope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
+            await repo.DecrementUsageAsync(tagName, cancellationToken: CancellationToken.None);
         }
 
-        await using var scope = _serviceProvider!.CreateAsyncScope();
-        var repo = scope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
-
-        // Act
-        await repo.DecrementUsageAsync(tagName, cancellationToken: CancellationToken.None);
-
-        // Assert — never goes negative
+        var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
         await using var ctx = await contextFactory.CreateDbContextAsync();
         var def = await ctx.TagDefinitions.AsNoTracking().FirstAsync(t => t.TagName == tagName);
         Assert.That(def.UsageCount, Is.EqualTo(0));

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs
@@ -143,4 +143,61 @@ public class TagDefinitionsRepositoryRaceTests
         var count = await ctx.TagDefinitions.CountAsync(t => t.TagName == tagName);
         Assert.That(count, Is.EqualTo(1));
     }
+
+    // ============================================================================
+    // DecrementUsageAsync Race Tests
+    // ============================================================================
+
+    [Test]
+    public async Task DecrementUsageAsync_ConcurrentCalls_FinalCountClampedAtZero()
+    {
+        // Arrange — create the tag and raise usage_count to 20
+        await using var setupScope = _serviceProvider!.CreateAsyncScope();
+        var setupRepo = setupScope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
+        var tagName = $"dec-race-{Guid.NewGuid():N}";
+        await setupRepo.CreateAsync(tagName, TagColor.Primary, CancellationToken.None);
+        for (var i = 0; i < 20; i++)
+        {
+            await setupRepo.IncrementUsageAsync(tagName, CancellationToken.None);
+        }
+
+        var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
+
+        const int concurrentCalls = 20;
+        var tasks = Enumerable.Range(0, concurrentCalls)
+            .Select(_ => Task.Run(async () =>
+            {
+                await using var scope = _serviceProvider!.CreateAsyncScope();
+                var scopedRepo = scope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
+                await scopedRepo.DecrementUsageAsync(tagName, CancellationToken.None);
+            }))
+            .ToArray();
+
+        // Act
+        await Task.WhenAll(tasks);
+
+        // Assert — 20 increments minus 20 concurrent decrements, no lost updates
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+        var def = await ctx.TagDefinitions.AsNoTracking().FirstAsync(t => t.TagName == tagName);
+        Assert.That(def.UsageCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task DecrementUsageAsync_WhenCountIsZero_StaysAtZero()
+    {
+        // Arrange — fresh tag, usage_count = 0
+        await using var setupScope = _serviceProvider!.CreateAsyncScope();
+        var setupRepo = setupScope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
+        var tagName = $"dec-zero-{Guid.NewGuid():N}";
+        await setupRepo.CreateAsync(tagName, TagColor.Primary, CancellationToken.None);
+
+        // Act
+        await setupRepo.DecrementUsageAsync(tagName, CancellationToken.None);
+
+        // Assert — never goes negative
+        var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+        var def = await ctx.TagDefinitions.AsNoTracking().FirstAsync(t => t.TagName == tagName);
+        Assert.That(def.UsageCount, Is.EqualTo(0));
+    }
 }

--- a/TelegramGroupsAdmin.IntegrationTests/Services/BackgroundJobConfigPersistenceTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/BackgroundJobConfigPersistenceTests.cs
@@ -49,6 +49,9 @@ public class BackgroundJobConfigPersistenceTests
         var mockScheduleConverter = Substitute.For<IQuartzScheduleConverter>();
         services.AddSingleton(mockScheduleConverter);
 
+        // IScheduleResyncSignal is required by BackgroundJobConfigService; signal behavior isn't under test here.
+        services.AddSingleton(Substitute.For<IScheduleResyncSignal>());
+
         // Add BackgroundJobConfigService
         services.AddScoped<IBackgroundJobConfigService, BackgroundJobConfigService>();
 

--- a/TelegramGroupsAdmin.IntegrationTests/TestData/SQL/canonical/12_tag_definitions.sql
+++ b/TelegramGroupsAdmin.IntegrationTests/TestData/SQL/canonical/12_tag_definitions.sql
@@ -4,3 +4,4 @@ INSERT INTO tag_definitions (tag_name, color, usage_count, created_at) VALUES ('
 INSERT INTO tag_definitions (tag_name, color, usage_count, created_at) VALUES ('admin', 3, 4, '2025-10-24 08:38:42.139594+00');
 INSERT INTO tag_definitions (tag_name, color, usage_count, created_at) VALUES ('joker', 4, 1, '2025-10-31 19:15:36.692304+00');
 INSERT INTO tag_definitions (tag_name, color, usage_count, created_at) VALUES ('combative', 5, 2, '2025-11-22 17:42:03.737449+00');
+INSERT INTO tag_definitions (tag_name, color, usage_count, created_at) VALUES ('power-user', 3, 20, '2025-11-15 09:30:00.000000+00');

--- a/TelegramGroupsAdmin.Telegram/Repositories/TagDefinitionsRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/TagDefinitionsRepository.cs
@@ -133,24 +133,12 @@ public class TagDefinitionsRepository : ITagDefinitionsRepository
         var normalizedTag = NormalizeTagName(tagName);
 
         await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-        var definition = await context.TagDefinitions
-            .FirstOrDefaultAsync(td => td.TagName == normalizedTag, cancellationToken);
 
-        if (definition == null)
-        {
-            _logger.LogWarning("Tag definition not found for decrement: {TagName}", normalizedTag);
-            return;
-        }
-
-        if (definition.UsageCount > 0)
-        {
-            definition.UsageCount--;
-            await context.SaveChangesAsync(cancellationToken);
-        }
-        else
-        {
-            _logger.LogWarning("Usage count already 0 for tag: {TagName}", normalizedTag);
-        }
+        // Atomic, clamp-at-zero: the WHERE guard makes a decrement at 0 a no-op,
+        // so concurrent callers can never lose an update or drive the count negative.
+        await context.TagDefinitions
+            .Where(t => t.TagName == normalizedTag && t.UsageCount > 0)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.UsageCount, t => t.UsageCount - 1), cancellationToken);
     }
 
     public async Task<bool> ExistsAsync(string tagName, CancellationToken cancellationToken = default)

--- a/TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs
@@ -45,7 +45,7 @@ public class UsernameBlacklistService(
         BlacklistMatchType matchType,
         string? notes,
         Actor actor,
-        CancellationToken ct = default)
+        CancellationToken cancellationToken = default)
     {
         var entry = new UsernameBlacklistEntry(
             Id: 0,
@@ -55,51 +55,51 @@ public class UsernameBlacklistService(
             CreatedAt: DateTimeOffset.UtcNow,
             Notes: notes);
 
-        var id = await repository.AddEntryAsync(entry, ct);
+        var id = await repository.AddEntryAsync(entry, cancellationToken);
 
         await auditService.LogEventAsync(
             AuditEventType.BlacklistEntryAdded,
             actor,
             target: null,
             value: pattern,
-            cancellationToken: ct);
+            cancellationToken: cancellationToken);
 
         return id;
     }
 
-    public async Task<bool> DeleteEntryAsync(long id, string pattern, Actor actor, CancellationToken ct = default)
+    public async Task<bool> DeleteEntryAsync(long id, string pattern, Actor actor, CancellationToken cancellationToken = default)
     {
-        var deleted = await repository.DeleteEntryAsync(id, ct);
+        var deleted = await repository.DeleteEntryAsync(id, cancellationToken);
         if (deleted)
         {
             await auditService.LogEventAsync(
                 AuditEventType.BlacklistEntryRemoved,
-                actor, target: null, value: pattern, cancellationToken: ct);
+                actor, target: null, value: pattern, cancellationToken: cancellationToken);
         }
         return deleted;
     }
 
-    public async Task<bool> SetEnabledAsync(long id, string pattern, bool enabled, Actor actor, CancellationToken ct = default)
+    public async Task<bool> SetEnabledAsync(long id, string pattern, bool enabled, Actor actor, CancellationToken cancellationToken = default)
     {
-        var updated = await repository.SetEnabledAsync(id, enabled, ct);
+        var updated = await repository.SetEnabledAsync(id, enabled, cancellationToken);
         if (updated)
         {
             var eventType = enabled
                 ? AuditEventType.BlacklistEntryEnabled
                 : AuditEventType.BlacklistEntryDisabled;
-            await auditService.LogEventAsync(eventType, actor, target: null, value: pattern, cancellationToken: ct);
+            await auditService.LogEventAsync(eventType, actor, target: null, value: pattern, cancellationToken: cancellationToken);
         }
         return updated;
     }
 
-    public async Task<bool> UpdateNotesAsync(long id, string pattern, string? notes, Actor actor, CancellationToken ct = default)
+    public async Task<bool> UpdateNotesAsync(long id, string pattern, string? notes, Actor actor, CancellationToken cancellationToken = default)
     {
-        var updated = await repository.UpdateNotesAsync(id, notes, ct);
+        var updated = await repository.UpdateNotesAsync(id, notes, cancellationToken);
         if (updated)
         {
             await auditService.LogEventAsync(
                 AuditEventType.BlacklistEntryNotesChanged,
-                actor, target: null, value: pattern, cancellationToken: ct);
+                actor, target: null, value: pattern, cancellationToken: cancellationToken);
         }
         return updated;
     }

--- a/TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs
@@ -60,9 +60,9 @@ public class UsernameBlacklistService(
         await auditService.LogEventAsync(
             AuditEventType.BlacklistEntryAdded,
             actor,
-            actor,
-            pattern,
-            ct);
+            target: null,
+            value: pattern,
+            cancellationToken: ct);
 
         return id;
     }
@@ -74,7 +74,7 @@ public class UsernameBlacklistService(
         {
             await auditService.LogEventAsync(
                 AuditEventType.BlacklistEntryRemoved,
-                actor, actor, pattern, ct);
+                actor, target: null, value: pattern, cancellationToken: ct);
         }
         return deleted;
     }
@@ -87,7 +87,7 @@ public class UsernameBlacklistService(
             var eventType = enabled
                 ? AuditEventType.BlacklistEntryEnabled
                 : AuditEventType.BlacklistEntryDisabled;
-            await auditService.LogEventAsync(eventType, actor, actor, pattern, ct);
+            await auditService.LogEventAsync(eventType, actor, target: null, value: pattern, cancellationToken: ct);
         }
         return updated;
     }
@@ -99,7 +99,7 @@ public class UsernameBlacklistService(
         {
             await auditService.LogEventAsync(
                 AuditEventType.BlacklistEntryNotesChanged,
-                actor, actor, pattern, ct);
+                actor, target: null, value: pattern, cancellationToken: ct);
         }
         return updated;
     }

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs
@@ -29,4 +29,20 @@ public class ScheduleResyncSignalTests
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
         Assert.ThrowsAsync<OperationCanceledException>(async () => await signal.WaitAsync(cts.Token));
     }
+
+    [Test]
+    public async Task RequestResync_ConcurrentCalls_NeverThrow()
+    {
+        var signal = new ScheduleResyncSignal();
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+        var tasks = Enumerable.Range(0, 100).Select(_ => Task.Run(() =>
+        {
+            try { signal.RequestResync(); }
+            catch (Exception ex) { exceptions.Add(ex); }
+        })).ToArray();
+        await Task.WhenAll(tasks);
+
+        Assert.That(exceptions, Is.Empty, "Concurrent RequestResync must never throw");
+    }
 }

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs
@@ -1,0 +1,32 @@
+using TelegramGroupsAdmin.BackgroundJobs.Services;
+
+namespace TelegramGroupsAdmin.UnitTests.BackgroundJobs;
+
+[TestFixture]
+public class ScheduleResyncSignalTests
+{
+    [Test]
+    public async Task RequestResync_ThenWaitAsync_Completes()
+    {
+        var signal = new ScheduleResyncSignal();
+
+        signal.RequestResync();
+
+        await signal.WaitAsync(CancellationToken.None); // must complete without blocking
+        Assert.Pass();
+    }
+
+    [Test]
+    public async Task RequestResync_CalledTwiceBeforeWait_Coalesces()
+    {
+        var signal = new ScheduleResyncSignal();
+
+        signal.RequestResync();
+        signal.RequestResync(); // must not throw; collapses into one pending wake
+
+        await signal.WaitAsync(CancellationToken.None); // first wait completes
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await signal.WaitAsync(cts.Token));
+    }
+}

--- a/TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs
@@ -8,7 +8,7 @@ public class ScheduleResyncSignalTests
     [Test]
     public async Task RequestResync_ThenWaitAsync_Completes()
     {
-        var signal = new ScheduleResyncSignal();
+        using var signal = new ScheduleResyncSignal();
 
         signal.RequestResync();
 
@@ -19,7 +19,7 @@ public class ScheduleResyncSignalTests
     [Test]
     public async Task RequestResync_CalledTwiceBeforeWait_Coalesces()
     {
-        var signal = new ScheduleResyncSignal();
+        using var signal = new ScheduleResyncSignal();
 
         signal.RequestResync();
         signal.RequestResync(); // must not throw; collapses into one pending wake
@@ -33,7 +33,7 @@ public class ScheduleResyncSignalTests
     [Test]
     public async Task RequestResync_ConcurrentCalls_NeverThrow()
     {
-        var signal = new ScheduleResyncSignal();
+        using var signal = new ScheduleResyncSignal();
         var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
 
         var tasks = Enumerable.Range(0, 100).Select(_ => Task.Run(() =>

--- a/TelegramGroupsAdmin.UnitTests/ContentDetection/CheckResultsSerializerTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/ContentDetection/CheckResultsSerializerTests.cs
@@ -49,23 +49,17 @@ public class CheckResultsSerializerTests
     #region Deserialize — Malformed JSON
 
     [Test]
-    public void Deserialize_MalformedJson_ReturnsEmptyList()
+    public void Deserialize_MalformedJson_Throws()
     {
-        // Arrange / Act
-        var result = CheckResultsSerializer.Deserialize("{ this is not valid json !!!");
-
-        // Assert
-        Assert.That(result, Is.Empty);
+        // Malformed JSON must propagate, not be silently swallowed into an empty list.
+        Assert.Throws<JsonException>(() => CheckResultsSerializer.Deserialize("{ this is not valid json !!!"));
     }
 
     [Test]
-    public void Deserialize_ValidJsonButWrongShape_ReturnsEmptyList()
+    public void Deserialize_ValidJsonButWrongShape_Throws()
     {
-        // Arrange — valid JSON but not the expected CheckResults wrapper shape
-        var result = CheckResultsSerializer.Deserialize("[1, 2, 3]");
-
-        // Assert
-        Assert.That(result, Is.Empty);
+        // Valid JSON of the wrong shape (array instead of the CheckResults object) must propagate.
+        Assert.Throws<JsonException>(() => CheckResultsSerializer.Deserialize("[1, 2, 3]"));
     }
 
     [Test]

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceMutationTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceMutationTests.cs
@@ -52,7 +52,7 @@ public class UsernameBlacklistServiceMutationTests
         await _audit.Received(1).LogEventAsync(
             AuditEventType.BlacklistEntryAdded,
             actor,
-            actor,
+            Arg.Is<Actor?>(t => t == null),
             "spam-pattern",
             Arg.Any<CancellationToken>());
     }
@@ -68,7 +68,7 @@ public class UsernameBlacklistServiceMutationTests
         Assert.That(result, Is.True);
         await _audit.Received(1).LogEventAsync(
             AuditEventType.BlacklistEntryRemoved,
-            actor, actor, "test-pattern",
+            actor, Arg.Is<Actor?>(t => t == null), "test-pattern",
             Arg.Any<CancellationToken>());
     }
 
@@ -97,7 +97,7 @@ public class UsernameBlacklistServiceMutationTests
         Assert.That(result, Is.True);
         await _audit.Received(1).LogEventAsync(
             AuditEventType.BlacklistEntryEnabled,
-            actor, actor, "test-pattern",
+            actor, Arg.Is<Actor?>(t => t == null), "test-pattern",
             Arg.Any<CancellationToken>());
     }
 
@@ -112,7 +112,7 @@ public class UsernameBlacklistServiceMutationTests
         Assert.That(result, Is.True);
         await _audit.Received(1).LogEventAsync(
             AuditEventType.BlacklistEntryDisabled,
-            actor, actor, "test-pattern",
+            actor, Arg.Is<Actor?>(t => t == null), "test-pattern",
             Arg.Any<CancellationToken>());
     }
 
@@ -141,7 +141,7 @@ public class UsernameBlacklistServiceMutationTests
         Assert.That(result, Is.True);
         await _audit.Received(1).LogEventAsync(
             AuditEventType.BlacklistEntryNotesChanged,
-            actor, actor, "test-pattern",
+            actor, Arg.Is<Actor?>(t => t == null), "test-pattern",
             Arg.Any<CancellationToken>());
     }
 

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceMutationTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceMutationTests.cs
@@ -37,7 +37,7 @@ public class UsernameBlacklistServiceMutationTests
             BlacklistMatchType.Exact,
             notes: "test notes",
             actor: actor,
-            ct: CancellationToken.None);
+            cancellationToken: CancellationToken.None);
 
         Assert.That(id, Is.EqualTo(42L));
 

--- a/TelegramGroupsAdmin/Repositories/AnalyticsRepository.cs
+++ b/TelegramGroupsAdmin/Repositories/AnalyticsRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using TelegramGroupsAdmin.ContentDetection.Models;
 using TelegramGroupsAdmin.ContentDetection.Utilities;
@@ -249,7 +250,15 @@ public class AnalyticsRepository : IAnalyticsRepository
 
     private List<CheckResult> ParseCheckResults(string? json)
     {
-        return CheckResultsSerializer.Deserialize(json ?? string.Empty);
+        try
+        {
+            return CheckResultsSerializer.Deserialize(json ?? string.Empty);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse check results JSON during analytics aggregation; treating as no checks");
+            return [];
+        }
     }
 
     private class AlgorithmStatsAccumulator

--- a/TelegramGroupsAdmin/Repositories/AnalyticsRepository.cs
+++ b/TelegramGroupsAdmin/Repositories/AnalyticsRepository.cs
@@ -176,6 +176,7 @@ public class AnalyticsRepository : IAnalyticsRepository
             .Where(dr => dr.CheckResultsJson != null) // Only rows with individual check data
             .Select(dr => new
             {
+                dr.Id,
                 dr.MessageId,
                 dr.CheckResultsJson,
                 dr.IsSpam
@@ -196,7 +197,7 @@ public class AnalyticsRepository : IAnalyticsRepository
 
         foreach (var detection in allDetections)
         {
-            var checks = ParseCheckResults(detection.CheckResultsJson);
+            var checks = ParseCheckResults(detection.CheckResultsJson, detection.Id);
             accuracyLookup.TryGetValue(detection.MessageId, out var accuracy);
             var isFalsePositive = accuracy?.IsFalsePositive ?? false;
             var isFalseNegative = accuracy?.IsFalseNegative ?? false;
@@ -248,7 +249,7 @@ public class AnalyticsRepository : IAnalyticsRepository
         return result;
     }
 
-    private List<CheckResult> ParseCheckResults(string? json)
+    private List<CheckResult> ParseCheckResults(string? json, long detectionResultId)
     {
         try
         {
@@ -256,7 +257,9 @@ public class AnalyticsRepository : IAnalyticsRepository
         }
         catch (JsonException ex)
         {
-            _logger.LogWarning(ex, "Failed to parse check results JSON during analytics aggregation; treating as no checks");
+            _logger.LogWarning(ex,
+                "Failed to parse check results JSON for detection result {DetectionResultId} during analytics aggregation; treating as no checks",
+                detectionResultId);
             return [];
         }
     }

--- a/docs/superpowers/plans/2026-05-30-correctness-bug-sweep.md
+++ b/docs/superpowers/plans/2026-05-30-correctness-bug-sweep.md
@@ -1,0 +1,691 @@
+# Correctness Bug Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix four triaged correctness bugs (#475, #473, #495, #472) on one branch, landing as one PR to `develop` with a commit per issue.
+
+**Architecture:** Each task is independent and self-contained. Order is easiest-to-hardest: an audit-argument fix, an atomic DB UPDATE, observability for swallowed exceptions, and a small DI decoupling. TDD throughout: failing test → minimal change → green → commit.
+
+**Tech Stack:** .NET 10, EF Core 10 (PostgreSQL), NUnit + NSubstitute (unit), real-Postgres integration tests, Quartz.NET hosted service.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-correctness-bug-sweep-design.md`
+
+**Branch:** `fix/correctness-bug-sweep` (already created off `develop`; the spec doc is already committed on it).
+
+---
+
+## File Structure
+
+| File | Task | Responsibility / change |
+|---|---|---|
+| `TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs` | 1 | 4 mutation methods: pass `target: null` not `actor` |
+| `TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceMutationTests.cs` | 1 | 5 positive-path assertions expect a null target |
+| `TelegramGroupsAdmin.Telegram/Repositories/TagDefinitionsRepository.cs` | 2 | `DecrementUsageAsync` → atomic `ExecuteUpdateAsync` |
+| `TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs` | 2 | add concurrent-decrement + clamp-at-zero tests |
+| `TelegramGroupsAdmin.ContentDetection/Utilities/CheckResultsSerializer.cs` | 3 | remove silent `catch` so `JsonException` propagates |
+| `TelegramGroupsAdmin/Repositories/AnalyticsRepository.cs` | 3 | per-call fail-open guard + log |
+| `TelegramGroupsAdmin.ContentDetection/ML/StopWordRecommendationService.cs` | 3 | per-row fail-open guard + log |
+| `TelegramGroupsAdmin.ContentDetection/Services/VideoFrameExtractionService.cs` | 3 | log before the `128.0` fallback |
+| `TelegramGroupsAdmin.UnitTests/ContentDetection/CheckResultsSerializerTests.cs` | 3 | 2 malformed tests flip to expect a throw |
+| `TelegramGroupsAdmin.BackgroundJobs/Services/IScheduleResyncSignal.cs` | 4 | **new** — shared wake-up signal abstraction + impl |
+| `TelegramGroupsAdmin.BackgroundJobs/Services/QuartzSchedulingSyncService.cs` | 4 | consume the signal; delete cast/field/`TriggerResync` |
+| `TelegramGroupsAdmin.BackgroundJobs/Services/BackgroundJobConfigService.cs` | 4 | inject signal; delete `_syncService`/`SetSyncService` |
+| `TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs` | 4 | register the signal singleton |
+| `TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs` | 4 | **new** — unit-test the signal |
+
+**Commands** (run from repo root):
+- Build: `dotnet build`
+- Unit tests (Debug, local): `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~<ClassName>"`
+- Integration tests (real Postgres; run in background with file output per project convention):
+  `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~<ClassName>"`
+
+---
+
+## Task 1: #475 — Blacklist audit passes actor as its own target
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs` (4 call sites: ~`:60`, `:75`, `:90`, `:100`)
+- Test: `TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceMutationTests.cs` (5 positive-path assertions)
+
+Note: there are **five** positive-path `Received(1)` assertions, not four — `SetEnabledAsync` has both a True→Enabled and a False→Disabled test. The two `DidNotReceive` tests already use `Arg.Any<Actor?>()` and need no change.
+
+- [ ] **Step 1: Update the test assertions to expect a null target (failing test)**
+
+In `UsernameBlacklistServiceMutationTests.cs`, change the **third argument** (the second `actor`) of each positive-path `Received(1).LogEventAsync(...)` to `Arg.Is<Actor?>(t => t == null)`. There are five:
+
+`AddEntryAsync_CallsRepoThenWritesAuditWithDedicatedEventType` (~line 52):
+```csharp
+        await _audit.Received(1).LogEventAsync(
+            AuditEventType.BlacklistEntryAdded,
+            actor,
+            Arg.Is<Actor?>(t => t == null),
+            "test-pattern",
+            Arg.Any<CancellationToken>());
+```
+`DeleteEntryAsync_WhenRepoReturnsTrue_WritesAudit` (~line 69):
+```csharp
+        await _audit.Received(1).LogEventAsync(
+            AuditEventType.BlacklistEntryRemoved,
+            actor, Arg.Is<Actor?>(t => t == null), "test-pattern",
+            Arg.Any<CancellationToken>());
+```
+`SetEnabledAsync_True_WritesEnabledAuditEvent` (~line 98):
+```csharp
+        await _audit.Received(1).LogEventAsync(
+            AuditEventType.BlacklistEntryEnabled,
+            actor, Arg.Is<Actor?>(t => t == null), "test-pattern",
+            Arg.Any<CancellationToken>());
+```
+`SetEnabledAsync_False_WritesDisabledAuditEvent` (~line 113):
+```csharp
+        await _audit.Received(1).LogEventAsync(
+            AuditEventType.BlacklistEntryDisabled,
+            actor, Arg.Is<Actor?>(t => t == null), "test-pattern",
+            Arg.Any<CancellationToken>());
+```
+`UpdateNotesAsync_WhenRepoReturnsTrue_WritesAudit` (~line 142):
+```csharp
+        await _audit.Received(1).LogEventAsync(
+            AuditEventType.BlacklistEntryNotesChanged,
+            actor, Arg.Is<Actor?>(t => t == null), "test-pattern",
+            Arg.Any<CancellationToken>());
+```
+
+(If the existing event-type argument on any site is currently written differently, keep it as-is — only the target argument changes.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~UsernameBlacklistServiceMutationTests"`
+Expected: the 5 positive-path tests FAIL (service still passes `actor` as target, so the received call has a non-null target).
+
+- [ ] **Step 3: Fix the four service call sites**
+
+In `UsernameBlacklistService.cs`, change each `LogEventAsync` call to pass `target: null` (fully named optional args for clarity):
+
+`AddEntryAsync`:
+```csharp
+        await auditService.LogEventAsync(
+            AuditEventType.BlacklistEntryAdded,
+            actor,
+            target: null,
+            value: pattern,
+            cancellationToken: ct);
+```
+`DeleteEntryAsync`:
+```csharp
+            await auditService.LogEventAsync(
+                AuditEventType.BlacklistEntryRemoved,
+                actor, target: null, value: pattern, cancellationToken: ct);
+```
+`SetEnabledAsync`:
+```csharp
+            await auditService.LogEventAsync(eventType, actor, target: null, value: pattern, cancellationToken: ct);
+```
+`UpdateNotesAsync`:
+```csharp
+            await auditService.LogEventAsync(
+                AuditEventType.BlacklistEntryNotesChanged,
+                actor, target: null, value: pattern, cancellationToken: ct);
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~UsernameBlacklistServiceMutationTests"`
+Expected: PASS (all 7 tests: 5 positive + 2 `DidNotReceive`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs \
+        TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceMutationTests.cs
+git commit -F- <<'EOF'
+fix(audit): pass null target for username blacklist mutations
+
+Blacklist mutations are config events with no distinct user target. All four
+mutation methods passed the admin actor into the target slot, producing
+misleading audit records and polluting target-based filtering. Pass target:
+null, matching the ConfigService convention.
+
+Closes #475
+EOF
+```
+
+---
+
+## Task 2: #473 — DecrementUsageAsync read-then-write TOCTOU race
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Repositories/TagDefinitionsRepository.cs` — `DecrementUsageAsync` (~`:131-154`)
+- Test: `TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs`
+
+These are integration tests against real Postgres. The concurrency test is probabilistic against the OLD code — under contention the lost-update race leaves the count above 0 intermittently; after the fix it is reliably 0.
+
+- [ ] **Step 1: Add the concurrent-decrement and clamp tests (failing test)**
+
+Append these two tests inside the `TagDefinitionsRepositoryRaceTests` class (before the closing brace), mirroring the existing increment-race harness:
+
+```csharp
+    [Test]
+    public async Task DecrementUsageAsync_ConcurrentCalls_FinalCountClampedAtZero()
+    {
+        // Arrange — create the tag and raise usage_count to 20
+        await using var setupScope = _serviceProvider!.CreateAsyncScope();
+        var setupRepo = setupScope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
+        var tagName = $"dec-race-{Guid.NewGuid():N}";
+        await setupRepo.CreateAsync(tagName, TagColor.Primary, CancellationToken.None);
+        for (var i = 0; i < 20; i++)
+        {
+            await setupRepo.IncrementUsageAsync(tagName, CancellationToken.None);
+        }
+
+        var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
+
+        const int concurrentCalls = 20;
+        var tasks = Enumerable.Range(0, concurrentCalls)
+            .Select(_ => Task.Run(async () =>
+            {
+                await using var scope = _serviceProvider!.CreateAsyncScope();
+                var scopedRepo = scope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
+                await scopedRepo.DecrementUsageAsync(tagName, CancellationToken.None);
+            }))
+            .ToArray();
+
+        // Act
+        await Task.WhenAll(tasks);
+
+        // Assert — 20 increments minus 20 concurrent decrements, no lost updates
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+        var def = await ctx.TagDefinitions.AsNoTracking().FirstAsync(t => t.TagName == tagName);
+        Assert.That(def.UsageCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task DecrementUsageAsync_WhenCountIsZero_StaysAtZero()
+    {
+        // Arrange — fresh tag, usage_count = 0
+        await using var setupScope = _serviceProvider!.CreateAsyncScope();
+        var setupRepo = setupScope.ServiceProvider.GetRequiredService<ITagDefinitionsRepository>();
+        var tagName = $"dec-zero-{Guid.NewGuid():N}";
+        await setupRepo.CreateAsync(tagName, TagColor.Primary, CancellationToken.None);
+
+        // Act
+        await setupRepo.DecrementUsageAsync(tagName, CancellationToken.None);
+
+        // Assert — never goes negative
+        var contextFactory = _serviceProvider!.GetRequiredService<IDbContextFactory<AppDbContext>>();
+        await using var ctx = await contextFactory.CreateDbContextAsync();
+        var def = await ctx.TagDefinitions.AsNoTracking().FirstAsync(t => t.TagName == tagName);
+        Assert.That(def.UsageCount, Is.EqualTo(0));
+    }
+```
+
+- [ ] **Step 2: Run the concurrency test against current code to observe the race**
+
+Run (a few times, since it's probabilistic):
+`dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~TagDefinitionsRepositoryRaceTests.DecrementUsageAsync_ConcurrentCalls_FinalCountClampedAtZero"`
+Expected: intermittent FAIL — final `UsageCount` is greater than 0 (lost updates) on at least one run. (`DecrementUsageAsync_WhenCountIsZero_StaysAtZero` already passes against the old code; that's fine.)
+
+- [ ] **Step 3: Replace DecrementUsageAsync with an atomic ExecuteUpdateAsync**
+
+Replace the entire `DecrementUsageAsync` method body:
+
+```csharp
+    public async Task DecrementUsageAsync(string tagName, CancellationToken cancellationToken = default)
+    {
+        var normalizedTag = NormalizeTagName(tagName);
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Atomic, clamp-at-zero: the WHERE guard makes a decrement at 0 a no-op,
+        // so concurrent callers can never lose an update or drive the count negative.
+        await context.TagDefinitions
+            .Where(t => t.TagName == normalizedTag && t.UsageCount > 0)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.UsageCount, t => t.UsageCount - 1), cancellationToken);
+    }
+```
+
+This drops the prior "tag not found" / "already 0" warning logs intentionally (they ran off the now-removed read; a decrement on a missing/zero tag is a benign no-op). Note this in the PR body. `using Microsoft.EntityFrameworkCore;` is already present (used by `IncrementUsageAsync`).
+
+- [ ] **Step 4: Run both decrement tests to verify they pass**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~TagDefinitionsRepositoryRaceTests"`
+Expected: PASS, including running the concurrency test reliably (final count `== 0`). Run it 2-3 times to confirm stability.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Repositories/TagDefinitionsRepository.cs \
+        TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs
+git commit -F- <<'EOF'
+fix(db): make DecrementUsageAsync atomic to close TOCTOU race
+
+Replace read-check-decrement-save with a single guarded ExecuteUpdateAsync
+(.Where(UsageCount > 0)). The WHERE clause preserves clamp-at-zero atomically,
+eliminating lost updates under concurrent tag deletions. Drops the prior
+not-found / already-zero warning logs (no longer have a prior read).
+
+Closes #473
+EOF
+```
+
+---
+
+## Task 3: #495 — Two silent catch blocks swallow errors
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.ContentDetection/Utilities/CheckResultsSerializer.cs` (~`:50-62`)
+- Modify: `TelegramGroupsAdmin/Repositories/AnalyticsRepository.cs` (`ParseCheckResults`, ~`:250`)
+- Modify: `TelegramGroupsAdmin.ContentDetection/ML/StopWordRecommendationService.cs` (~`:333`)
+- Modify: `TelegramGroupsAdmin.ContentDetection/Services/VideoFrameExtractionService.cs` (`AnalyzeFrameBrightnessAsync`, ~`:628`)
+- Test: `TelegramGroupsAdmin.UnitTests/ContentDetection/CheckResultsSerializerTests.cs` (2 malformed tests)
+
+Background: the three `DetectionResultsRepository` callers already wrap `Deserialize` in `try/catch (Exception) { LogWarning; skip }`, but the serializer's silent catch defeats them. We make the serializer propagate, leave those three untouched, and add matching guards to the two unguarded callers.
+
+- [ ] **Step 1: Flip the serializer's malformed-JSON tests to expect a throw (failing test)**
+
+In `CheckResultsSerializerTests.cs`, replace the two tests in the "Malformed JSON" region:
+
+```csharp
+    [Test]
+    public void Deserialize_MalformedJson_Throws()
+    {
+        // Malformed JSON must propagate, not be silently swallowed into an empty list.
+        Assert.Throws<JsonException>(() => CheckResultsSerializer.Deserialize("{ this is not valid json !!!"));
+    }
+
+    [Test]
+    public void Deserialize_ValidJsonButWrongShape_Throws()
+    {
+        // Valid JSON of the wrong shape (array instead of the CheckResults object) must propagate.
+        Assert.Throws<JsonException>(() => CheckResultsSerializer.Deserialize("[1, 2, 3]"));
+    }
+```
+
+(`using System.Text.Json;` is already present in this test file.) The null/empty/whitespace tests stay unchanged (they still return `[]`).
+
+- [ ] **Step 2: Run the serializer tests to verify the two flipped tests fail**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~CheckResultsSerializerTests"`
+Expected: the two malformed tests FAIL (current code returns `[]` instead of throwing).
+
+- [ ] **Step 3: Remove the silent catch in CheckResultsSerializer**
+
+In `CheckResultsSerializer.cs`, replace the `Deserialize` method's try/catch so exceptions propagate:
+
+```csharp
+    public static List<CheckResult> Deserialize(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return [];
+
+        var results = JsonSerializer.Deserialize<CheckResults>(json, DeserializeOptions);
+
+        return results?.Checks ?? [];
+    }
+```
+
+- [ ] **Step 4: Run the serializer tests to verify all pass**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~CheckResultsSerializerTests"`
+Expected: PASS (malformed → throws; null/empty/whitespace → `[]`; valid → parsed).
+
+- [ ] **Step 5: Add a fail-open guard to AnalyticsRepository.ParseCheckResults**
+
+In `AnalyticsRepository.cs`, add `using System.Text.Json;` to the imports, then replace `ParseCheckResults`:
+
+```csharp
+    private List<CheckResult> ParseCheckResults(string? json)
+    {
+        try
+        {
+            return CheckResultsSerializer.Deserialize(json ?? string.Empty);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse check results JSON during analytics aggregation; treating as no checks");
+            return [];
+        }
+    }
+```
+
+- [ ] **Step 6: Add a fail-open guard to StopWordRecommendationService**
+
+In `StopWordRecommendationService.cs`, add `using System.Text.Json;` to the imports, then wrap the per-row `Deserialize` in the inner `foreach`:
+
+```csharp
+            foreach (var result in detectionResults)
+            {
+                List<CheckResult> checkResults;
+                try
+                {
+                    checkResults = CheckResultsSerializer.Deserialize(result.CheckResultsJson!);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse check results JSON during stop word analysis; skipping malformed record");
+                    continue;
+                }
+
+                var stopWordsCheck = checkResults.FirstOrDefault(c => c.CheckName == CheckName.StopWords);
+```
+
+(Leave the rest of the loop body unchanged.)
+
+- [ ] **Step 7: Log before the brightness fallback in VideoFrameExtractionService**
+
+In `VideoFrameExtractionService.cs`, change the bare `catch` at the end of `AnalyzeFrameBrightnessAsync`:
+
+```csharp
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Frame brightness analysis failed for {FramePath}; defaulting to 128.0", framePath);
+            return 128.0;
+        }
+```
+
+(No new `using` needed — this catches general ffmpeg/process/IO failures, not `JsonException`.)
+
+- [ ] **Step 8: Build and run the broader unit suite**
+
+Run: `dotnet build`
+Then: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~ContentDetection"`
+Expected: build succeeds; ContentDetection unit tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add TelegramGroupsAdmin.ContentDetection/Utilities/CheckResultsSerializer.cs \
+        TelegramGroupsAdmin/Repositories/AnalyticsRepository.cs \
+        TelegramGroupsAdmin.ContentDetection/ML/StopWordRecommendationService.cs \
+        TelegramGroupsAdmin.ContentDetection/Services/VideoFrameExtractionService.cs \
+        TelegramGroupsAdmin.UnitTests/ContentDetection/CheckResultsSerializerTests.cs
+git commit -F- <<'EOF'
+fix(detection): stop silently swallowing deserialization and brightness errors
+
+CheckResultsSerializer.Deserialize now propagates JsonException instead of
+returning an empty list, so corrupt CheckResultsJson is observable. The three
+DetectionResultsRepository callers already catch+log+skip; add the same
+fail-open guard to AnalyticsRepository and StopWordRecommendationService.
+VideoFrameExtractionService logs before defaulting to 128.0 brightness.
+
+Closes #495
+EOF
+```
+
+---
+
+## Task 4: #472 — QuartzSchedulingSyncService casts to concrete type for live re-sync
+
+**Files:**
+- Create: `TelegramGroupsAdmin.BackgroundJobs/Services/IScheduleResyncSignal.cs`
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Services/QuartzSchedulingSyncService.cs`
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Services/BackgroundJobConfigService.cs`
+- Modify: `TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs`
+- Test: `TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs` (new)
+
+Extract the wake-up semaphore (currently private inside the worker) into a shared singleton both services inject. This removes the concrete cast, the `_syncService` back-reference, and `SetSyncService`/`TriggerResync`.
+
+- [ ] **Step 1: Write the failing signal unit test**
+
+Create `TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs` (mirror the namespace/style of an existing test in that project; the type under test lives in `TelegramGroupsAdmin.BackgroundJobs.Services`):
+
+```csharp
+using TelegramGroupsAdmin.BackgroundJobs.Services;
+
+namespace TelegramGroupsAdmin.UnitTests.BackgroundJobs;
+
+[TestFixture]
+public class ScheduleResyncSignalTests
+{
+    [Test]
+    public async Task RequestResync_ThenWaitAsync_Completes()
+    {
+        var signal = new ScheduleResyncSignal();
+
+        signal.RequestResync();
+
+        await signal.WaitAsync(CancellationToken.None); // must complete without blocking
+        Assert.Pass();
+    }
+
+    [Test]
+    public async Task RequestResync_CalledTwiceBeforeWait_Coalesces()
+    {
+        var signal = new ScheduleResyncSignal();
+
+        signal.RequestResync();
+        signal.RequestResync(); // must not throw; collapses into one pending wake
+
+        await signal.WaitAsync(CancellationToken.None); // first wait completes
+
+        // A second wait should now block; assert it does NOT complete promptly.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        Assert.ThrowsAsync<OperationCanceledException>(async () => await signal.WaitAsync(cts.Token));
+    }
+}
+```
+
+This references `ScheduleResyncSignal`, so the test project needs the type to be visible. If `ScheduleResyncSignal` is `internal`, add `[assembly: InternalsVisibleTo("TelegramGroupsAdmin.UnitTests")]` to the BackgroundJobs project (check whether an `InternalsVisibleTo` for the unit test project already exists there before adding a duplicate); otherwise make the class `public`. Prefer matching whatever the BackgroundJobs project already does for test visibility.
+
+- [ ] **Step 2: Run the test to verify it fails to compile/run**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~ScheduleResyncSignalTests"`
+Expected: FAIL — `ScheduleResyncSignal` does not exist yet.
+
+- [ ] **Step 3: Create the signal abstraction and implementation**
+
+Create `TelegramGroupsAdmin.BackgroundJobs/Services/IScheduleResyncSignal.cs`:
+
+```csharp
+namespace TelegramGroupsAdmin.BackgroundJobs.Services;
+
+/// <summary>
+/// A one-slot wake-up signal decoupling the config writer (producer) from the
+/// schedule-sync worker (consumer). Replaces the former concrete back-reference
+/// (SetSyncService cast). Registered as a singleton so both sides share one instance.
+/// </summary>
+public interface IScheduleResyncSignal
+{
+    /// <summary>
+    /// Request a re-sync. Coalescing: multiple calls before the next WaitAsync
+    /// collapse into a single pending wake-up.
+    /// </summary>
+    void RequestResync();
+
+    /// <summary>Await the next re-sync request (or cancellation).</summary>
+    Task WaitAsync(CancellationToken cancellationToken);
+}
+
+internal sealed class ScheduleResyncSignal : IScheduleResyncSignal, IDisposable
+{
+    private readonly SemaphoreSlim _signal = new(0, 1);
+
+    public void RequestResync()
+    {
+        // maxCount = 1: Release when already signaled throws SemaphoreFullException,
+        // which means a resync is already pending — safe to ignore (coalescing).
+        try
+        {
+            _signal.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+        }
+    }
+
+    public Task WaitAsync(CancellationToken cancellationToken) => _signal.WaitAsync(cancellationToken);
+
+    public void Dispose() => _signal.Dispose();
+}
+```
+
+(If Step 1 required `public` instead of `InternalsVisibleTo`, make `ScheduleResyncSignal` `public sealed`.)
+
+- [ ] **Step 4: Run the signal test to verify it passes**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~ScheduleResyncSignalTests"`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Register the signal singleton**
+
+In `ServiceCollectionExtensions.cs`, add the registration immediately before the synchronizer registration (~line 41, just before `AddSingleton<IQuartzScheduleSynchronizer, ...>`):
+
+```csharp
+        // Shared wake-up signal decoupling the config writer from the sync worker (replaces the concrete cast).
+        services.AddSingleton<IScheduleResyncSignal, ScheduleResyncSignal>();
+```
+
+- [ ] **Step 6: Consume the signal in QuartzSchedulingSyncService**
+
+In `QuartzSchedulingSyncService.cs`:
+
+1. Add `IScheduleResyncSignal resyncSignal` to the primary constructor:
+```csharp
+public class QuartzSchedulingSyncService(
+    ILogger<QuartzSchedulingSyncService> logger,
+    ISchedulerFactory schedulerFactory,
+    IBackgroundJobConfigService jobConfigService,
+    IQuartzScheduleSynchronizer synchronizer,
+    IScheduleResyncSignal resyncSignal) : BackgroundService
+{
+```
+2. **Delete** the field `private readonly SemaphoreSlim _resyncSignal = new(0, 1);`.
+3. **Delete** the entire registration block (the comment + `if (jobConfigService is BackgroundJobConfigService configService) { configService.SetSyncService(this); ... }`).
+4. In the loop, change the wait from the deleted field to the injected signal:
+```csharp
+                    // Block until a re-sync is requested or cancellation is requested
+                    await resyncSignal.WaitAsync(stoppingToken);
+```
+5. **Delete** the `public void TriggerResync()` method in its entirety.
+6. **Delete** the `public override void Dispose()` override (it only disposed the removed semaphore; the base `BackgroundService.Dispose()` suffices and the signal singleton is disposed by the DI container).
+
+- [ ] **Step 7: Raise the signal from BackgroundJobConfigService**
+
+In `BackgroundJobConfigService.cs`:
+
+1. **Delete** the field `private volatile QuartzSchedulingSyncService? _syncService;`.
+2. **Delete** the `SetSyncService` method in its entirety.
+3. Add a readonly field alongside the others:
+```csharp
+    private readonly IScheduleResyncSignal _resyncSignal;
+```
+4. Add the constructor parameter and assignment:
+```csharp
+    public BackgroundJobConfigService(
+        IDbContextFactory<AppDbContext> contextFactory,
+        ILogger<BackgroundJobConfigService> logger,
+        IQuartzScheduleConverter scheduleConverter,
+        IScheduleResyncSignal resyncSignal)
+    {
+        _contextFactory = contextFactory;
+        _logger = logger;
+        _scheduleConverter = scheduleConverter;
+        _resyncSignal = resyncSignal;
+    }
+```
+5. Replace the resync trigger (in `UpdateJobConfigAsync`):
+```csharp
+            _logger.LogDebug("Triggering Quartz re-sync for {JobName} due to config change", jobName);
+            _resyncSignal.RequestResync();
+```
+
+- [ ] **Step 8: Build and fix any constructor call sites**
+
+Run: `dotnet build`
+Two constructors changed signature. Fix any compile errors:
+- `QuartzSchedulingSyncService` is resolved by DI (`AddHostedService`) — no manual construction in production. Check tests: `grep -rn "new QuartzSchedulingSyncService(\|new BackgroundJobConfigService(" --include=*.cs`. For any test that manually constructs either, pass a signal: a real `new ScheduleResyncSignal()` (for the config service, where you want to observe a request) or `Substitute.For<IScheduleResyncSignal>()`.
+Expected: build succeeds after fixes.
+
+- [ ] **Step 9: Run the BackgroundJobs-related unit tests**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~BackgroundJob"`
+Then also: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~Quartz"`
+Expected: PASS. (If a test asserted the old `TriggerResync`/`SetSyncService` wiring, update it to assert `_resyncSignal.Received(1).RequestResync()` via a substitute instead.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add TelegramGroupsAdmin.BackgroundJobs/Services/IScheduleResyncSignal.cs \
+        TelegramGroupsAdmin.BackgroundJobs/Services/QuartzSchedulingSyncService.cs \
+        TelegramGroupsAdmin.BackgroundJobs/Services/BackgroundJobConfigService.cs \
+        TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs \
+        TelegramGroupsAdmin.UnitTests/BackgroundJobs/ScheduleResyncSignalTests.cs
+git commit -F- <<'EOF'
+refactor(jobs): decouple live re-sync via a shared signal singleton
+
+Replace the concrete-type cast (QuartzSchedulingSyncService casting
+IBackgroundJobConfigService to BackgroundJobConfigService to call
+SetSyncService) with a shared IScheduleResyncSignal both services inject.
+Deletes the back-reference field, SetSyncService, and TriggerResync. The
+DI cycle stays broken; a missing registration now fails fast at startup
+instead of silently disabling re-sync.
+
+Closes #472
+EOF
+```
+
+---
+
+## Task 5: Final verification and PR
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build`
+Expected: succeeds with no new warnings.
+
+- [ ] **Step 2: Run the full unit suite**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests`
+Expected: PASS.
+
+- [ ] **Step 3: Run the affected integration tests (background, file output)**
+
+Run (in background per convention):
+`dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~TagDefinitionsRepository"`
+Expected: PASS, including the new decrement-race test run a few times.
+
+- [ ] **Step 4: Confirm the commit-per-issue history**
+
+Run: `git log --oneline develop..HEAD`
+Expected: the spec doc commit plus one fix/refactor commit per issue (#475, #473, #495, #472).
+
+- [ ] **Step 5: Push and open the PR to develop**
+
+```bash
+git push -u origin fix/correctness-bug-sweep
+gh pr create --base develop --title "fix: correctness bug sweep (#495, #475, #473, #472)" --body "$(cat <<'EOF'
+Closes #495
+Closes #475
+Closes #473
+Closes #472
+
+Four triaged correctness bugs, one commit each. Spec:
+docs/superpowers/specs/2026-05-30-correctness-bug-sweep-design.md
+
+- #475 audit: blacklist mutations pass target: null (was actor twice).
+- #473 db: DecrementUsageAsync is now an atomic ExecuteUpdateAsync with a
+  clamp-at-zero WHERE guard; drops the prior not-found/already-zero warnings.
+- #495 detection: CheckResultsSerializer.Deserialize propagates JsonException;
+  AnalyticsRepository and StopWordRecommendationService fail open per-row with
+  a log; VideoFrameExtractionService logs before the 128.0 fallback.
+- #472 jobs: shared IScheduleResyncSignal singleton replaces the concrete cast,
+  back-reference field, SetSyncService, and TriggerResync.
+
+#468 (/report Markdown parse) is intentionally excluded as a standalone PR.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #495 — serializer propagate (Task 3 S3), 3 repo callers unchanged (noted), 2 unguarded callers guarded (S5, S6), VideoFrame log (S7), tests flipped (S1). ✅
+- #475 — 4 call sites → `target: null` (Task 1 S3), 5 positive assertions (S1). ✅
+- #473 — atomic `ExecuteUpdateAsync` clamp (Task 2 S3), 20-concurrent + clamp tests (S1). ✅
+- #472 — shared signal, deletes cast/field/SetSyncService/TriggerResync, DI fail-fast (Task 4). ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. The only conditional ("if internal, add InternalsVisibleTo; else public") is a real, decidable branch with both outcomes specified.
+
+**Type consistency:** `IScheduleResyncSignal` / `ScheduleResyncSignal` / `RequestResync` / `WaitAsync` consistent across Tasks 4 definitions, registration, and both consumers. `Arg.Is<Actor?>(t => t == null)` consistent across the 5 assertions. `DecrementUsageAsync` signature unchanged (callers unaffected).

--- a/docs/superpowers/specs/2026-05-30-correctness-bug-sweep-design.md
+++ b/docs/superpowers/specs/2026-05-30-correctness-bug-sweep-design.md
@@ -1,0 +1,277 @@
+# Correctness bug sweep — #495, #475, #473, #472
+
+Closes #495
+Closes #475
+Closes #473
+Closes #472
+
+One branch (`fix/correctness-bug-sweep`) → one PR to `develop`, with a commit per issue plus doc commits.
+#468 (`/report` Markdown parse) is deliberately excluded and tracked as a standalone PR per the
+ParseMode-churn-standalone convention.
+
+---
+
+## #495 — Two silent catch blocks swallow errors
+
+### Problem
+
+Two `catch` blocks return fallback values with no logging, so the failure path is invisible.
+
+1. `CheckResultsSerializer.Deserialize` (`TelegramGroupsAdmin.ContentDetection/Utilities/CheckResultsSerializer.cs:57`)
+   has `catch { return []; }`. A deserialization failure returns an empty `List<CheckResult>`, so
+   callers see "no checks ran" instead of "the stored data was corrupt." This already bit us once
+   (migration `20260307182307_FixCheckResultsJsonCheckNameType` exists because malformed `CheckName`
+   enum data was being silently swallowed here).
+2. `VideoFrameExtractionService.AnalyzeFrameBrightnessAsync`
+   (`TelegramGroupsAdmin.ContentDetection/Services/VideoFrameExtractionService.cs:~628`) has
+   `catch { return 128.0; }`. Any ffmpeg/process/IO failure returns a hardcoded "normal brightness"
+   with no trace, silently degrading black-frame detection.
+
+### Key finding — the callers already expect a throw
+
+The three `DetectionResultsRepository` call sites (`:503`, `:549`, `:604`) **already** wrap
+`Deserialize` in `try { … } catch (Exception ex) { _logger.LogWarning(…); /* skip - fail open */ }`.
+They were written expecting `Deserialize` to throw on corrupt JSON — but the serializer's internal
+silent catch means those handlers **can never fire**. A corrupt row silently becomes "zero checks"
+instead of "skip the row and log it."
+
+Two other callers do NOT wrap it:
+- `AnalyticsRepository.ParseCheckResults` (`TelegramGroupsAdmin/Repositories/AnalyticsRepository.cs:252`)
+- `StopWordRecommendationService` (`TelegramGroupsAdmin.ContentDetection/ML/StopWordRecommendationService.cs:333`, inside a `foreach`)
+
+So the correct policy is: **the serializer should not decide the fallback** — it should propagate, and
+each caller fails open per-row with a log. This makes every corrupt row observable and lets the
+existing `DetectionResultsRepository` handlers do their job.
+
+### Approach
+
+**`CheckResultsSerializer.Deserialize`** — **remove the `try/catch` entirely** so any exception
+(`JsonException` and anything else unexpected) propagates to the caller. The empty/whitespace
+short-circuit (`return []`) and the `results?.Checks ?? []` null-coalesce both stay. The static class
+needs no logger because logging moves to the callers, which all have one.
+
+**Callers:**
+- `DetectionResultsRepository` (`:503`, `:549`, `:604`) — **no change**. Their existing
+  `catch (Exception ex) { _logger.LogWarning(…) }` now actually fires and skips the row.
+- `AnalyticsRepository.ParseCheckResults` — wrap the `Deserialize` call in a per-row
+  `try/catch (JsonException ex) { _logger.LogWarning(ex, …); return []; }`, matching the
+  fail-open pattern from `DetectionResultsRepository`.
+- `StopWordRecommendationService` (`:333`) — wrap the per-row `Deserialize` inside the `foreach`
+  with the same guard (`LogWarning` + `continue`).
+
+**`VideoFrameExtractionService.AnalyzeFrameBrightnessAsync`** — change `catch` to
+`catch (Exception ex)` and add
+`_logger.LogWarning(ex, "Frame brightness analysis failed for {FramePath}; defaulting to 128.0", framePath)`
+before `return 128.0;`. `_logger` is already injected and used throughout. The fallback is genuinely
+fine here (one frame degrading gracefully); we only need observability.
+
+### Tests
+
+`TelegramGroupsAdmin.UnitTests/ContentDetection/CheckResultsSerializerTests.cs`:
+- The two malformed-input tests that currently assert `Deserialize` returns `[]`
+  (`:55` `"{ this is not valid json !!!"`, `:65` `"[1, 2, 3]"`) flip to assert it throws `JsonException`.
+- The null/empty/whitespace tests (`:21`, `:31`, `:41`) stay green (still return `[]`).
+- All valid-JSON tests are unaffected.
+
+Add/confirm caller coverage where it already exists; a unit test asserting `AnalyticsRepository` /
+`StopWordRecommendationService` skip a malformed row without throwing is welcome if cheap, but the
+primary contract change is exercised by the serializer tests.
+
+### Acceptance criteria
+
+- [ ] Neither catch block is silent.
+- [ ] `Deserialize` propagates `JsonException` (bare catch removed / narrowed-and-rethrown).
+- [ ] `AnalyticsRepository` and `StopWordRecommendationService` fail open per-row with a `LogWarning`.
+- [ ] `VideoFrameExtractionService` logs before the `128.0` fallback.
+- [ ] `CheckResultsSerializerTests` updated: malformed JSON now asserts a throw; null/empty still `[]`.
+
+---
+
+## #475 — UsernameBlacklistService passes actor as both actor and target
+
+### Problem
+
+The four mutation methods on `UsernameBlacklistService` (`AddEntryAsync`, `DeleteEntryAsync`,
+`SetEnabledAsync`, `UpdateNotesAsync`) call
+`auditService.LogEventAsync(eventType, actor, actor, pattern, ct)` — binding the admin `actor` into
+the `target` slot. Blacklist mutations operate on configuration, not a discrete user, so `target`
+should be `null`. The duplicate actor produces misleading audit records and pollutes target-based
+filtering (`GetEventsForUserAsync` / `targetUserIdFilter`).
+
+`IAuditService.LogEventAsync` (`TelegramGroupsAdmin.Core/Services/IAuditService.cs:10`) already
+defaults `target` to `null`. The convention for config-style events is to omit it
+(`RotateBackupPassphraseJob.cs:182` uses `target: null`; `TelegramSessionManager` / `TelegramAuthService`
+omit it).
+
+### Approach
+
+In `TelegramGroupsAdmin.Telegram/Services/UsernameBlacklistService.cs`, change all four
+`LogEventAsync` calls (`:60-65`, `:75-77`, `:90`, `:100-104`) to pass `target: null` (named, for
+clarity) instead of the second positional `actor`.
+
+### Tests
+
+`TelegramGroupsAdmin.UnitTests/Telegram/Services/UsernameBlacklistServiceMutationTests.cs`:
+- The four positive-path `Received(1)` assertions that currently expect `actor, actor` change to
+  expect a `null` target (e.g. `Arg.Is<Actor?>(t => t == null)`).
+- The two `DidNotReceive` tests use `Arg.Any<Actor?>()` and need no change.
+
+### Acceptance criteria
+
+- [ ] All four `LogEventAsync` calls pass `null` for `target`.
+- [ ] The four positive-path assertions verify a `null` target.
+- [ ] `DidNotReceive` tests unchanged and green.
+- [ ] No other audit call sites touched.
+
+---
+
+## #473 — TagDefinitionsRepository.DecrementUsageAsync TOCTOU race
+
+### Problem
+
+`TagDefinitionsRepository.DecrementUsageAsync` (`:131-154`) reads the row, checks `UsageCount > 0` in
+memory, decrements the tracked entity, then `SaveChangesAsync`. Read and write are separate
+round-trips with no DB guard, so concurrent decrements lose updates (two callers read N, both write
+N-1). The sibling `IncrementUsageAsync` (`:116-129`) is already atomic. Sole caller is
+`UserTagsRepository.DeleteTagAsync` (`:74`); concurrent deletes of distinct `user_tags` rows sharing a
+tag name race here. This was the item explicitly deferred by the #407 sweep (PR #479).
+
+### Approach — atomic `ExecuteUpdateAsync` with the clamp in the WHERE clause
+
+```csharp
+await context.TagDefinitions
+    .Where(t => t.TagName == normalizedTag && t.UsageCount > 0)
+    .ExecuteUpdateAsync(s => s.SetProperty(t => t.UsageCount, t => t.UsageCount - 1), cancellationToken);
+```
+
+- Single atomic UPDATE; the `UsageCount > 0` filter makes the below-zero case a no-op, preserving
+  today's clamp-at-zero behavior. Drops the `FirstOrDefaultAsync` read.
+- **`ExecuteUpdateAsync` (LINQ), not raw SQL** — deliberately diverges from the #407 sweep's
+  `ExecuteSqlAsync(... ON CONFLICT ...)` because it keeps us on the Fluent/LINQ path
+  (`prefer-EF-Core-over-raw-SQL`) while still compiling to one atomic statement. `ExecuteUpdateAsync`
+  is already used elsewhere (`BanCelebrationGifRepository`, `TelegramUserRepository`).
+- **Logging change:** the existing "tag not found" / "already 0" warning logs are dropped — they ran
+  off the prior read, which no longer happens. These were low-value (a decrement on a missing/zero tag
+  is a benign no-op). Intentional; called out in the PR body.
+
+### Tests
+
+`TelegramGroupsAdmin.IntegrationTests/Repositories/TagDefinitionsRepositoryRaceTests.cs` — extend with
+a concurrent-decrement test mirroring the existing
+`IncrementUsageAsync_ConcurrentCalls_FinalCountEqualsCallCount` harness:
+1. Seed a tag with `usage_count = N` (e.g. 20).
+2. Fire 20 concurrent `DecrementUsageAsync` calls, each from its own DI scope / `DbContext`.
+3. Assert final `usage_count == 0` (i.e. `N - 20`, clamped).
+
+A second small test: decrementing a tag already at 0 leaves it at 0 (no negative).
+
+### Acceptance criteria
+
+- [ ] `DecrementUsageAsync` is a single atomic `ExecuteUpdateAsync` (no read-then-write).
+- [ ] Clamp-at-zero preserved; never goes negative.
+- [ ] 20-concurrent-decrement integration test asserts final count `== N - decrements` (clamped).
+- [ ] Existing `TagDefinitionsRepository` integration tests pass; dropped warning logs noted in PR.
+
+---
+
+## #472 — QuartzSchedulingSyncService casts to concrete type for live re-sync
+
+### Problem
+
+`QuartzSchedulingSyncService` registers its resync callback by downcasting the injected
+`IBackgroundJobConfigService` to the concrete `BackgroundJobConfigService`
+(`QuartzSchedulingSyncService.cs:42-46`), calling `SetSyncService(this)`. `SetSyncService` is not on the
+interface. The config service stores the back-reference in
+`volatile QuartzSchedulingSyncService? _syncService` and calls `_syncService?.TriggerResync()` on
+schedule/enabled changes (`BackgroundJobConfigService.cs:22`, `:50-53`, `:158-162`). If the resolved
+implementation is ever not exactly `BackgroundJobConfigService` (test double, decorator), the `is`
+match fails silently, `_syncService` stays null, and live re-sync stops with no error — until the next
+restart.
+
+### What we're actually solving
+
+Two long-lived singletons with an asymmetric relationship:
+- **Worker** `QuartzSchedulingSyncService` has a real data dependency on the config service (reads
+  config) → legitimate constructor injection.
+- **Config writer** `BackgroundJobConfigService` only needs to deliver a one-way "config changed —
+  re-sync now" **wake-up signal**.
+
+A constructor edge for that signal would create a DI cycle (A→B, B→A). The entire `SetSyncService` /
+cast / lazy-null-field / silent-`?.` apparatus exists only to smuggle that one signal across the cycle.
+
+### Approach — extract the wake-up signal into a shared singleton (no events)
+
+The synchronization primitive already exists *inside* the worker:
+`SemaphoreSlim _resyncSignal = new(0, 1)`; `TriggerResync()` does a guarded `Release()` (coalescing
+rapid edits via `catch (SemaphoreFullException)`); the loop does `_resyncSignal.WaitAsync()`. Lift it
+out into its own injectable object that both services depend on.
+
+```csharp
+public interface IScheduleResyncSignal
+{
+    void RequestResync();                     // producer — the config writer
+    Task WaitAsync(CancellationToken cancellationToken);  // consumer — the worker loop
+}
+
+internal sealed class ScheduleResyncSignal : IScheduleResyncSignal
+{
+    private readonly SemaphoreSlim _signal = new(0, 1);
+
+    public void RequestResync()
+    {
+        try { _signal.Release(); }            // same coalescing semantics as today's TriggerResync
+        catch (SemaphoreFullException) { }    // a resync is already pending
+    }
+
+    public Task WaitAsync(CancellationToken cancellationToken) => _signal.WaitAsync(cancellationToken);
+}
+```
+
+Events were considered and rejected: handler subscriptions rooted on long-lived singletons are a
+classic managed-memory leak and add invocation-ordering / thread-affinity concerns. A shared signal
+object has nothing to unsubscribe.
+
+**Wiring changes:**
+- DI: `services.AddSingleton<IScheduleResyncSignal, ScheduleResyncSignal>();` in
+  `TelegramGroupsAdmin.BackgroundJobs/Extensions/ServiceCollectionExtensions.cs` (near `:42-45`).
+- `BackgroundJobConfigService` — inject `IScheduleResyncSignal`; replace `_syncService?.TriggerResync()`
+  (`:161`) with `_resyncSignal.RequestResync()`. **Delete** the `_syncService` field (`:22`) and
+  `SetSyncService` (`:50-53`).
+- `QuartzSchedulingSyncService` — inject `IScheduleResyncSignal`; the loop awaits
+  `_resyncSignal.WaitAsync(stoppingToken)`. **Delete** the private `SemaphoreSlim`, the
+  `is BackgroundJobConfigService configService` block (`:42-46`), and the `TriggerResync()` method.
+
+### Why this satisfies the issue's ACs
+
+- No concrete cast, no abstraction leak.
+- Resync works purely through abstractions; swapping the implementation can't silently break it.
+- **Fail-fast, not silent:** if the signal isn't registered, DI throws at startup — the old silent
+  `?.` failure mode is structurally impossible.
+- DI cycle stays broken: both services depend on `IScheduleResyncSignal`; the signal depends on
+  nothing; the writer no longer references the worker at all (strictly fewer couplings than today).
+
+### Tests
+
+- A focused unit test for `ScheduleResyncSignal`: `RequestResync` then `WaitAsync` completes;
+  duplicate `RequestResync` before a wait coalesces (no throw, one wake).
+- Confirm existing background-job config / sync tests still pass with the new wiring. Any test that
+  reached `SetSyncService` or `TriggerResync` directly is updated to drive the signal instead.
+
+### Acceptance criteria
+
+- [ ] `QuartzSchedulingSyncService` no longer casts/`is`-checks `IBackgroundJobConfigService`.
+- [ ] Resync wiring is through abstractions only (the shared signal); swapping the implementation does
+      not silently disable live re-sync.
+- [ ] A missing signal registration is observable (DI fail-fast at startup), not a silent null path.
+- [ ] Live config-change re-sync still works end-to-end (schedule/enabled edit triggers a Quartz re-sync).
+- [ ] DI circular dependency remains broken (no startup resolution cycle).
+
+---
+
+## Out of scope
+
+- #468 (`/report` Markdown parse) — standalone PR per the ParseMode-churn-standalone convention.
+- Any other `ParseMode.Markdown` call sites — covered by #468, not here.
+- Repository methods with read-then-write shapes other than `DecrementUsageAsync` — fix as found in
+  their own issues.
+- Changing correct callers (`UserTagsRepository.DeleteTagAsync`, etc.) — only internals change.


### PR DESCRIPTION
Closes #495
Closes #475
Closes #473
Closes #472

Four triaged correctness bugs landing as one branch → one PR (commit per issue + spec/plan docs). #468 (/report Markdown parse) was deliberately left out as a standalone PR per the ParseMode-churn convention.

## What changed

### #495 — silent catch blocks swallowing errors
- `CheckResultsSerializer.Deserialize` now **propagates** `JsonException` instead of returning an empty list, so a corrupt `check_results_json` is observable rather than silently dropped.
- The three existing `DetectionResultsRepository` callers already caught+logged+skipped. Added the same per-row fail-open guard to the two that didn't: `AnalyticsRepository.ParseCheckResults` and `StopWordRecommendationService` (the warning includes the detection-result id, matching the repository guards).
- `VideoFrameExtractionService` now logs before defaulting to `128.0` brightness instead of swallowing the exception blind.

### #475 — username-blacklist audit attribution
All four blacklist mutation methods passed the admin **actor** into the **target** slot, producing misleading audit records and polluting target-based filtering. Blacklist mutations are config events with no distinct user target, so they now pass `target: null`, matching the ConfigService convention.

### #473 — `DecrementUsageAsync` TOCTOU race
Replaced read-check-decrement-save with a single guarded `ExecuteUpdateAsync(.Where(UsageCount > 0))`. The `WHERE` clause preserves clamp-at-zero atomically, eliminating lost updates under concurrent tag deletions.
- **Behavior note:** the prior "not found" / "already 0" warning logs are intentionally gone — with no prior read there's nothing to branch on. The clamp now lives in the `WHERE`.

### #472 — Quartz re-sync concrete-type cast / DI cycle
`QuartzSchedulingSyncService` cast `IBackgroundJobConfigService` down to the concrete `BackgroundJobConfigService` to call `SetSyncService`. Replaced with a shared `IScheduleResyncSignal` singleton both services inject (no events — avoids subscriber leaks on long-lived singletons). Deleted the back-reference field, `SetSyncService`, and `TriggerResync`. `RequestResync` coalesces via `try/catch (SemaphoreFullException)` (the `CurrentCount` check is a TOCTOU race under concurrent config saves). A missing registration now fails fast at startup instead of silently disabling live re-sync.

## Testing
- Full integration suite green: **681 passed, 0 failed** (~36s).
- Race coverage asserts against canonical golden rows: a seeded high-usage `power-user` tag for no-lost-update, the real zero-count `tester` tag for clamp-at-zero.
- New unit coverage for the resync signal incl. a concurrent-`RequestResync` regression test.

## Pre-PR multi-agent review (`/review-all` vs `develop`)
Verdict: **APPROVED (with suggestions)**. Security found the new SQL parameterized and the audit change integrity-positive; concurrency certified both the #472 coalescing pattern and the #473 atomic clamp; dead-code hunter found zero orphaned references from the #472 refactor.

The one actionable in-scope finding — neither #495 caller-catch branch was exercised by a test — is **fixed in this PR** (`test(content-detection): cover #495 caller-side JsonException catches`). Both tests corrupt one canonical row to a legacy V1-era shape (`CheckName` as a JSON string — valid JSONB but rejected by `System.Text.Json`, the exact shape migration `20260307182307` was written to repair), with the raw-SQL mutation documented in-test as the deliberate exception to the golden-builder-verb rule. Pre-existing out-of-scope nits (e.g. `StopWordRecommendationService` direct `DbContext` access) are already tracked by #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)