### PR TITLE
feat: unified permission model (single PermissionLevel ladder + chat scope)

### DIFF
--- a/TelegramGroupsAdmin.ComponentTests/Components/NotificationPreferencesCardTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/NotificationPreferencesCardTests.cs
@@ -327,10 +327,10 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
     [Test]
     public void HidesOwnerOnlyEvents_ForAdmin()
     {
-        // Arrange & Act - Admin level (1)
+        // Arrange & Act - Admin tier (non-owner)
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, PermissionLevel.GlobalAdmin));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Admin));
 
         // Assert - Should not show owner-only events
         // Note: The actual text in the checkbox is "Backup Failed (Owners)"

--- a/TelegramGroupsAdmin.ComponentTests/Components/NotificationPreferencesCardTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/NotificationPreferencesCardTests.cs
@@ -332,14 +332,31 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
             .Add(x => x.UserId, "test-user-id")
             .Add(x => x.UserPermissionLevel, PermissionLevel.Admin));
 
-        // Assert - Should not show owner-only events
-        // Note: The actual text in the checkbox is "Backup Failed (Owners)"
-        // but non-owners won't see this option at all
+        // Assert - owner-only events must not appear for non-owners
         cut.WaitForAssertion(() =>
         {
-            // The Backup Failed option should not be visible for non-owners
-            // We check that the general structure renders
             Assert.That(cut.Markup, Does.Contain("Notification Preferences"));
+            Assert.That(cut.Markup, Does.Not.Contain("Backup Failed"));
+            Assert.That(cut.Markup, Does.Not.Contain("Chat Health Warning"));
+            Assert.That(cut.Markup, Does.Not.Contain("Chat Admin Changed"));
+        });
+    }
+
+    [Test]
+    public void HidesOwnerOnlyEvents_ForGlobalAdmin()
+    {
+        // Arrange & Act - GlobalAdmin tier (also a non-owner)
+        var cut = Render<NotificationPreferencesCard>(p => p
+            .Add(x => x.UserId, "test-user-id")
+            .Add(x => x.UserPermissionLevel, PermissionLevel.GlobalAdmin));
+
+        // Assert - GlobalAdmin is below Owner so owner-only events must be hidden
+        cut.WaitForAssertion(() =>
+        {
+            Assert.That(cut.Markup, Does.Contain("Notification Preferences"));
+            Assert.That(cut.Markup, Does.Not.Contain("Backup Failed"));
+            Assert.That(cut.Markup, Does.Not.Contain("Chat Health Warning"));
+            Assert.That(cut.Markup, Does.Not.Contain("Chat Admin Changed"));
         });
     }
 

--- a/TelegramGroupsAdmin.ComponentTests/Components/NotificationPreferencesCardTests.cs
+++ b/TelegramGroupsAdmin.ComponentTests/Components/NotificationPreferencesCardTests.cs
@@ -95,7 +95,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2)); // Owner level
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner)); // Owner level
 
         // Assert
         Assert.That(cut.Markup, Is.Not.Empty);
@@ -107,7 +107,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -122,7 +122,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -141,7 +141,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -156,7 +156,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -171,7 +171,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -193,7 +193,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert - Telegram DM tab should be disabled when not linked
         cut.WaitForAssertion(() =>
@@ -221,7 +221,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert - Telegram DM tab should NOT be disabled when linked
         cut.WaitForAssertion(() =>
@@ -241,7 +241,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert - Email tab should be active (first enabled tab)
         cut.WaitForAssertion(() =>
@@ -262,7 +262,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -281,7 +281,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -296,7 +296,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -315,7 +315,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act - Owner level (2)
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 2));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.Owner));
 
         // Assert - Should show owner-only events
         cut.WaitForAssertion(() =>
@@ -330,7 +330,7 @@ public class NotificationPreferencesCardTests : NotificationPreferencesCardTestC
         // Arrange & Act - Admin level (1)
         var cut = Render<NotificationPreferencesCard>(p => p
             .Add(x => x.UserId, "test-user-id")
-            .Add(x => x.UserPermissionLevel, 1));
+            .Add(x => x.UserPermissionLevel, PermissionLevel.GlobalAdmin));
 
         // Assert - Should not show owner-only events
         // Note: The actual text in the checkbox is "Backup Failed (Owners)"

--- a/TelegramGroupsAdmin.Core/Models/PermissionLevel.cs
+++ b/TelegramGroupsAdmin.Core/Models/PermissionLevel.cs
@@ -7,6 +7,10 @@ namespace TelegramGroupsAdmin.Core.Models;
 /// </summary>
 public enum PermissionLevel
 {
+    /// <summary>No privileges — regular member. Computed at request time; never persisted.</summary>
+    [Display(Name = "Member")]
+    Member = -1,
+
     /// <summary>Chat-scoped moderation - Can view/moderate only chats they're Telegram admin in, read-only global settings, edit per-chat overrides</summary>
     [Display(Name = "Admin")]
     Admin = 0,

--- a/TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs
+++ b/TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace TelegramGroupsAdmin.Core.Models;
+
+/// <summary>
+/// Single source of truth for the human-readable name of a <see cref="PermissionLevel"/>.
+/// Replaces the previously duplicated GetPermissionName / GetRoleName mappers.
+/// </summary>
+public static class PermissionLevelExtensions
+{
+    public static string GetDisplayName(this PermissionLevel level)
+    {
+        var member = typeof(PermissionLevel).GetMember(level.ToString()).FirstOrDefault();
+        var display = member?.GetCustomAttribute<DisplayAttribute>();
+        return display?.Name ?? level.ToString();
+    }
+}

--- a/TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs
+++ b/TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs
@@ -11,9 +11,17 @@ public static class PermissionLevelExtensions
 {
     /// <summary>
     /// Returns the <see cref="DisplayAttribute.Name"/> for the given tier, falling back to the enum name.
+    /// An undefined value fails closed to <see cref="PermissionLevel.Member"/> (the no-privilege floor)
+    /// instead of emitting a raw int, so the role-claim path can never mint a privileged role for an
+    /// unrecognized tier (e.g. a future higher value).
     /// </summary>
     public static string GetDisplayName(this PermissionLevel level)
     {
+        if (!Enum.IsDefined(level))
+        {
+            level = PermissionLevel.Member;
+        }
+
         var member = typeof(PermissionLevel).GetMember(level.ToString()).FirstOrDefault();
         var display = member?.GetCustomAttribute<DisplayAttribute>();
         return display?.Name ?? level.ToString();

--- a/TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs
+++ b/TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs
@@ -9,6 +9,9 @@ namespace TelegramGroupsAdmin.Core.Models;
 /// </summary>
 public static class PermissionLevelExtensions
 {
+    /// <summary>
+    /// Returns the <see cref="DisplayAttribute.Name"/> for the given tier, falling back to the enum name.
+    /// </summary>
     public static string GetDisplayName(this PermissionLevel level)
     {
         var member = typeof(PermissionLevel).GetMember(level.ToString()).FirstOrDefault();

--- a/TelegramGroupsAdmin.Core/Repositories/IReportsRepository.cs
+++ b/TelegramGroupsAdmin.Core/Repositories/IReportsRepository.cs
@@ -45,6 +45,15 @@ public interface IReportsRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Get count of pending reports restricted to the given set of chats.
+    /// An empty collection applies no chat filter (counts all pending).
+    /// </summary>
+    Task<int> GetPendingCountAsync(
+        IReadOnlyCollection<long> chatIds,
+        ReportType? type = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Update report status and reviewer info.
     /// </summary>
     Task UpdateStatusAsync(

--- a/TelegramGroupsAdmin.Core/Repositories/IReportsRepository.cs
+++ b/TelegramGroupsAdmin.Core/Repositories/IReportsRepository.cs
@@ -37,16 +37,10 @@ public interface IReportsRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Get count of pending reports, optionally filtered by chat and/or type.
-    /// </summary>
-    Task<int> GetPendingCountAsync(
-        long? chatId = null,
-        ReportType? type = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Get count of pending reports restricted to the given set of chats.
-    /// An empty collection applies no chat filter (counts all pending).
+    /// Get count of pending reports scoped by the given chat-id collection.
+    /// A collection containing <c>0</c> (GlobalChatId) counts all pending reports (global / no filter).
+    /// An empty collection returns 0 rows.
+    /// A non-empty collection without <c>0</c> counts only reports in those specific chats.
     /// </summary>
     Task<int> GetPendingCountAsync(
         IReadOnlyCollection<long> chatIds,

--- a/TelegramGroupsAdmin.Core/Repositories/ReportsRepository.cs
+++ b/TelegramGroupsAdmin.Core/Repositories/ReportsRepository.cs
@@ -101,26 +101,6 @@ public class ReportsRepository : IReportsRepository
     }
 
     public async Task<int> GetPendingCountAsync(
-        long? chatId = null,
-        ReportType? type = null,
-        CancellationToken cancellationToken = default)
-    {
-        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-
-        var query = context.Reports
-            .AsNoTracking()
-            .Where(r => r.Status == (int)ReportStatus.Pending);
-
-        if (chatId.HasValue)
-            query = query.Where(r => r.ChatId == chatId.Value);
-
-        if (type.HasValue)
-            query = query.Where(r => r.Type == (short)type.Value);
-
-        return await query.CountAsync(cancellationToken);
-    }
-
-    public async Task<int> GetPendingCountAsync(
         IReadOnlyCollection<long> chatIds,
         ReportType? type = null,
         CancellationToken cancellationToken = default)
@@ -131,7 +111,8 @@ public class ReportsRepository : IReportsRepository
             .AsNoTracking()
             .Where(r => r.Status == (int)ReportStatus.Pending);
 
-        if (chatIds.Count > 0)
+        // Empty ⇒ no chats (0 rows). A collection containing 0 (GlobalChatId) ⇒ global / no filter.
+        if (!chatIds.Contains(0L)) // 0L == GlobalChatId
             query = query.Where(r => chatIds.Contains(r.ChatId));
 
         if (type.HasValue)

--- a/TelegramGroupsAdmin.Core/Repositories/ReportsRepository.cs
+++ b/TelegramGroupsAdmin.Core/Repositories/ReportsRepository.cs
@@ -120,6 +120,26 @@ public class ReportsRepository : IReportsRepository
         return await query.CountAsync(cancellationToken);
     }
 
+    public async Task<int> GetPendingCountAsync(
+        IReadOnlyCollection<long> chatIds,
+        ReportType? type = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Reports
+            .AsNoTracking()
+            .Where(r => r.Status == (int)ReportStatus.Pending);
+
+        if (chatIds.Count > 0)
+            query = query.Where(r => chatIds.Contains(r.ChatId));
+
+        if (type.HasValue)
+            query = query.Where(r => r.Type == (short)type.Value);
+
+        return await query.CountAsync(cancellationToken);
+    }
+
     public async Task UpdateStatusAsync(
         long reportId,
         ReportStatus status,

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/AnalyticsPage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/AnalyticsPage.cs
@@ -131,6 +131,30 @@ public class AnalyticsPage
     }
 
     /// <summary>
+    /// Locates the clickable tab element (button) for the given tab name.
+    /// MudBlazor renders each tab as a <c>.mud-tab</c> element; a disabled
+    /// <c>MudTabPanel</c> adds the <c>mud-disabled</c> class to this element.
+    /// </summary>
+    private ILocator TabButton(string tabName) =>
+        _page.GetByRole(AriaRole.Tab, new() { Name = tabName });
+
+    /// <summary>
+    /// Checks whether the tab with the given name is rendered but disabled.
+    /// MudBlazor marks a disabled <c>MudTabPanel</c> tab with the
+    /// <c>mud-disabled</c> CSS class on the <c>.mud-tab</c> element.
+    /// Web-first <see cref="Assertions.Expect(ILocator)"/> is used as the sync
+    /// point so the tab is rendered before its class list is inspected.
+    /// </summary>
+    public async Task<bool> IsTabDisabledAsync(string tabName)
+    {
+        var tab = TabButton(tabName);
+        await Expect(tab).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        var classAttr = await tab.GetAttributeAsync("class");
+        return classAttr is not null && classAttr.Split(' ').Contains("mud-disabled");
+    }
+
+    /// <summary>
     /// Checks if the Content Detection tab is active.
     /// </summary>
     public Task<bool> IsContentDetectionTabActiveAsync() => IsTabActiveAsync("Content Detection");

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/HomePage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/HomePage.cs
@@ -1,4 +1,5 @@
 using Microsoft.Playwright;
+using static Microsoft.Playwright.Assertions;
 
 namespace TelegramGroupsAdmin.E2ETests.PageObjects;
 
@@ -237,6 +238,64 @@ public class HomePage
     {
         var statItem = _page.Locator(".mud-grid-item").Filter(new() { HasText = "Pending Reports" });
         return await statItem.IsVisibleAsync();
+    }
+
+    // The greyed placeholder rendered in global cards for an Admin shows this
+    // caption (Home.razor) instead of a numeric value, plus a Lock icon.
+    private const string GlobalAdminOnlyCaption = "GlobalAdmin only";
+
+    // The Recent Activity panel placeholder caption shown for an Admin (Home.razor).
+    private const string ActivityPlaceholderCaption = "Requires GlobalAdmin to view";
+
+    /// <summary>
+    /// Returns true when the Total Messages card is rendered as the greyed
+    /// "GlobalAdmin only" placeholder (Lock icon + caption, no numeric value).
+    /// Uses a web-first assertion as the sync point before reading state so the
+    /// card has rendered. The data-leak guarantee is that an Admin sees the
+    /// caption and NO <c>.mud-typography-h5</c> numeric value.
+    /// </summary>
+    public async Task<bool> IsTotalMessagesGreyedPlaceholderAsync()
+    {
+        var card = _page.Locator(".mud-grid-item").Filter(new() { HasText = "Total Messages" });
+        await Expect(card).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        var hasPlaceholderCaption =
+            await card.GetByText(GlobalAdminOnlyCaption).CountAsync() > 0;
+        var hasNumericValue = await card.Locator(".mud-typography-h5").CountAsync() > 0;
+
+        return hasPlaceholderCaption && !hasNumericValue;
+    }
+
+    /// <summary>
+    /// Returns the numeric Total Messages value (the <c>.mud-typography-h5</c>
+    /// text) when the card shows real data, or <c>null</c> when the card is
+    /// rendered as the greyed "GlobalAdmin only" placeholder (no numeric value).
+    /// </summary>
+    public async Task<string?> GetTotalMessagesValueOrNullAsync()
+    {
+        var card = _page.Locator(".mud-grid-item").Filter(new() { HasText = "Total Messages" });
+        await Expect(card).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        var value = card.Locator(".mud-typography-h5");
+        if (await value.CountAsync() == 0)
+        {
+            return null;
+        }
+
+        return await value.TextContentAsync();
+    }
+
+    /// <summary>
+    /// Returns true when the Recent Activity panel is rendered as the greyed
+    /// placeholder ("Requires GlobalAdmin to view") rather than a real activity
+    /// list. Web-first assertion is the sync point before reading state.
+    /// </summary>
+    public async Task<bool> IsActivityFeedPlaceholderAsync()
+    {
+        var panel = _page.Locator(".mud-paper").Filter(new() { HasText = "Recent Activity" });
+        await Expect(panel).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+        return await panel.GetByText(ActivityPlaceholderCaption).CountAsync() > 0;
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/HomePage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/HomePage.cs
@@ -212,10 +212,31 @@ public class HomePage
 
     /// <summary>
     /// Checks if the Recent Activity section is visible.
+    /// Only GlobalAdmin/Owner see this panel (gated on _canSeeGlobalStats).
     /// </summary>
     public async Task<bool> IsActivityFeedVisibleAsync()
     {
         return await _page.Locator("text=Recent Activity").IsVisibleAsync();
+    }
+
+    /// <summary>
+    /// Checks if the Total Messages stat card is visible.
+    /// Only GlobalAdmin/Owner see this global stat card (gated on _canSeeGlobalStats).
+    /// </summary>
+    public async Task<bool> IsTotalMessagesCardVisibleAsync()
+    {
+        var statItem = _page.Locator(".mud-grid-item").Filter(new() { HasText = "Total Messages" });
+        return await statItem.IsVisibleAsync();
+    }
+
+    /// <summary>
+    /// Checks if the Pending Reports stat card is visible.
+    /// This scoped card is shown for all permission tiers (Admin, GlobalAdmin, Owner).
+    /// </summary>
+    public async Task<bool> IsPendingReportsCardVisibleAsync()
+    {
+        var statItem = _page.Locator(".mud-grid-item").Filter(new() { HasText = "Pending Reports" });
+        return await statItem.IsVisibleAsync();
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin.E2ETests/Tests/Analytics/AnalyticsTests.cs
+++ b/TelegramGroupsAdmin.E2ETests/Tests/Analytics/AnalyticsTests.cs
@@ -90,7 +90,7 @@ public class AnalyticsTests : SharedAuthenticatedTestBase
     }
 
     [Test]
-    public async Task Analytics_Admin_SeesOnlyMessageTrends()
+    public async Task Analytics_Admin_SeesAllTabs_GlobalOnesDisabled()
     {
         // Arrange - login as Admin (chat-scoped permission)
         await LoginAsAdminAsync();
@@ -98,19 +98,41 @@ public class AnalyticsTests : SharedAuthenticatedTestBase
         // Act - navigate to analytics page
         await _analyticsPage.NavigateAsync();
 
-        // Assert - the three global/leaky tabs are hidden (#509); only Message Trends renders.
+        // Assert - interim cross-chat-leak UX: all four tab shells render, but the
+        // three global tabs are DISABLED/greyed (mud-disabled) so an Admin cannot
+        // open them and no global data component mounts. Message Trends is the only
+        // enabled tab and is forced active for Admin.
         var tabNames = await _analyticsPage.GetTabNamesAsync();
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(tabNames, Has.Count.EqualTo(4),
+                "Admin should still see all four tab shells");
+            Assert.That(tabNames, Does.Contain("Content Detection"),
+                "Admin should see the Content Detection tab shell");
             Assert.That(tabNames, Does.Contain("Message Trends"),
                 "Admin should see the Message Trends tab");
-            Assert.That(tabNames, Does.Not.Contain("Content Detection"),
-                "Admin should NOT see the Content Detection tab");
-            Assert.That(tabNames, Does.Not.Contain("Performance"),
-                "Admin should NOT see the Performance tab");
-            Assert.That(tabNames, Does.Not.Contain("Welcome Analytics"),
-                "Admin should NOT see the Welcome Analytics tab");
+            Assert.That(tabNames, Does.Contain("Performance"),
+                "Admin should see the Performance tab shell");
+            Assert.That(tabNames, Does.Contain("Welcome Analytics"),
+                "Admin should see the Welcome Analytics tab shell");
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            // The three global tabs must be disabled (mud-disabled on the .mud-tab element).
+            Assert.That(await _analyticsPage.IsTabDisabledAsync("Content Detection"), Is.True,
+                "Admin: Content Detection tab should be disabled/greyed");
+            Assert.That(await _analyticsPage.IsTabDisabledAsync("Performance"), Is.True,
+                "Admin: Performance tab should be disabled/greyed");
+            Assert.That(await _analyticsPage.IsTabDisabledAsync("Welcome Analytics"), Is.True,
+                "Admin: Welcome Analytics tab should be disabled/greyed");
+
+            // Message Trends stays enabled and is the active tab for Admin.
+            Assert.That(await _analyticsPage.IsTabDisabledAsync("Message Trends"), Is.False,
+                "Admin: Message Trends tab should remain enabled");
+            Assert.That(await _analyticsPage.IsMessageTrendsTabActiveAsync(), Is.True,
+                "Admin: Message Trends should be the active tab");
         }
     }
 
@@ -123,7 +145,7 @@ public class AnalyticsTests : SharedAuthenticatedTestBase
         // Act - navigate to analytics page
         await _analyticsPage.NavigateAsync();
 
-        // Assert - GlobalAdmin sees all four tabs
+        // Assert - GlobalAdmin sees all four tabs, all ENABLED (none greyed/disabled).
         var tabNames = await _analyticsPage.GetTabNamesAsync();
 
         using (Assert.EnterMultipleScope())
@@ -138,6 +160,18 @@ public class AnalyticsTests : SharedAuthenticatedTestBase
                 "GlobalAdmin should see the Performance tab");
             Assert.That(tabNames, Does.Contain("Welcome Analytics"),
                 "GlobalAdmin should see the Welcome Analytics tab");
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await _analyticsPage.IsTabDisabledAsync("Content Detection"), Is.False,
+                "GlobalAdmin: Content Detection tab should be enabled");
+            Assert.That(await _analyticsPage.IsTabDisabledAsync("Message Trends"), Is.False,
+                "GlobalAdmin: Message Trends tab should be enabled");
+            Assert.That(await _analyticsPage.IsTabDisabledAsync("Performance"), Is.False,
+                "GlobalAdmin: Performance tab should be enabled");
+            Assert.That(await _analyticsPage.IsTabDisabledAsync("Welcome Analytics"), Is.False,
+                "GlobalAdmin: Welcome Analytics tab should be enabled");
         }
     }
 

--- a/TelegramGroupsAdmin.E2ETests/Tests/Analytics/AnalyticsTests.cs
+++ b/TelegramGroupsAdmin.E2ETests/Tests/Analytics/AnalyticsTests.cs
@@ -90,6 +90,58 @@ public class AnalyticsTests : SharedAuthenticatedTestBase
     }
 
     [Test]
+    public async Task Analytics_Admin_SeesOnlyMessageTrends()
+    {
+        // Arrange - login as Admin (chat-scoped permission)
+        await LoginAsAdminAsync();
+
+        // Act - navigate to analytics page
+        await _analyticsPage.NavigateAsync();
+
+        // Assert - the three global/leaky tabs are hidden (#509); only Message Trends renders.
+        var tabNames = await _analyticsPage.GetTabNamesAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tabNames, Does.Contain("Message Trends"),
+                "Admin should see the Message Trends tab");
+            Assert.That(tabNames, Does.Not.Contain("Content Detection"),
+                "Admin should NOT see the Content Detection tab");
+            Assert.That(tabNames, Does.Not.Contain("Performance"),
+                "Admin should NOT see the Performance tab");
+            Assert.That(tabNames, Does.Not.Contain("Welcome Analytics"),
+                "Admin should NOT see the Welcome Analytics tab");
+        }
+    }
+
+    [Test]
+    public async Task Analytics_GlobalAdmin_SeesAllFourTabs()
+    {
+        // Arrange - login as GlobalAdmin
+        await LoginAsGlobalAdminAsync();
+
+        // Act - navigate to analytics page
+        await _analyticsPage.NavigateAsync();
+
+        // Assert - GlobalAdmin sees all four tabs
+        var tabNames = await _analyticsPage.GetTabNamesAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tabNames, Has.Count.EqualTo(4),
+                "GlobalAdmin should see exactly four tabs");
+            Assert.That(tabNames, Does.Contain("Content Detection"),
+                "GlobalAdmin should see the Content Detection tab");
+            Assert.That(tabNames, Does.Contain("Message Trends"),
+                "GlobalAdmin should see the Message Trends tab");
+            Assert.That(tabNames, Does.Contain("Performance"),
+                "GlobalAdmin should see the Performance tab");
+            Assert.That(tabNames, Does.Contain("Welcome Analytics"),
+                "GlobalAdmin should see the Welcome Analytics tab");
+        }
+    }
+
+    [Test]
     public async Task Analytics_ContentDetectionTab_IsDefaultActive()
     {
         // Arrange - login as Owner

--- a/TelegramGroupsAdmin.E2ETests/Tests/Dashboard/DashboardTests.cs
+++ b/TelegramGroupsAdmin.E2ETests/Tests/Dashboard/DashboardTests.cs
@@ -185,14 +185,16 @@ public class DashboardTests : AuthenticatedTestBase
         await _homePage.NavigateAsync();
         await _homePage.WaitForLoadAsync();
 
-        // Assert - Admin sees the scoped Overview (scoped cards present), not the global stats.
-        // Cross-chat-leak fix (#510): Admin no longer sees global message stats.
+        // Assert - Admin sees the scoped Overview cards AND the global card shells,
+        // but the global cards are greyed placeholders with no data (interim UX).
         using (Assert.EnterMultipleScope())
         {
             Assert.That(await _homePage.IsPendingReportsCardVisibleAsync(), Is.True,
                 "Admin should see the scoped Pending Reports card");
-            Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.False,
-                "Admin should NOT see the global Total Messages card");
+            Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.True,
+                "Admin should see the global Total Messages card shell");
+            Assert.That(await _homePage.IsTotalMessagesGreyedPlaceholderAsync(), Is.True,
+                "Admin's Total Messages card should be the greyed 'GlobalAdmin only' placeholder");
         }
     }
 
@@ -212,7 +214,7 @@ public class DashboardTests : AuthenticatedTestBase
     }
 
     [Test]
-    public async Task Dashboard_Admin_HidesGlobalWidgets_ShowsScopedCards()
+    public async Task Dashboard_Admin_GlobalWidgetsGreyed_ScopedCardsReal()
     {
         // Arrange - login as Admin (chat-scoped permission)
         await LoginAsAdminAsync();
@@ -221,15 +223,33 @@ public class DashboardTests : AuthenticatedTestBase
         await _homePage.NavigateAsync();
         await _homePage.WaitForLoadAsync();
 
-        // Assert - Admin sees scoped cards but NOT global widgets (#510 cross-chat-leak fix).
+        // Assert - interim cross-chat-leak UX: the global card/panel shells render
+        // for an Admin but are greyed placeholders with NO data, while scoped cards
+        // (Pending Reports) show real values. The data-leak guarantee is that the
+        // Admin sees the "GlobalAdmin only" placeholder and no numeric global value.
         using (Assert.EnterMultipleScope())
         {
+            // Global Total Messages card: shell present but greyed placeholder, no numeric value.
+            Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.True,
+                "Admin should see the global Total Messages card shell");
+            Assert.That(await _homePage.IsTotalMessagesGreyedPlaceholderAsync(), Is.True,
+                "Admin's Total Messages card should be the greyed 'GlobalAdmin only' placeholder");
+            Assert.That(await _homePage.GetTotalMessagesValueOrNullAsync(), Is.Null,
+                "Admin's Total Messages card must NOT show a numeric value");
+
+            // Global Recent Activity panel: present but the greyed placeholder, not a real list.
+            Assert.That(await _homePage.IsActivityFeedVisibleAsync(), Is.True,
+                "Admin should see the Recent Activity panel shell");
+            Assert.That(await _homePage.IsActivityFeedPlaceholderAsync(), Is.True,
+                "Admin's Recent Activity panel should show the GlobalAdmin placeholder, not a real list");
+            Assert.That(await _homePage.GetActivityFeedItemCountAsync(), Is.EqualTo(0),
+                "Admin's Recent Activity panel must NOT render real activity items");
+
+            // Scoped card shows a real value for Admin.
             Assert.That(await _homePage.IsPendingReportsCardVisibleAsync(), Is.True,
                 "Admin should see the scoped Pending Reports card");
-            Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.False,
-                "Admin should NOT see the global Total Messages card");
-            Assert.That(await _homePage.IsActivityFeedVisibleAsync(), Is.False,
-                "Admin should NOT see the global Recent Activity panel");
+            Assert.That(await _homePage.GetPendingReportsCountAsync(), Is.Not.Null.And.Not.Empty,
+                "Admin's scoped Pending Reports card should show a real value");
         }
     }
 
@@ -243,13 +263,22 @@ public class DashboardTests : AuthenticatedTestBase
         await _homePage.NavigateAsync();
         await _homePage.WaitForLoadAsync();
 
-        // Assert - GlobalAdmin sees the global widgets (full dashboard).
+        // Assert - GlobalAdmin sees the global widgets with real data (full dashboard):
+        // Total Messages shows a real numeric value (not the placeholder) and Recent
+        // Activity is the real panel (not the placeholder).
         using (Assert.EnterMultipleScope())
         {
             Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.True,
                 "GlobalAdmin should see the global Total Messages card");
+            Assert.That(await _homePage.IsTotalMessagesGreyedPlaceholderAsync(), Is.False,
+                "GlobalAdmin's Total Messages card should NOT be the greyed placeholder");
+            Assert.That(await _homePage.GetTotalMessagesValueOrNullAsync(), Is.Not.Null.And.Not.Empty,
+                "GlobalAdmin's Total Messages card should show a real numeric value");
+
             Assert.That(await _homePage.IsActivityFeedVisibleAsync(), Is.True,
                 "GlobalAdmin should see the global Recent Activity panel");
+            Assert.That(await _homePage.IsActivityFeedPlaceholderAsync(), Is.False,
+                "GlobalAdmin's Recent Activity panel should be the real panel, not the placeholder");
         }
     }
 

--- a/TelegramGroupsAdmin.E2ETests/Tests/Dashboard/DashboardTests.cs
+++ b/TelegramGroupsAdmin.E2ETests/Tests/Dashboard/DashboardTests.cs
@@ -185,9 +185,15 @@ public class DashboardTests : AuthenticatedTestBase
         await _homePage.NavigateAsync();
         await _homePage.WaitForLoadAsync();
 
-        // Assert - Admin can view dashboard
-        Assert.That(await _homePage.AreStatsVisibleAsync(), Is.True,
-            "Admin should be able to view dashboard stats");
+        // Assert - Admin sees the scoped Overview (scoped cards present), not the global stats.
+        // Cross-chat-leak fix (#510): Admin no longer sees global message stats.
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await _homePage.IsPendingReportsCardVisibleAsync(), Is.True,
+                "Admin should see the scoped Pending Reports card");
+            Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.False,
+                "Admin should NOT see the global Total Messages card");
+        }
     }
 
     [Test]
@@ -203,6 +209,48 @@ public class DashboardTests : AuthenticatedTestBase
         // Assert - GlobalAdmin can view dashboard
         Assert.That(await _homePage.AreStatsVisibleAsync(), Is.True,
             "GlobalAdmin should be able to view dashboard stats");
+    }
+
+    [Test]
+    public async Task Dashboard_Admin_HidesGlobalWidgets_ShowsScopedCards()
+    {
+        // Arrange - login as Admin (chat-scoped permission)
+        await LoginAsAdminAsync();
+
+        // Act
+        await _homePage.NavigateAsync();
+        await _homePage.WaitForLoadAsync();
+
+        // Assert - Admin sees scoped cards but NOT global widgets (#510 cross-chat-leak fix).
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await _homePage.IsPendingReportsCardVisibleAsync(), Is.True,
+                "Admin should see the scoped Pending Reports card");
+            Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.False,
+                "Admin should NOT see the global Total Messages card");
+            Assert.That(await _homePage.IsActivityFeedVisibleAsync(), Is.False,
+                "Admin should NOT see the global Recent Activity panel");
+        }
+    }
+
+    [Test]
+    public async Task Dashboard_GlobalAdmin_ShowsAllWidgets()
+    {
+        // Arrange - login as GlobalAdmin
+        await LoginAsGlobalAdminAsync();
+
+        // Act
+        await _homePage.NavigateAsync();
+        await _homePage.WaitForLoadAsync();
+
+        // Assert - GlobalAdmin sees the global widgets (full dashboard).
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.True,
+                "GlobalAdmin should see the global Total Messages card");
+            Assert.That(await _homePage.IsActivityFeedVisibleAsync(), Is.True,
+                "GlobalAdmin should see the global Recent Activity panel");
+        }
     }
 
     #region Enhanced Dashboard Tests (#173)

--- a/TelegramGroupsAdmin.IntegrationTests/ContentDetection/Repositories/ReportsRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/ContentDetection/Repositories/ReportsRepositoryTests.cs
@@ -366,6 +366,40 @@ public class ReportsRepositoryTests
         Assert.That(count, Is.EqualTo(2));
     }
 
+    [Test]
+    public async Task GetPendingCountAsync_WithChatIdCollection_CountsOnlyThoseChats()
+    {
+        // Arrange — pending reports across three chats
+        const long chatA = -1001000000001;
+        const long chatB = -1001000000002;
+        const long chatC = -1001000000003;
+
+        await _repository!.InsertContentReportAsync(CreateTestReport(messageId: 1, chatId: chatA));
+        await _repository.InsertContentReportAsync(CreateTestReport(messageId: 2, chatId: chatA));
+        await _repository.InsertContentReportAsync(CreateTestReport(messageId: 3, chatId: chatB));
+        await _repository.InsertContentReportAsync(CreateTestReport(messageId: 4, chatId: chatC)); // excluded
+
+        // Act — count pending only in A and B
+        var count = await _repository.GetPendingCountAsync(new[] { chatA, chatB });
+
+        // Assert — 2 in A + 1 in B, C excluded
+        Assert.That(count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task GetPendingCountAsync_WithEmptyChatIdCollection_CountsAllPending()
+    {
+        // Arrange
+        await _repository!.InsertContentReportAsync(CreateTestReport(messageId: 10, chatId: -1001000000010));
+        await _repository.InsertContentReportAsync(CreateTestReport(messageId: 11, chatId: -1001000000011));
+
+        // Act — empty collection means "no chat filter" (count all pending)
+        var count = await _repository.GetPendingCountAsync(Array.Empty<long>());
+
+        // Assert
+        Assert.That(count, Is.EqualTo(2));
+    }
+
     #endregion
 
     #region Test Helpers

--- a/TelegramGroupsAdmin.IntegrationTests/ContentDetection/Repositories/ReportsRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/ContentDetection/Repositories/ReportsRepositoryTests.cs
@@ -350,19 +350,19 @@ public class ReportsRepositoryTests
     }
 
     [Test]
-    public async Task GetPendingCountAsync_ReturnsCorrectCount()
+    public async Task GetPendingCountAsync_WithGlobalChatId_CountsAllPending()
     {
-        // Arrange
+        // Arrange — reports in different chats
         await _repository!.InsertContentReportAsync(CreateTestReport(messageId: 1));
         await _repository.InsertContentReportAsync(CreateTestReport(messageId: 2));
         var reviewedId = await _repository.InsertContentReportAsync(CreateTestReport(messageId: 3));
 
         await _repository.UpdateStatusAsync(reviewedId, ReportStatus.Reviewed, "admin", "Spam");
 
-        // Act
-        var count = await _repository.GetPendingCountAsync();
+        // Act — [0] (GlobalChatId) means global / no filter
+        var count = await _repository.GetPendingCountAsync(new long[] { 0L });
 
-        // Assert
+        // Assert — 2 pending, 1 reviewed (excluded)
         Assert.That(count, Is.EqualTo(2));
     }
 
@@ -387,17 +387,17 @@ public class ReportsRepositoryTests
     }
 
     [Test]
-    public async Task GetPendingCountAsync_WithEmptyChatIdCollection_CountsAllPending()
+    public async Task GetPendingCountAsync_WithEmptyChatIdCollection_ReturnsZero()
     {
-        // Arrange
+        // Arrange — seed some pending reports
         await _repository!.InsertContentReportAsync(CreateTestReport(messageId: 10, chatId: -1001000000010));
         await _repository.InsertContentReportAsync(CreateTestReport(messageId: 11, chatId: -1001000000011));
 
-        // Act — empty collection means "no chat filter" (count all pending)
+        // Act — empty collection ⇒ no accessible chats ⇒ 0 rows (not global)
         var count = await _repository.GetPendingCountAsync(Array.Empty<long>());
 
         // Assert
-        Assert.That(count, Is.EqualTo(2));
+        Assert.That(count, Is.EqualTo(0));
     }
 
     #endregion

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
@@ -166,11 +166,26 @@ public class TelegramUserRepositoryTests
             await historyRepo.InsertAsync(userId, "historic_handle", "Present", "User");
         }
 
-        // Tab counts filtered by the old name must include the user in the active count
+        // GlobalChatId (0) ⇒ global / no filter; tab counts should include the seeded user in the active count.
         var counts = await _repository!.GetUserTabCountsAsync(
-            chatIds: null, searchText: "historic_handle");
+            chatIds: new List<long> { 0L }, searchText: "historic_handle");
 
         Assert.That(counts.ActiveCount, Is.GreaterThanOrEqualTo(1));
+    }
+
+    [Test]
+    public async Task GetUserTabCountsAsync_WithEmptyChatIds_ReturnsZeroCounts()
+    {
+        // Empty list ⇒ no accessible chats ⇒ nothing visible (0 rows, not global).
+        var counts = await _repository!.GetUserTabCountsAsync(
+            chatIds: new List<long>(), searchText: null);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(counts.ActiveCount, Is.EqualTo(0));
+            Assert.That(counts.TrustedCount, Is.EqualTo(0));
+            Assert.That(counts.BannedCount, Is.EqualTo(0));
+        }
     }
 
     [Test]

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/TelegramUserRepositoryTests.cs
@@ -6,6 +6,7 @@ using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Data;
 using TelegramGroupsAdmin.Telegram.Models;
 using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.IntegrationTests.TestData;
 using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
 using UiModels = TelegramGroupsAdmin.Telegram.Models;
 
@@ -121,7 +122,7 @@ public class TelegramUserRepositoryTests
         // Search by old username — should find the user via username_history join
         var (items, totalCount) = await _repository!.GetPagedUsersAsync(
             UiModels.UserListFilter.Active, skip: 0, take: 10,
-            searchText: "old_name", chatIds: null,
+            searchText: "old_name", chatIds: new List<long> { 0L }, // GlobalChatId ⇒ no chat filter
             sortLabel: null, sortDescending: false);
 
         Assert.That(totalCount, Is.EqualTo(1));
@@ -145,7 +146,7 @@ public class TelegramUserRepositoryTests
         // Search by old first name — should find the user via username_history join
         var (items, totalCount) = await _repository!.GetPagedUsersAsync(
             UiModels.UserListFilter.Active, skip: 0, take: 10,
-            searchText: "OldFirst", chatIds: null,
+            searchText: "OldFirst", chatIds: new List<long> { 0L }, // GlobalChatId ⇒ no chat filter
             sortLabel: null, sortDescending: false);
 
         Assert.That(totalCount, Is.EqualTo(1));
@@ -185,6 +186,65 @@ public class TelegramUserRepositoryTests
             Assert.That(counts.ActiveCount, Is.EqualTo(0));
             Assert.That(counts.TrustedCount, Is.EqualTo(0));
             Assert.That(counts.BannedCount, Is.EqualTo(0));
+        }
+    }
+
+    [Test]
+    public async Task GetPagedUsersAsync_WithEmptyChatIds_ReturnsNothing()
+    {
+        // Empty list ⇒ no accessible chats ⇒ 0 items (not global).
+        var (items, totalCount) = await _repository!.GetPagedUsersAsync(
+            UiModels.UserListFilter.Active, skip: 0, take: 50,
+            searchText: null, chatIds: new List<long>(),
+            sortLabel: null, sortDescending: false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(totalCount, Is.EqualTo(0));
+            Assert.That(items, Is.Empty);
+        }
+    }
+
+    [Test]
+    public async Task GetPagedUsersAsync_WithGlobalChatId_ReturnsRows()
+    {
+        // [0] (GlobalChatId) ⇒ global / no filter ⇒ canonical active users are returned.
+        var (items, totalCount) = await _repository!.GetPagedUsersAsync(
+            UiModels.UserListFilter.Active, skip: 0, take: 50,
+            searchText: null, chatIds: new List<long> { 0L },
+            sortLabel: null, sortDescending: false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(totalCount, Is.GreaterThan(0));
+            Assert.That(items, Is.Not.Empty);
+        }
+    }
+
+    [Test]
+    public async Task GetPagedUsersAsync_WithSpecificChatId_ReturnsOnlyThatChatsUsers()
+    {
+        // Scope to MainChat: the prolific canonical ham author (messages in MainChat) is included.
+        var (mainChatItems, mainChatTotal) = await _repository!.GetPagedUsersAsync(
+            UiModels.UserListFilter.Active, skip: 0, take: 1000,
+            searchText: null, chatIds: new List<long> { GoldenDatasetConstants.Chats.MainChatId },
+            sortLabel: null, sortDescending: false);
+
+        // Scope to a chat with no messages from anyone ⇒ no users.
+        const long emptyChatId = -100099999999999L;
+        var (emptyChatItems, emptyChatTotal) = await _repository.GetPagedUsersAsync(
+            UiModels.UserListFilter.Active, skip: 0, take: 1000,
+            searchText: null, chatIds: new List<long> { emptyChatId },
+            sortLabel: null, sortDescending: false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(mainChatTotal, Is.GreaterThan(0));
+            Assert.That(mainChatItems.Any(u => u.TelegramUserId == TopHamAuthorId), Is.True,
+                "Top MainChat ham author should be visible when scoped to MainChat");
+            Assert.That(emptyChatTotal, Is.EqualTo(0),
+                "A chat with no messages yields no scoped users");
+            Assert.That(emptyChatItems, Is.Empty);
         }
     }
 
@@ -240,7 +300,7 @@ public class TelegramUserRepositoryTests
 
         var (items, totalCount) = await _repository!.GetPagedUsersAsync(
             UiModels.UserListFilter.Active, skip: 0, take: 10,
-            searchText: "unique_old_handle", chatIds: null,
+            searchText: "unique_old_handle", chatIds: new List<long> { 0L }, // GlobalChatId ⇒ no chat filter
             sortLabel: null, sortDescending: false);
 
         Assert.Multiple(() =>

--- a/TelegramGroupsAdmin.Telegram/Constants/CommandConstants.cs
+++ b/TelegramGroupsAdmin.Telegram/Constants/CommandConstants.cs
@@ -1,3 +1,5 @@
+using TelegramGroupsAdmin.Core.Models;
+
 namespace TelegramGroupsAdmin.Telegram.Constants;
 
 /// <summary>
@@ -15,13 +17,9 @@ public static class CommandConstants
     /// </summary>
     public static readonly TimeSpan DefaultMuteDuration = TimeSpan.FromMinutes(5);
 
-    /// <summary>
-    /// Minimum permission level for default commands (regular users)
-    /// </summary>
-    public const int DefaultCommandPermissionLevel = 0;
+    /// <summary>Tier whose command set is registered in the default (all-users) Telegram scope.</summary>
+    public const PermissionLevel DefaultCommandPermissionLevel = PermissionLevel.Member;
 
-    /// <summary>
-    /// Minimum permission level for admin commands
-    /// </summary>
-    public const int AdminCommandPermissionLevel = 1;
+    /// <summary>Tier whose command set is registered in the group-admin Telegram scope.</summary>
+    public const PermissionLevel AdminCommandPermissionLevel = PermissionLevel.Admin;
 }

--- a/TelegramGroupsAdmin.Telegram/Constants/ModerationConstants.cs
+++ b/TelegramGroupsAdmin.Telegram/Constants/ModerationConstants.cs
@@ -11,11 +11,6 @@ public static class ModerationConstants
     public static readonly TimeSpan DefaultWarningExpiry = TimeSpan.FromDays(90);
 
     /// <summary>
-    /// Minimum permission level required for admin commands (0 = regular user, 1 = admin, 2 = owner)
-    /// </summary>
-    public const int AdminPermissionLevel = 1;
-
-    /// <summary>
     /// Number of chats affected when operation succeeds (single chat operations)
     /// </summary>
     public const int SingleChatSuccess = 1;

--- a/TelegramGroupsAdmin.Telegram/Repositories/ChatAdminsRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/ChatAdminsRepository.cs
@@ -24,25 +24,6 @@ public class ChatAdminsRepository : IChatAdminsRepository
     }
 
     /// <inheritdoc/>
-    public async Task<int> GetPermissionLevelAsync(long chatId, long telegramId, CancellationToken cancellationToken = default)
-    {
-        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
-
-        var admin = await context.ChatAdmins
-            .AsNoTracking()
-            .Where(ca => ca.ChatId == chatId && ca.TelegramId == telegramId && ca.IsActive == true)
-            .Select(ca => new { ca.IsCreator })
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (admin == null)
-        {
-            return -1; // Not an admin
-        }
-
-        return admin.IsCreator ? 2 : 1; // Creator = Owner (2), Admin = Admin (1)
-    }
-
-    /// <inheritdoc/>
     public async Task<bool> IsAdminAsync(long chatId, long telegramId, CancellationToken cancellationToken = default)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);

--- a/TelegramGroupsAdmin.Telegram/Repositories/IChatAdminsRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/IChatAdminsRepository.cs
@@ -10,12 +10,6 @@ namespace TelegramGroupsAdmin.Telegram.Repositories;
 public interface IChatAdminsRepository
 {
     /// <summary>
-    /// Get admin permission level for a specific user in a specific chat
-    /// Returns 2 if creator, 1 if admin, -1 if not admin/not found
-    /// </summary>
-    Task<int> GetPermissionLevelAsync(long chatId, long telegramId, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Check if user is an active admin in the specified chat
     /// </summary>
     Task<bool> IsAdminAsync(long chatId, long telegramId, CancellationToken cancellationToken = default);

--- a/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
@@ -6,6 +6,7 @@ using TelegramGroupsAdmin.Core;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Data;
 using TelegramGroupsAdmin.Core.Extensions;
+using TelegramGroupsAdmin.Telegram.Constants;
 using TelegramGroupsAdmin.Telegram.Extensions;
 using DataModels = TelegramGroupsAdmin.Data.Models;
 using UiModels = TelegramGroupsAdmin.Telegram.Models;
@@ -640,10 +641,12 @@ public class TelegramUserRepository : ITelegramUserRepository
         // Build base queryable (exclude system user)
         var baseQuery = context.TelegramUsers.AsNoTracking().Where(u => u.TelegramUserId != 0);
 
-        // Apply chatIds filter
-        if (chatIds is { Count: > 0 })
+        // Apply chatIds filter.
+        // Contains GlobalChatId (0) ⇒ global / no filter. Empty or null ⇒ nothing (0 rows).
+        var scopeIds = chatIds ?? [];
+        if (!scopeIds.Contains(ModerationConstants.GlobalChatId))
         {
-            baseQuery = baseQuery.Where(u => context.Messages.Any(m => m.UserId == u.TelegramUserId && chatIds.Contains(m.ChatId)));
+            baseQuery = baseQuery.Where(u => context.Messages.Any(m => m.UserId == u.TelegramUserId && scopeIds.Contains(m.ChatId)));
         }
 
         // Apply search text filter

--- a/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
+++ b/TelegramGroupsAdmin.Telegram/Repositories/TelegramUserRepository.cs
@@ -462,10 +462,12 @@ public class TelegramUserRepository : ITelegramUserRepository
                 break;
         }
 
-        // Apply chatIds filter (Admin users have scoped access via messages table)
-        if (chatIds is { Count: > 0 })
+        // Apply chatIds filter (Admin users have scoped access via messages table).
+        // Contains GlobalChatId (0) ⇒ global / no filter. Empty (or null) ⇒ nothing.
+        var scopeIds = chatIds ?? [];
+        if (!scopeIds.Contains(ModerationConstants.GlobalChatId))
         {
-            query = query.Where(u => context.Messages.Any(m => m.UserId == u.TelegramUserId && chatIds.Contains(m.ChatId)));
+            query = query.Where(u => context.Messages.Any(m => m.UserId == u.TelegramUserId && scopeIds.Contains(m.ChatId)));
         }
 
         // Apply search text filter

--- a/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/TelegramBotPollingHost.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BackgroundServices/TelegramBotPollingHost.cs
@@ -249,7 +249,7 @@ public class TelegramBotPollingHost(
         {
             // Register commands with different scopes based on permission levels
 
-            // Default scope - commands for all users (Admin level 0)
+            // Default scope - public commands for all users (Member tier)
             var defaultCommands = commandRouter.GetAvailableCommands(permissionLevel: CommandConstants.DefaultCommandPermissionLevel)
                 .Select(cmd => new BotCommand
                 {
@@ -263,7 +263,7 @@ public class TelegramBotPollingHost(
                 scope: new BotCommandScopeDefault(),
                 cancellationToken: cancellationToken);
 
-            // Admin scope - commands for group admins (Admin level 1+)
+            // Admin scope - adds moderation commands for group admins (Admin tier)
             var adminCommands = commandRouter.GetAvailableCommands(permissionLevel: CommandConstants.AdminCommandPermissionLevel)
                 .Select(cmd => new BotCommand
                 {

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;
 using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Extensions;
 using TelegramGroupsAdmin.Telegram.Metrics;
@@ -84,39 +85,20 @@ public partial class CommandRouter
             using var scope = _serviceProvider.CreateScope();
             var command = scope.ServiceProvider.GetRequiredKeyedService<IBotCommand>(commandName);
 
-            // Get actual permission level for all commands
-            var actualPermissionLevel = await GetPermissionLevelAsync(message.Chat.Id, message.From.Id, cancellationToken);
+            // Resolve the user's effective tier in this chat (web tier ⊕ chat-admin status).
+            var permissionLevel = await GetPermissionLevelAsync(message.Chat.Id, message.From.Id, cancellationToken);
 
-            // Special cases: /link, /start, /report, /help, and /invite bypass permission checks (accessible to everyone)
-            // BUT they still receive actual permission level for context (e.g., /help shows correct commands)
-            var bypassPermissionCheck = commandName is "link" or "start" or "report" or "help" or "invite";
-            var permissionLevel = bypassPermissionCheck ? Math.Max(actualPermissionLevel, command.MinPermissionLevel) : actualPermissionLevel;
-
-            // Check permission
-            if (!bypassPermissionCheck && permissionLevel < command.MinPermissionLevel)
+            // Gate: public commands are PermissionLevel.Member (the floor) so they never fail this.
+            if (permissionLevel < command.MinPermissionLevel)
             {
                 _logger.LogWarning(
-                    "User {User} attempted to use command /{Command} without sufficient permissions (has {UserLevel}, needs {RequiredLevel})",
+                    "User {User} attempted /{Command} without sufficient permission (has {UserLevel}, needs {RequiredLevel})",
                     TelegramDisplayName.Format(message.From.FirstName, message.From.LastName, message.From.Username, message.From.Id),
                     commandName, permissionLevel, command.MinPermissionLevel);
 
-                // Build appropriate message based on permission level and required level
-                string permissionMessage;
-                if (permissionLevel == -1 && command.MinPermissionLevel >= 1)
-                {
-                    // Regular user trying to use admin command
-                    permissionMessage = "❌ This command is only available to group administrators.";
-                }
-                else if (permissionLevel == -1)
-                {
-                    // Regular user trying to use a regular command (shouldn't happen with /help, /report exceptions)
-                    permissionMessage = "❌ You don't have permission to use this command.";
-                }
-                else
-                {
-                    // Linked user without sufficient permission level
-                    permissionMessage = $"❌ Insufficient permissions. This command requires {GetPermissionName(command.MinPermissionLevel)} level.";
-                }
+                var permissionMessage = command.MinPermissionLevel >= PermissionLevel.Admin
+                    ? "❌ This command is only available to group administrators."
+                    : "❌ You don't have permission to use this command.";
 
                 return new CommandResult(TelegramMessage.Plain(permissionMessage), true); // Auto-delete permission denied messages
             }
@@ -149,9 +131,8 @@ public partial class CommandRouter
     /// <summary>
     /// Get all available commands for a user's permission level
     /// </summary>
-    public IEnumerable<IBotCommand> GetAvailableCommands(int permissionLevel)
+    public IEnumerable<IBotCommand> GetAvailableCommands(PermissionLevel permissionLevel)
     {
-        // Create a scope to resolve commands (they're Scoped)
         using var scope = _serviceProvider.CreateScope();
 
         var commands = new List<IBotCommand>();
@@ -168,51 +149,24 @@ public partial class CommandRouter
     }
 
     /// <summary>
-    /// Get permission level for a Telegram user
-    /// Priority order:
-    /// 1. Linked web app user → their permission level (0-2, global across all chats)
-    /// 2. Telegram group creator → Owner (2, per-chat only)
-    /// 3. Telegram group admin → Admin (1, per-chat only)
-    /// 4. Not linked and not admin → -1 (no permission)
+    /// Resolves a Telegram user's effective permission tier in a specific chat via
+    /// <see cref="PermissionResolver"/>: their stored web tier (global) combined with their
+    /// Telegram admin/creator status in this chat (chat-scoped Admin).
     /// </summary>
-    private async Task<int> GetPermissionLevelAsync(long chatId, long telegramId, CancellationToken cancellationToken = default)
+    private async Task<PermissionLevel> GetPermissionLevelAsync(long chatId, long telegramId, CancellationToken cancellationToken = default)
     {
         using var scope = _serviceProvider.CreateScope();
 
-        // Check web app linking FIRST (global permissions, works in all chats)
-        // Optimized: Single query with JOIN instead of 2 separate queries
         var mappingRepository = scope.ServiceProvider.GetRequiredService<ITelegramUserMappingRepository>();
-        var permissionLevel = await mappingRepository.GetPermissionLevelByTelegramIdAsync(telegramId, cancellationToken);
+        var webTier = await mappingRepository.GetPermissionLevelByTelegramIdAsync(telegramId, cancellationToken);
 
-        if (permissionLevel.HasValue)
-        {
-            _logger.LogDebug("User {TelegramId} is linked to web app user with {PermissionLevel} permissions (global)",
-                telegramId, permissionLevel.Value);
-            return (int)permissionLevel.Value; // 0=Admin, 1=GlobalAdmin, 2=Owner (global)
-        }
-
-        // Check Telegram admin permissions (cached, per-chat only)
         var chatAdminsRepository = scope.ServiceProvider.GetRequiredService<IChatAdminsRepository>();
-        var adminPermissionLevel = await chatAdminsRepository.GetPermissionLevelAsync(chatId, telegramId, cancellationToken);
+        var isChatAdmin = await chatAdminsRepository.IsAdminAsync(chatId, telegramId, cancellationToken);
 
-        if (adminPermissionLevel > -1)
-        {
-            var roleName = adminPermissionLevel == 2 ? "creator" : "admin";
-            _logger.LogDebug("User {TelegramId} is Telegram {Role} in chat {ChatId}, granting {Level} permissions (per-chat)",
-                telegramId, roleName, chatId, adminPermissionLevel);
-            return adminPermissionLevel; // 1=Admin or 2=Creator (per-chat)
-        }
-
-        // Not linked and not admin
-        _logger.LogDebug("User {TelegramId} has no permissions in chat {ChatId}", telegramId, chatId);
-        return -1;
+        var effective = PermissionResolver.Resolve(webTier, isChatAdmin);
+        _logger.LogDebug(
+            "Resolved permission for {TelegramId} in chat {ChatId}: {Tier} (web={WebTier}, chatAdmin={IsChatAdmin})",
+            telegramId, chatId, effective, webTier, isChatAdmin);
+        return effective;
     }
-
-    private static string GetPermissionName(int level) => level switch
-    {
-        0 => "Admin",
-        1 => "GlobalAdmin",
-        2 => "Owner",
-        _ => "Unknown"
-    };
 }

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs
@@ -96,11 +96,11 @@ public partial class CommandRouter
                     TelegramDisplayName.Format(message.From.FirstName, message.From.LastName, message.From.Username, message.From.Id),
                     commandName, permissionLevel, command.MinPermissionLevel);
 
-                var permissionMessage = command.MinPermissionLevel >= PermissionLevel.Admin
-                    ? "❌ This command is only available to group administrators."
-                    : "❌ You don't have permission to use this command.";
-
-                return new CommandResult(TelegramMessage.Plain(permissionMessage), true); // Auto-delete permission denied messages
+                // Every gated command requires Admin (moderation); public commands are Member (the floor)
+                // and can never reach this branch, so the only denial is "needs admin".
+                return new CommandResult(
+                    TelegramMessage.Plain("❌ This command is only available to group administrators."),
+                    true); // Auto-delete permission denied messages
             }
 
             // Check reply requirement

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/BanCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/BanCommand.cs
@@ -29,7 +29,7 @@ public class BanCommand : IBotCommand
     public string Name => "ban";
     public string Description => "Ban user from all managed chats";
     public string Usage => "/ban (reply) | /ban @username | /ban <user_id> | /ban <name>";
-    public int MinPermissionLevel => 1; // Admin required
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => false; // Now supports multiple input methods
     public bool DeleteCommandMessage => true; // Clean up moderation command
     public int? DeleteResponseAfterSeconds => null;
@@ -51,7 +51,7 @@ public class BanCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         UserIdentity? targetIdentity = null;

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/DeleteCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/DeleteCommand.cs
@@ -9,7 +9,7 @@ using TelegramGroupsAdmin.Telegram.Services.Bot;
 namespace TelegramGroupsAdmin.Telegram.Services.BotCommands.Commands;
 
 /// <summary>
-/// /delete - TEMPORARY TEST COMMAND - Delete a message (testing Telegram.Bot API)
+/// /delete - Delete the message you reply to.
 /// </summary>
 public class DeleteCommand : IBotCommand
 {
@@ -17,7 +17,7 @@ public class DeleteCommand : IBotCommand
     private readonly IServiceProvider _serviceProvider;
 
     public string Name => "delete";
-    public string Description => "[TEST] Delete a message";
+    public string Description => "Delete the replied-to message";
     public string Usage => "/delete (reply to message)";
     public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => true;
@@ -57,12 +57,12 @@ public class DeleteCommand : IBotCommand
                 cancellationToken);
 
             _logger.LogInformation(
-                "DELETE TEST: {Admin} deleted message {MessageId} in {Chat}",
-                message.From.ToLogInfo(),
+                "Deleted message {MessageId} in {Chat} by {Admin}",
                 targetMessage.MessageId,
-                message.Chat.ToLogInfo());
+                message.Chat.ToLogInfo(),
+                message.From.ToLogInfo());
 
-            return new CommandResult(TelegramMessage.Plain("✅ Message deleted successfully!\n\nThis is a temporary test command."), DeleteCommandMessage, DeleteResponseAfterSeconds);
+            return new CommandResult(TelegramMessage.Plain("✅ Message deleted successfully!"), DeleteCommandMessage, DeleteResponseAfterSeconds);
         }
         catch (Exception ex)
         {

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/DeleteCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/DeleteCommand.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Extensions;
 using TelegramGroupsAdmin.Telegram.Services.Bot;
@@ -18,7 +19,7 @@ public class DeleteCommand : IBotCommand
     public string Name => "delete";
     public string Description => "[TEST] Delete a message";
     public string Usage => "/delete (reply to message)";
-    public int MinPermissionLevel => 1; // Admin required
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => true;
     public bool DeleteCommandMessage => true; // Clean up command message
     public int? DeleteResponseAfterSeconds => null;
@@ -34,7 +35,7 @@ public class DeleteCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         if (message.ReplyToMessage == null)

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs
@@ -1,4 +1,5 @@
 using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Utilities;
 
 namespace TelegramGroupsAdmin.Telegram.Services.BotCommands.Commands;
@@ -36,7 +37,7 @@ public class HelpCommand : IBotCommand
     public string Name => "help";
     public string Description => "Show available commands";
     public string Usage => "/help";
-    public int MinPermissionLevel => 0; // Everyone can see help
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Member; // everyone
     public bool RequiresReply => false;
     public bool DeleteCommandMessage => false; // Keep visible for reference
     public int? DeleteResponseAfterSeconds => 30; // Auto-delete help response after 30 seconds
@@ -44,7 +45,7 @@ public class HelpCommand : IBotCommand
     public Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         var builder = new TelegramMessageBuilder()
@@ -52,7 +53,7 @@ public class HelpCommand : IBotCommand
             .LineBreak();
 
         var availableCommands = _commandMetadata
-            .Where(c => c.MinPermissionLevel <= userPermissionLevel)
+            .Where(c => c.MinPermissionLevel <= userPermission)
             .ToList();
 
         // Group by permission level
@@ -68,7 +69,7 @@ public class HelpCommand : IBotCommand
         }
 
         // Show Admin commands
-        if (adminCommands.Any() && userPermissionLevel >= 1)
+        if (adminCommands.Any() && userPermission >= 1)
         {
             builder.LineBreak().Bold("Admin Commands:").LineBreak();
             foreach (var cmd in adminCommands)
@@ -77,7 +78,7 @@ public class HelpCommand : IBotCommand
             }
         }
 
-        builder.LineBreak().Italic($"Permission: {GetPermissionName(userPermissionLevel)}");
+        builder.LineBreak().Italic($"Permission: {GetPermissionName(userPermission)}");
 
         return Task.FromResult(new CommandResult(builder.Build(), DeleteCommandMessage, DeleteResponseAfterSeconds));
     }

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs
@@ -9,30 +9,23 @@ namespace TelegramGroupsAdmin.Telegram.Services.BotCommands.Commands;
 /// </summary>
 public class HelpCommand : IBotCommand
 {
-    private readonly IServiceProvider _serviceProvider;
-
     // Static metadata for all commands (avoids reflection complexity with DI)
     // Note: /start is excluded - it's only for deep links and DMs
     private static readonly List<CommandMetadata> _commandMetadata =
     [
-        new("report", "Report message for admin review", 0),
-        new("invite", "Get invite link for this chat", -1),
-        new("link", "Link your Telegram account to web app", 1),
-        new("spam", "Mark message as spam and delete it", 1),
-        new("ban", "Ban user from all managed chats", 1),
-        new("tempban", "Temporarily ban user with auto-unrestriction", 1),
-        new("trust", "Whitelist user (bypass spam detection)", 1),
-        new("unban", "Remove ban from user", 1),
-        new("warn", "Issue warning to user", 1),
-        new("delete", "[TEST] Delete a message", 1)
+        new("report", "Report message for admin review", PermissionLevel.Member),
+        new("invite", "Get invite link for this chat", PermissionLevel.Member),
+        new("link", "Link your Telegram account to web app", PermissionLevel.Member),
+        new("spam", "Mark message as spam and delete it", PermissionLevel.Admin),
+        new("ban", "Ban user from all managed chats", PermissionLevel.Admin),
+        new("tempban", "Temporarily ban user with auto-unrestriction", PermissionLevel.Admin),
+        new("trust", "Whitelist user (bypass spam detection)", PermissionLevel.Admin),
+        new("unban", "Remove ban from user", PermissionLevel.Admin),
+        new("warn", "Issue warning to user", PermissionLevel.Admin),
+        new("delete", "[TEST] Delete a message", PermissionLevel.Admin)
     ];
 
-    private record CommandMetadata(string Name, string Description, int MinPermissionLevel);
-
-    public HelpCommand(IServiceProvider serviceProvider)
-    {
-        _serviceProvider = serviceProvider;
-    }
+    private record CommandMetadata(string Name, string Description, PermissionLevel MinPermissionLevel);
 
     public string Name => "help";
     public string Description => "Show available commands";
@@ -56,20 +49,18 @@ public class HelpCommand : IBotCommand
             .Where(c => c.MinPermissionLevel <= userPermission)
             .ToList();
 
-        // Group by permission level
-        var readOnlyCommands = availableCommands.Where(c => c.MinPermissionLevel == 0).ToList();
-        var adminCommands = availableCommands.Where(c => c.MinPermissionLevel >= 1).ToList();
+        var publicCommands = availableCommands.Where(c => c.MinPermissionLevel < PermissionLevel.Admin).ToList();
+        var adminCommands = availableCommands.Where(c => c.MinPermissionLevel >= PermissionLevel.Admin).ToList();
 
-        // Show Admin commands (including self)
+        // Show /help itself plus the public commands
         AppendCommandLine(builder, GetCommandEmoji("help"), "help", Description);
-
-        foreach (var cmd in readOnlyCommands)
+        foreach (var cmd in publicCommands)
         {
             AppendCommandLine(builder, GetCommandEmoji(cmd.Name), cmd.Name, cmd.Description);
         }
 
-        // Show Admin commands
-        if (adminCommands.Any() && userPermission >= 1)
+        // Show Admin commands only to admins
+        if (adminCommands.Any() && userPermission >= PermissionLevel.Admin)
         {
             builder.LineBreak().Bold("Admin Commands:").LineBreak();
             foreach (var cmd in adminCommands)
@@ -78,7 +69,7 @@ public class HelpCommand : IBotCommand
             }
         }
 
-        builder.LineBreak().Italic($"Permission: {GetPermissionName(userPermission)}");
+        builder.LineBreak().Italic($"Permission: {userPermission.GetDisplayName()}");
 
         return Task.FromResult(new CommandResult(builder.Build(), DeleteCommandMessage, DeleteResponseAfterSeconds));
     }
@@ -103,13 +94,5 @@ public class HelpCommand : IBotCommand
         "unban" => "🔓",
         "warn" => "⚠️",
         _ => "🔹"
-    };
-
-    private static string GetPermissionName(int level) => level switch
-    {
-        0 => "Admin",
-        1 => "GlobalAdmin",
-        2 => "Owner",
-        _ => "Unknown"
     };
 }

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Telegram.Bot.Types;
 using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Utilities;
@@ -9,23 +10,12 @@ namespace TelegramGroupsAdmin.Telegram.Services.BotCommands.Commands;
 /// </summary>
 public class HelpCommand : IBotCommand
 {
-    // Static metadata for all commands (avoids reflection complexity with DI)
-    // Note: /start is excluded - it's only for deep links and DMs
-    private static readonly List<CommandMetadata> _commandMetadata =
-    [
-        new("report", "Report message for admin review", PermissionLevel.Member),
-        new("invite", "Get invite link for this chat", PermissionLevel.Member),
-        new("link", "Link your Telegram account to web app", PermissionLevel.Member),
-        new("spam", "Mark message as spam and delete it", PermissionLevel.Admin),
-        new("ban", "Ban user from all managed chats", PermissionLevel.Admin),
-        new("tempban", "Temporarily ban user with auto-unrestriction", PermissionLevel.Admin),
-        new("trust", "Whitelist user (bypass spam detection)", PermissionLevel.Admin),
-        new("unban", "Remove ban from user", PermissionLevel.Admin),
-        new("warn", "Issue warning to user", PermissionLevel.Admin),
-        new("delete", "[TEST] Delete a message", PermissionLevel.Admin)
-    ];
+    private readonly IServiceProvider _serviceProvider;
 
-    private record CommandMetadata(string Name, string Description, PermissionLevel MinPermissionLevel);
+    public HelpCommand(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
 
     public string Name => "help";
     public string Description => "Show available commands";
@@ -41,31 +31,32 @@ public class HelpCommand : IBotCommand
         PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
+        using var scope = _serviceProvider.CreateScope();
+        var available = CommandNames.All
+            .Select(name => scope.ServiceProvider.GetRequiredKeyedService<IBotCommand>(name))
+            .Where(c => c.Name != "start")                  // /start is deep-link/DM-only, not listed
+            .Where(c => c.MinPermissionLevel <= userPermission)
+            .OrderBy(c => c.Name)
+            .ToList();
+
+        var publicCommands = available.Where(c => c.MinPermissionLevel < PermissionLevel.Admin).ToList();
+        var adminCommands = available.Where(c => c.MinPermissionLevel >= PermissionLevel.Admin).ToList();
+
         var builder = new TelegramMessageBuilder()
             .Text("🤖 ").Bold("TelegramGroupsAdmin Bot").LineBreak()
             .LineBreak();
 
-        var availableCommands = _commandMetadata
-            .Where(c => c.MinPermissionLevel <= userPermission)
-            .ToList();
-
-        var publicCommands = availableCommands.Where(c => c.MinPermissionLevel < PermissionLevel.Admin).ToList();
-        var adminCommands = availableCommands.Where(c => c.MinPermissionLevel >= PermissionLevel.Admin).ToList();
-
-        // Show /help itself plus the public commands
-        AppendCommandLine(builder, GetCommandEmoji("help"), "help", Description);
-        foreach (var cmd in publicCommands)
+        foreach (var c in publicCommands)
         {
-            AppendCommandLine(builder, GetCommandEmoji(cmd.Name), cmd.Name, cmd.Description);
+            AppendCommandLine(builder, GetCommandEmoji(c.Name), c.Name, c.Description);
         }
 
-        // Show Admin commands only to admins
-        if (adminCommands.Any() && userPermission >= PermissionLevel.Admin)
+        if (adminCommands.Count > 0 && userPermission >= PermissionLevel.Admin)
         {
             builder.LineBreak().Bold("Admin Commands:").LineBreak();
-            foreach (var cmd in adminCommands)
+            foreach (var c in adminCommands)
             {
-                AppendCommandLine(builder, GetCommandEmoji(cmd.Name), cmd.Name, cmd.Description);
+                AppendCommandLine(builder, GetCommandEmoji(c.Name), c.Name, c.Description);
             }
         }
 
@@ -87,6 +78,10 @@ public class HelpCommand : IBotCommand
         "start" => "👋",
         "report" => "📢",
         "invite" => "🔗",
+        "link" => "🔑",
+        "mystatus" => "👤",
+        "mute" => "🔇",
+        "delete" => "🗑️",
         "spam" => "🚫",
         "ban" => "⛔",
         "tempban" => "⏱️",

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/InviteCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/InviteCommand.cs
@@ -16,7 +16,7 @@ namespace TelegramGroupsAdmin.Telegram.Services.BotCommands.Commands;
 
 /// <summary>
 /// /invite - Get invite link for current chat (for users in private groups)
-/// Permission level: -1 (everyone, including non-admins)
+/// Permission level: Member (everyone, including non-admins)
 /// Configurable: Global and per-chat enable/disable
 /// Auto-deletes: Command and response after 30 seconds (configurable)
 /// </summary>

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/InviteCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/InviteCommand.cs
@@ -28,7 +28,7 @@ public class InviteCommand : IBotCommand
     public string Name => "invite";
     public string Description => "Get invite link for this chat";
     public string Usage => "/invite";
-    public int MinPermissionLevel => -1; // Everyone can use this
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Member; // everyone
     public bool RequiresReply => false;
     public bool DeleteCommandMessage => true; // Default, overridden by config
     public int? DeleteResponseAfterSeconds => 30; // Default, overridden by config
@@ -44,7 +44,7 @@ public class InviteCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         // Only works in groups/supergroups

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/LinkCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/LinkCommand.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Models;
 using TelegramGroupsAdmin.Core.Utilities;
 using TelegramGroupsAdmin.Telegram.Repositories;
 
@@ -14,7 +15,7 @@ public class LinkCommand : IBotCommand
     public string Name => "link";
     public string Description => "Link your Telegram account to web app";
     public string Usage => "/link <token>";
-    public int MinPermissionLevel => 0; // Anyone can link
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Member; // everyone
     public bool RequiresReply => false;
     public bool DeleteCommandMessage => true; // Delete for security (contains token)
     public int? DeleteResponseAfterSeconds => null;
@@ -30,7 +31,7 @@ public class LinkCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         // Validate token argument

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/MuteCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/MuteCommand.cs
@@ -23,7 +23,7 @@ public class MuteCommand : IBotCommand
     public string Name => "mute";
     public string Description => "Temporarily mute user with auto-unmute";
     public string Usage => "/mute (reply to message) <5m|1h|24h> [reason]";
-    public int MinPermissionLevel => ModerationConstants.AdminPermissionLevel; // Admin required
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => true;
     public bool DeleteCommandMessage => true; // Clean up moderation command
     public int? DeleteResponseAfterSeconds => null;
@@ -41,7 +41,7 @@ public class MuteCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         if (message.ReplyToMessage == null)

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/MyStatusCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/MyStatusCommand.cs
@@ -35,7 +35,7 @@ public class MyStatusCommand : IBotCommand
     public string Name => "mystatus";
     public string Description => "Check your warning count, trust status, and other info (DM only)";
     public string Usage => "/mystatus";
-    public int MinPermissionLevel => 0; // Everyone can use
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Member; // everyone
     public bool RequiresReply => false;
     public bool DeleteCommandMessage => true; // Delete command for privacy
     public int? DeleteResponseAfterSeconds => null;
@@ -43,7 +43,7 @@ public class MyStatusCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         if (message.From == null)

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/ReportCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/ReportCommand.cs
@@ -19,7 +19,7 @@ public class ReportCommand(
     public string Name => "report";
     public string Description => "Report message for admin review";
     public string Usage => "/report (reply to message)";
-    public int MinPermissionLevel => 0; // Anyone can report
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Member; // everyone
     public bool RequiresReply => true;
     public bool DeleteCommandMessage => false; // Keep visible for confirmation
     public int? DeleteResponseAfterSeconds => null;
@@ -27,7 +27,7 @@ public class ReportCommand(
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         if (message.ReplyToMessage == null)

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/SpamCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/SpamCommand.cs
@@ -22,7 +22,7 @@ public class SpamCommand : IBotCommand
     public string Name => "spam";
     public string Description => "Mark message as spam and delete it";
     public string Usage => "/spam (reply to message)";
-    public int MinPermissionLevel => 1; // Admin required
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => true;
     public bool DeleteCommandMessage => true; // Clean up moderation command
     public int? DeleteResponseAfterSeconds => null;
@@ -40,7 +40,7 @@ public class SpamCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         if (message.ReplyToMessage == null)

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/StartCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/StartCommand.cs
@@ -52,7 +52,7 @@ public class StartCommand : IBotCommand
     public string Name => "start";
     public string Description => "Start conversation with bot";
     public string Usage => "/start [deeplink_payload]";
-    public int MinPermissionLevel => 0; // Everyone can use
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Member; // everyone
     public bool RequiresReply => false;
     public bool DeleteCommandMessage => false;
     public int? DeleteResponseAfterSeconds => null;
@@ -60,7 +60,7 @@ public class StartCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         // Only respond to /start in private DMs, ignore in group chats

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/TempBanCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/TempBanCommand.cs
@@ -24,7 +24,7 @@ public class TempBanCommand : IBotCommand
     public string Name => "tempban";
     public string Description => "Temporarily ban user with auto-unrestriction";
     public string Usage => "/tempban (reply to message) <5m|1h|24h> [reason]";
-    public int MinPermissionLevel => ModerationConstants.AdminPermissionLevel; // Admin required
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => true;
     public bool DeleteCommandMessage => true; // Clean up moderation command
     public int? DeleteResponseAfterSeconds => null;
@@ -42,7 +42,7 @@ public class TempBanCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         if (message.ReplyToMessage == null)

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/TrustCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/TrustCommand.cs
@@ -23,7 +23,7 @@ public class TrustCommand : IBotCommand
     public string Name => "trust";
     public string Description => "Toggle trust status (bypass spam detection)";
     public string Usage => "/trust (reply to message) OR /trust <username>";
-    public int MinPermissionLevel => 1; // Admin required
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => false;
     public bool DeleteCommandMessage => false; // Keep visible for confirmation
     public int? DeleteResponseAfterSeconds => null;
@@ -41,7 +41,7 @@ public class TrustCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         User? targetUser = null;

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/UnbanCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/UnbanCommand.cs
@@ -14,7 +14,6 @@ namespace TelegramGroupsAdmin.Telegram.Services.BotCommands.Commands;
 public class UnbanCommand : IBotCommand
 {
     private readonly ILogger<UnbanCommand> _logger;
-    private readonly IServiceProvider _serviceProvider;
     private readonly IBotModerationService _moderationService;
 
     public string Name => "unban";
@@ -27,11 +26,9 @@ public class UnbanCommand : IBotCommand
 
     public UnbanCommand(
         ILogger<UnbanCommand> logger,
-        IServiceProvider serviceProvider,
         IBotModerationService moderationService)
     {
         _logger = logger;
-        _serviceProvider = serviceProvider;
         _moderationService = moderationService;
     }
 

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/UnbanCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/UnbanCommand.cs
@@ -20,7 +20,7 @@ public class UnbanCommand : IBotCommand
     public string Name => "unban";
     public string Description => "Remove ban from user";
     public string Usage => "/unban (reply to message)";
-    public int MinPermissionLevel => 1; // Admin required
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => true;
     public bool DeleteCommandMessage => false; // Keep visible for confirmation
     public int? DeleteResponseAfterSeconds => null;
@@ -38,7 +38,7 @@ public class UnbanCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         if (message.ReplyToMessage == null)

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/WarnCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/WarnCommand.cs
@@ -24,7 +24,7 @@ public class WarnCommand : IBotCommand
     public string Name => "warn";
     public string Description => "Issue warning to user (auto-ban after threshold)";
     public string Usage => "/warn (reply to message) [reason]";
-    public int MinPermissionLevel => 1; // Admin required
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
     public bool RequiresReply => true;
     public bool DeleteCommandMessage => false; // Keep visible as public warning
     public int? DeleteResponseAfterSeconds => null;
@@ -44,7 +44,7 @@ public class WarnCommand : IBotCommand
     public async Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default)
     {
         if (message.ReplyToMessage == null)

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/IBotCommand.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/IBotCommand.cs
@@ -1,4 +1,5 @@
 using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Models;
 
 namespace TelegramGroupsAdmin.Telegram.Services.BotCommands;
 
@@ -23,9 +24,9 @@ public interface IBotCommand
     string Usage { get; }
 
     /// <summary>
-    /// Minimum permission level required (0=Admin, 1=GlobalAdmin, 2=Owner)
+    /// Minimum permission tier required to run this command.
     /// </summary>
-    int MinPermissionLevel { get; }
+    PermissionLevel MinPermissionLevel { get; }
 
     /// <summary>
     /// Whether this command requires replying to a message
@@ -48,12 +49,12 @@ public interface IBotCommand
     /// </summary>
     /// <param name="message">Telegram message containing the command</param>
     /// <param name="args">Command arguments (parsed after command name)</param>
-    /// <param name="userPermissionLevel">Permission level of user who issued command</param>
+    /// <param name="userPermission">Effective permission tier of the user who issued the command</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>CommandResult with response message and optional dynamic deletion time</returns>
     Task<CommandResult> ExecuteAsync(
         Message message,
         string[] args,
-        int userPermissionLevel,
+        PermissionLevel userPermission,
         CancellationToken cancellationToken = default);
 }

--- a/TelegramGroupsAdmin.Telegram/Services/BotCommands/PermissionResolver.cs
+++ b/TelegramGroupsAdmin.Telegram/Services/BotCommands/PermissionResolver.cs
@@ -1,0 +1,21 @@
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Services.BotCommands;
+
+/// <summary>
+/// Resolves a user's effective permission tier in a specific chat from the two sources
+/// of authority: their stored web tier (if any) and their Telegram admin status in that chat.
+///
+/// GlobalAdmin/Owner apply globally (any chat). Admin is chat-scoped — it applies only
+/// where the user is a Telegram admin/creator. Everyone else is Member.
+/// This naturally yields the MAX of the two sources.
+/// </summary>
+public static class PermissionResolver
+{
+    public static PermissionLevel Resolve(PermissionLevel? webTier, bool isChatAdminOrCreator)
+        => webTier is PermissionLevel.GlobalAdmin or PermissionLevel.Owner
+            ? webTier.Value
+            : isChatAdminOrCreator
+                ? PermissionLevel.Admin
+                : PermissionLevel.Member;
+}

--- a/TelegramGroupsAdmin.UnitTests/Core/Models/PermissionLevelTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Core/Models/PermissionLevelTests.cs
@@ -22,6 +22,16 @@ public class PermissionLevelTests
     }
 
     [Test]
+    public void GetDisplayName_UndefinedValue_FailsClosedToMember()
+    {
+        // Defense-in-depth: an unknown tier (e.g., a future int that would map to a HIGHER
+        // privilege) must resolve to the no-privilege floor — never a stringified int and
+        // never a privileged role. The role-claim path (AuthCookieService/Login) depends on this.
+        var undefined = (PermissionLevel)99;
+        Assert.That(undefined.GetDisplayName(), Is.EqualTo("Member"));
+    }
+
+    [Test]
     public void StoredTiers_KeepExistingIntValues()
     {
         // Web claims/policies depend on these — must not change.

--- a/TelegramGroupsAdmin.UnitTests/Core/Models/PermissionLevelTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Core/Models/PermissionLevelTests.cs
@@ -1,0 +1,32 @@
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.UnitTests.Core.Models;
+
+[TestFixture]
+public class PermissionLevelTests
+{
+    [Test]
+    public void Member_IsMinusOne_AndBelowAdmin()
+    {
+        Assert.That((int)PermissionLevel.Member, Is.EqualTo(-1));
+        Assert.That(PermissionLevel.Member, Is.LessThan(PermissionLevel.Admin));
+    }
+
+    [TestCase(PermissionLevel.Member, "Member")]
+    [TestCase(PermissionLevel.Admin, "Admin")]
+    [TestCase(PermissionLevel.GlobalAdmin, "GlobalAdmin")]
+    [TestCase(PermissionLevel.Owner, "Owner")]
+    public void GetDisplayName_ReturnsDisplayAttributeName(PermissionLevel level, string expected)
+    {
+        Assert.That(level.GetDisplayName(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void StoredTiers_KeepExistingIntValues()
+    {
+        // Web claims/policies depend on these — must not change.
+        Assert.That((int)PermissionLevel.Admin, Is.EqualTo(0));
+        Assert.That((int)PermissionLevel.GlobalAdmin, Is.EqualTo(1));
+        Assert.That((int)PermissionLevel.Owner, Is.EqualTo(2));
+    }
+}

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/CommandRouterTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/CommandRouterTests.cs
@@ -1,0 +1,179 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Utilities;
+using TelegramGroupsAdmin.Telegram.Metrics;
+using TelegramGroupsAdmin.Telegram.Repositories;
+using TelegramGroupsAdmin.Telegram.Services.BotCommands;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services.BotCommands;
+
+/// <summary>
+/// Tests that CommandRouter correctly wires GetPermissionLevelAsync → PermissionResolver.Resolve
+/// → permission gate, producing a denial or executing the command accordingly.
+/// </summary>
+[TestFixture]
+public class CommandRouterTests
+{
+    private const string DenialMessage = "❌ This command is only available to group administrators.";
+    private const string ExecutedSentinel = "EXECUTED";
+
+    // Keyed under the real "ban" command name; MinPermissionLevel = Admin
+    private sealed class StubBanCommand : IBotCommand
+    {
+        public string Name => "ban";
+        public string Description => "Stub ban command";
+        public string Usage => "/ban";
+        public PermissionLevel MinPermissionLevel => PermissionLevel.Admin;
+        public bool RequiresReply => false;
+        public bool DeleteCommandMessage => false;
+        public int? DeleteResponseAfterSeconds => null;
+
+        public bool WasExecuted { get; private set; }
+
+        public Task<CommandResult> ExecuteAsync(
+            Message message,
+            string[] args,
+            PermissionLevel userPermission,
+            CancellationToken cancellationToken = default)
+        {
+            WasExecuted = true;
+            return Task.FromResult(new CommandResult(TelegramMessage.Plain(ExecutedSentinel), false));
+        }
+    }
+
+    private static readonly Message BanMessage = new()
+    {
+        Text = "/ban",
+        From = new User { Id = 123 },
+        Chat = new Chat { Id = -1001 }
+    };
+
+    private static (CommandRouter router, StubBanCommand stub, ITelegramUserMappingRepository mappingRepo, IChatAdminsRepository chatAdminsRepo)
+        BuildRouter()
+    {
+        var stub = new StubBanCommand();
+        var mappingRepo = Substitute.For<ITelegramUserMappingRepository>();
+        var chatAdminsRepo = Substitute.For<IChatAdminsRepository>();
+
+        var services = new ServiceCollection();
+
+        // Register the stub as the keyed "ban" command
+        services.AddKeyedScoped<IBotCommand>(CommandNames.Ban, (_, _) => stub);
+
+        // Register all other commands as minimal stubs (CommandRouter.GetAvailableCommands
+        // iterates CommandNames.All; we need every name registered to avoid exceptions)
+        foreach (var name in CommandNames.All.Where(n => n != CommandNames.Ban))
+        {
+            var otherName = name; // capture
+            services.AddKeyedScoped<IBotCommand>(otherName, (_, _) => new MinimalStub(otherName));
+        }
+
+        // Register repositories as scoped so CreateScope() resolves the substitutes
+        services.AddScoped(_ => mappingRepo);
+        services.AddScoped(_ => chatAdminsRepo);
+
+        var provider = services.BuildServiceProvider();
+        var router = new CommandRouter(
+            NullLogger<CommandRouter>.Instance,
+            provider,
+            new PipelineMetrics());
+
+        return (router, stub, mappingRepo, chatAdminsRepo);
+    }
+
+    /// <summary>Minimal do-nothing command for names other than "ban".</summary>
+    private sealed class MinimalStub(string name) : IBotCommand
+    {
+        public string Name => name;
+        public string Description => string.Empty;
+        public string Usage => $"/{name}";
+        public PermissionLevel MinPermissionLevel => PermissionLevel.Member;
+        public bool RequiresReply => false;
+        public bool DeleteCommandMessage => false;
+        public int? DeleteResponseAfterSeconds => null;
+
+        public Task<CommandResult> ExecuteAsync(Message message, string[] args, PermissionLevel userPermission, CancellationToken cancellationToken = default)
+            => Task.FromResult(new CommandResult(TelegramMessage.Plain("other"), false));
+    }
+
+    [Test]
+    public async Task Member_Denied_WhenBelowAdmin()
+    {
+        // Arrange: no web tier, not a chat admin → effective Member → below Admin
+        var (router, stub, mappingRepo, chatAdminsRepo) = BuildRouter();
+        mappingRepo.GetPermissionLevelByTelegramIdAsync(123L, Arg.Any<CancellationToken>())
+                   .Returns((PermissionLevel?)null);
+        chatAdminsRepo.IsAdminAsync(-1001L, 123L, Arg.Any<CancellationToken>())
+                      .Returns(false);
+
+        // Act
+        var result = await router.RouteCommandAsync(BanMessage);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Message.Text, Does.Contain(DenialMessage));
+        Assert.That(stub.WasExecuted, Is.False, "Command must not execute when permission denied");
+    }
+
+    [Test]
+    public async Task NativeChatAdmin_Allowed()
+    {
+        // Arrange: no web tier, IS a chat admin → effective Admin ≥ Admin
+        var (router, stub, mappingRepo, chatAdminsRepo) = BuildRouter();
+        mappingRepo.GetPermissionLevelByTelegramIdAsync(123L, Arg.Any<CancellationToken>())
+                   .Returns((PermissionLevel?)null);
+        chatAdminsRepo.IsAdminAsync(-1001L, 123L, Arg.Any<CancellationToken>())
+                      .Returns(true);
+
+        // Act
+        var result = await router.RouteCommandAsync(BanMessage);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Message.Text, Is.EqualTo(ExecutedSentinel));
+        Assert.That(stub.WasExecuted, Is.True, "Command must execute for native chat admin");
+    }
+
+    [Test]
+    public async Task WebAdmin_InChatTheyDontAdminister_IsDenied()
+    {
+        // Arrange: web tier = Admin, NOT a chat admin in this chat → effective Member → denied.
+        // This is the canonical chat-scoping rule: web Admin only counts where they're also
+        // a Telegram admin/creator in the specific chat.
+        var (router, stub, mappingRepo, chatAdminsRepo) = BuildRouter();
+        mappingRepo.GetPermissionLevelByTelegramIdAsync(123L, Arg.Any<CancellationToken>())
+                   .Returns(PermissionLevel.Admin);
+        chatAdminsRepo.IsAdminAsync(-1001L, 123L, Arg.Any<CancellationToken>())
+                      .Returns(false);
+
+        // Act
+        var result = await router.RouteCommandAsync(BanMessage);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Message.Text, Does.Contain(DenialMessage));
+        Assert.That(stub.WasExecuted, Is.False, "Web Admin without chat admin status must be denied");
+    }
+
+    [Test]
+    public async Task GlobalAdmin_Allowed_Anywhere()
+    {
+        // Arrange: GlobalAdmin bypasses chat-admin requirement → effective GlobalAdmin ≥ Admin
+        var (router, stub, mappingRepo, chatAdminsRepo) = BuildRouter();
+        mappingRepo.GetPermissionLevelByTelegramIdAsync(123L, Arg.Any<CancellationToken>())
+                   .Returns(PermissionLevel.GlobalAdmin);
+        chatAdminsRepo.IsAdminAsync(-1001L, 123L, Arg.Any<CancellationToken>())
+                      .Returns(false);
+
+        // Act
+        var result = await router.RouteCommandAsync(BanMessage);
+
+        // Assert
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Message.Text, Is.EqualTo(ExecutedSentinel));
+        Assert.That(stub.WasExecuted, Is.True, "GlobalAdmin must execute in any chat");
+    }
+}

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/Commands/HelpCommandTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/Commands/HelpCommandTests.cs
@@ -1,0 +1,48 @@
+using Telegram.Bot.Types;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Services.BotCommands.Commands;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services.BotCommands.Commands;
+
+[TestFixture]
+public class HelpCommandTests
+{
+    private HelpCommand _command = null!;
+    private Message _message = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _command = new HelpCommand();
+        _message = new Message { Text = "/help" };
+    }
+
+    [Test]
+    public async Task Help_Footer_ShowsAdmin_ForAdminTier()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Admin);
+        Assert.That(result.Message.Text, Does.Contain("Permission: Admin"));
+        Assert.That(result.Message.Text, Does.Not.Contain("Permission: GlobalAdmin"));
+    }
+
+    [Test]
+    public async Task Help_Footer_ShowsMember_ForMemberTier()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Member);
+        Assert.That(result.Message.Text, Does.Contain("Permission: Member"));
+    }
+
+    [Test]
+    public async Task Help_HidesAdminCommandsSection_ForMember()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Member);
+        Assert.That(result.Message.Text, Does.Not.Contain("Admin Commands:"));
+    }
+
+    [Test]
+    public async Task Help_ShowsAdminCommandsSection_ForAdmin()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Admin);
+        Assert.That(result.Message.Text, Does.Contain("Admin Commands:"));
+    }
+}

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/Commands/HelpCommandTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/Commands/HelpCommandTests.cs
@@ -1,5 +1,8 @@
+using Microsoft.Extensions.DependencyInjection;
 using Telegram.Bot.Types;
 using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Core.Utilities;
+using TelegramGroupsAdmin.Telegram.Services.BotCommands;
 using TelegramGroupsAdmin.Telegram.Services.BotCommands.Commands;
 
 namespace TelegramGroupsAdmin.UnitTests.Telegram.Services.BotCommands.Commands;
@@ -10,10 +13,56 @@ public class HelpCommandTests
     private HelpCommand _command = null!;
     private Message _message = null!;
 
+    /// <summary>
+    /// Minimal stub implementing IBotCommand with configurable properties.
+    /// </summary>
+    private sealed class StubCommand : IBotCommand
+    {
+        public required string Name { get; init; }
+        public required string Description { get; init; }
+        public required PermissionLevel MinPermissionLevel { get; init; }
+        public string Usage => $"/{Name}";
+        public bool RequiresReply => false;
+        public bool DeleteCommandMessage => false;
+        public int? DeleteResponseAfterSeconds => null;
+
+        public Task<CommandResult> ExecuteAsync(
+            Message message,
+            string[] args,
+            PermissionLevel userPermission,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new CommandResult(TelegramMessage.Plain("stub"), false));
+    }
+
     [SetUp]
     public void SetUp()
     {
-        _command = new HelpCommand();
+        var services = new ServiceCollection();
+
+        // Public (Member-tier) commands
+        foreach (var name in new[] { "help", "start", "mystatus", "report", "link", "invite" })
+        {
+            services.AddKeyedScoped<IBotCommand>(name, (_, _) => new StubCommand
+            {
+                Name = name,
+                Description = $"{name} description",
+                MinPermissionLevel = PermissionLevel.Member
+            });
+        }
+
+        // Admin-tier (moderation) commands
+        foreach (var name in new[] { "ban", "delete", "spam", "mute", "tempban", "trust", "unban", "warn" })
+        {
+            services.AddKeyedScoped<IBotCommand>(name, (_, _) => new StubCommand
+            {
+                Name = name,
+                Description = $"{name} description",
+                MinPermissionLevel = PermissionLevel.Admin
+            });
+        }
+
+        var provider = services.BuildServiceProvider();
+        _command = new HelpCommand(provider);
         _message = new Message { Text = "/help" };
     }
 
@@ -44,5 +93,45 @@ public class HelpCommandTests
     {
         var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Admin);
         Assert.That(result.Message.Text, Does.Contain("Admin Commands:"));
+    }
+
+    [Test]
+    public async Task Help_Member_ListsPublicCommands_IncludingMyStatus()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Member);
+        Assert.That(result.Message.Text, Does.Contain("/mystatus"));
+        Assert.That(result.Message.Text, Does.Contain("/report"));
+        Assert.That(result.Message.Text, Does.Not.Contain("Admin Commands:"));
+    }
+
+    [Test]
+    public async Task Help_Admin_ListsModeration_IncludingMute()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Admin);
+        Assert.That(result.Message.Text, Does.Contain("Admin Commands:"));
+        Assert.That(result.Message.Text, Does.Contain("/mute"));
+        Assert.That(result.Message.Text, Does.Contain("/ban"));
+    }
+
+    [Test]
+    public async Task Help_Admin_ExcludesStart()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Admin);
+        Assert.That(result.Message.Text, Does.Not.Contain("/start"));
+    }
+
+    [Test]
+    public async Task Help_Member_ExcludesStart()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Member);
+        Assert.That(result.Message.Text, Does.Not.Contain("/start"));
+    }
+
+    [Test]
+    public async Task Help_GlobalAdmin_SeesAdminSection()
+    {
+        var result = await _command.ExecuteAsync(_message, [], PermissionLevel.GlobalAdmin);
+        Assert.That(result.Message.Text, Does.Contain("Admin Commands:"));
+        Assert.That(result.Message.Text, Does.Contain("Permission: GlobalAdmin"));
     }
 }

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/Commands/ReportCommandTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/Commands/ReportCommandTests.cs
@@ -111,7 +111,7 @@ public class ReportCommandTests
             .Returns(new ReportCreationResult(ReportId: 7));
 
         // Act
-        var result = await _command.ExecuteAsync(message, [], userPermissionLevel: 0);
+        var result = await _command.ExecuteAsync(message, [], userPermission: PermissionLevel.Admin);
 
         // Assert: text contains the report number
         Assert.That(result.Message.Text, Does.Contain("Report #7"));

--- a/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/PermissionResolverTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/PermissionResolverTests.cs
@@ -1,0 +1,22 @@
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Services.BotCommands;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services.BotCommands;
+
+[TestFixture]
+public class PermissionResolverTests
+{
+    // webTier, isChatAdminOrCreator -> effective
+    [TestCase(null, false, PermissionLevel.Member)]                       // unknown user
+    [TestCase(null, true, PermissionLevel.Admin)]                        // native TG admin/creator
+    [TestCase(PermissionLevel.Admin, false, PermissionLevel.Member)]     // web Admin in a chat they don't administer
+    [TestCase(PermissionLevel.Admin, true, PermissionLevel.Admin)]       // web Admin who is also a chat admin
+    [TestCase(PermissionLevel.GlobalAdmin, false, PermissionLevel.GlobalAdmin)] // global, any chat
+    [TestCase(PermissionLevel.GlobalAdmin, true, PermissionLevel.GlobalAdmin)]
+    [TestCase(PermissionLevel.Owner, false, PermissionLevel.Owner)]      // global, any chat
+    [TestCase(PermissionLevel.Owner, true, PermissionLevel.Owner)]
+    public void Resolve_MatchesCanonicalModel(PermissionLevel? webTier, bool isChatAdmin, PermissionLevel expected)
+    {
+        Assert.That(PermissionResolver.Resolve(webTier, isChatAdmin), Is.EqualTo(expected));
+    }
+}

--- a/TelegramGroupsAdmin/Components/Layout/NavMenu.razor
+++ b/TelegramGroupsAdmin/Components/Layout/NavMenu.razor
@@ -52,7 +52,7 @@
             {
                 // Admin=0, GlobalAdmin=1, Owner=2
                 // GlobalAdmin and Owner can see Settings, Audit, Chat Management
-                _isGlobalAdminOrOwner = level >= 1;
+                _isGlobalAdminOrOwner = (PermissionLevel)level >= PermissionLevel.GlobalAdmin;
             }
         }
     }

--- a/TelegramGroupsAdmin/Components/Layout/NavMenu.razor
+++ b/TelegramGroupsAdmin/Components/Layout/NavMenu.razor
@@ -50,7 +50,7 @@
             var permissionClaim = user.FindFirst(CustomClaimTypes.PermissionLevel);
             if (permissionClaim != null && int.TryParse(permissionClaim.Value, out var level))
             {
-                // Admin=0, GlobalAdmin=1, Owner=2
+                // Member=-1, Admin=0, GlobalAdmin=1, Owner=2
                 // GlobalAdmin and Owner can see Settings, Audit, Chat Management
                 _isGlobalAdminOrOwner = (PermissionLevel)level >= PermissionLevel.GlobalAdmin;
             }

--- a/TelegramGroupsAdmin/Components/Pages/Analytics.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Analytics.razor
@@ -12,29 +12,32 @@
     <MudText Typo="Typo.body1" Class="mb-4">Deep-dive statistics and trends across all managed chats</MudText>
 
     <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6" ActivePanelIndex="_activeTabIndex" ActivePanelIndexChanged="OnTabChanged">
-        @if (_canSeeGlobalAnalytics)
-        {
-            <MudTabPanel Text="Content Detection" Icon="@Icons.Material.Filled.Shield">
+        <MudTabPanel Text="Content Detection" Icon="@Icons.Material.Filled.Shield" Disabled="@(!_canSeeGlobalAnalytics)">
+            @if (_canSeeGlobalAnalytics)
+            {
                 <ContentDetectionAnalytics />
-            </MudTabPanel>
-        }
+            }
+        </MudTabPanel>
 
         <MudTabPanel Text="Message Trends" Icon="@Icons.Material.Filled.TrendingUp">
             <MessageTrends />
         </MudTabPanel>
 
-        @if (_canSeeGlobalAnalytics)
-        {
-            <MudTabPanel Text="Performance" Icon="@Icons.Material.Filled.Speed">
+        <MudTabPanel Text="Performance" Icon="@Icons.Material.Filled.Speed" Disabled="@(!_canSeeGlobalAnalytics)">
+            @if (_canSeeGlobalAnalytics)
+            {
                 <MudAlert Severity="Severity.Info" Class="mb-4">Performance metrics show global statistics across all chats to evaluate overall spam detection effectiveness.</MudAlert>
                 <PerformanceMetrics />
-            </MudTabPanel>
+            }
+        </MudTabPanel>
 
-            <MudTabPanel Text="Welcome Analytics" Icon="@Icons.Material.Filled.People">
+        <MudTabPanel Text="Welcome Analytics" Icon="@Icons.Material.Filled.People" Disabled="@(!_canSeeGlobalAnalytics)">
+            @if (_canSeeGlobalAnalytics)
+            {
                 <MudAlert Severity="Severity.Info" Class="mb-4">Welcome system metrics track user onboarding success rates, join trends, and per-chat performance.</MudAlert>
                 <WelcomeAnalytics />
-            </MudTabPanel>
-        }
+            }
+        </MudTabPanel>
     </MudTabs>
 </MudContainer>
 
@@ -52,6 +55,10 @@
         var fragment = new Uri(Navigation.Uri).Fragment.TrimStart('#');
         _activeTabIndex = FragmentToIndex(fragment);
 
+        // Admin can only use Message Trends (index 1); disabled tabs must not be active
+        if (!_canSeeGlobalAnalytics && _activeTabIndex != 1)
+            _activeTabIndex = 1;
+
         Navigation.LocationChanged += OnLocationChanged;
     }
 
@@ -59,6 +66,10 @@
     {
         var fragment = new Uri(e.Location).Fragment.TrimStart('#');
         var newIndex = FragmentToIndex(fragment);
+
+        // Admin must stay on Message Trends regardless of fragment
+        if (!_canSeeGlobalAnalytics && newIndex != 1)
+            newIndex = 1;
 
         if (newIndex != _activeTabIndex)
         {
@@ -73,36 +84,23 @@
         Navigation.NavigateTo($"/analytics#{IndexToFragment(index)}", false);
     }
 
-    // For Admin only Message Trends renders (index 0). For GlobalAdmin+ all four render in declared order.
-    private int FragmentToIndex(string fragment)
+    private int FragmentToIndex(string fragment) => fragment switch
     {
-        if (!_canSeeGlobalAnalytics)
-            return 0; // Only Message Trends is visible
+        "detection" => 0,
+        "trends" => 1,
+        "performance" => 2,
+        "welcome" => 3,
+        _ => 0
+    };
 
-        return fragment switch
-        {
-            "detection" or "spam" => 0,  // Support both for backwards compatibility
-            "trends" => 1,
-            "performance" => 2,
-            "welcome" => 3,
-            _ => 0
-        };
-    }
-
-    private string IndexToFragment(int index)
+    private string IndexToFragment(int index) => index switch
     {
-        if (!_canSeeGlobalAnalytics)
-            return "trends"; // Only Message Trends is visible
-
-        return index switch
-        {
-            0 => "detection",
-            1 => "trends",
-            2 => "performance",
-            3 => "welcome",
-            _ => "detection"
-        };
-    }
+        0 => "detection",
+        1 => "trends",
+        2 => "performance",
+        3 => "welcome",
+        _ => "detection"
+    };
 
     public void Dispose()
     {

--- a/TelegramGroupsAdmin/Components/Pages/Analytics.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Analytics.razor
@@ -12,41 +12,45 @@
     <MudText Typo="Typo.body1" Class="mb-4">Deep-dive statistics and trends across all managed chats</MudText>
 
     <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" TabPanelsClass="pa-6" ActivePanelIndex="_activeTabIndex" ActivePanelIndexChanged="OnTabChanged">
-        <MudTabPanel Text="Content Detection" Icon="@Icons.Material.Filled.Shield">
-            <ContentDetectionAnalytics />
-        </MudTabPanel>
+        @if (_canSeeGlobalAnalytics)
+        {
+            <MudTabPanel Text="Content Detection" Icon="@Icons.Material.Filled.Shield">
+                <ContentDetectionAnalytics />
+            </MudTabPanel>
+        }
 
         <MudTabPanel Text="Message Trends" Icon="@Icons.Material.Filled.TrendingUp">
             <MessageTrends />
         </MudTabPanel>
 
-        <MudTabPanel Text="Performance" Icon="@Icons.Material.Filled.Speed">
-            <MudAlert Severity="Severity.Info" Class="mb-4">Performance metrics show global statistics across all chats to evaluate overall spam detection effectiveness.</MudAlert>
-            <PerformanceMetrics />
-        </MudTabPanel>
+        @if (_canSeeGlobalAnalytics)
+        {
+            <MudTabPanel Text="Performance" Icon="@Icons.Material.Filled.Speed">
+                <MudAlert Severity="Severity.Info" Class="mb-4">Performance metrics show global statistics across all chats to evaluate overall spam detection effectiveness.</MudAlert>
+                <PerformanceMetrics />
+            </MudTabPanel>
 
-        <MudTabPanel Text="Welcome Analytics" Icon="@Icons.Material.Filled.People">
-            <MudAlert Severity="Severity.Info" Class="mb-4">Welcome system metrics track user onboarding success rates, join trends, and per-chat performance.</MudAlert>
-            <WelcomeAnalytics />
-        </MudTabPanel>
+            <MudTabPanel Text="Welcome Analytics" Icon="@Icons.Material.Filled.People">
+                <MudAlert Severity="Severity.Info" Class="mb-4">Welcome system metrics track user onboarding success rates, join trends, and per-chat performance.</MudAlert>
+                <WelcomeAnalytics />
+            </MudTabPanel>
+        }
     </MudTabs>
 </MudContainer>
 
 @code {
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+
     private int _activeTabIndex;
+    private bool _canSeeGlobalAnalytics;
 
     protected override void OnInitialized()
     {
+        _canSeeGlobalAnalytics = WebUser?.IsGlobalAdminOrHigher ?? false;
+
         // Parse URL fragment for tab selection
         var fragment = new Uri(Navigation.Uri).Fragment.TrimStart('#');
-        _activeTabIndex = fragment switch
-        {
-            "detection" or "spam" => 0,  // Support both for backwards compatibility
-            "trends" => 1,
-            "performance" => 2,
-            "welcome" => 3,
-            _ => 0
-        };
+        _activeTabIndex = FragmentToIndex(fragment);
 
         Navigation.LocationChanged += OnLocationChanged;
     }
@@ -54,14 +58,7 @@
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
         var fragment = new Uri(e.Location).Fragment.TrimStart('#');
-        var newIndex = fragment switch
-        {
-            "detection" or "spam" => 0,  // Support both for backwards compatibility
-            "trends" => 1,
-            "performance" => 2,
-            "welcome" => 3,
-            _ => 0
-        };
+        var newIndex = FragmentToIndex(fragment);
 
         if (newIndex != _activeTabIndex)
         {
@@ -73,8 +70,31 @@
     private void OnTabChanged(int index)
     {
         _activeTabIndex = index;
+        Navigation.NavigateTo($"/analytics#{IndexToFragment(index)}", false);
+    }
 
-        var fragment = index switch
+    // For Admin only Message Trends renders (index 0). For GlobalAdmin+ all four render in declared order.
+    private int FragmentToIndex(string fragment)
+    {
+        if (!_canSeeGlobalAnalytics)
+            return 0; // Only Message Trends is visible
+
+        return fragment switch
+        {
+            "detection" or "spam" => 0,  // Support both for backwards compatibility
+            "trends" => 1,
+            "performance" => 2,
+            "welcome" => 3,
+            _ => 0
+        };
+    }
+
+    private string IndexToFragment(int index)
+    {
+        if (!_canSeeGlobalAnalytics)
+            return "trends"; // Only Message Trends is visible
+
+        return index switch
         {
             0 => "detection",
             1 => "trends",
@@ -82,8 +102,6 @@
             3 => "welcome",
             _ => "detection"
         };
-
-        Navigation.NavigateTo($"/analytics#{fragment}", false);
     }
 
     public void Dispose()

--- a/TelegramGroupsAdmin/Components/Pages/Audit.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Audit.razor
@@ -8,7 +8,7 @@
 @inject ITelegramUserRepository TelegramUserRepository
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation
-@attribute [Authorize(Roles = "GlobalAdmin,Owner")]
+@attribute [Authorize(Policy = AuthenticationConstants.PolicyGlobalAdminOrOwner)]
 @implements IDisposable
 
 <PageTitle>Audit Log - TelegramGroupsAdmin</PageTitle>

--- a/TelegramGroupsAdmin/Components/Pages/Home.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Home.razor
@@ -35,43 +35,88 @@
         <MudPaper Class="pa-4 mb-4" Elevation="2">
             <MudText Typo="Typo.h6" Class="mb-3">Overview</MudText>
             <MudGrid>
-                @* Row 1: Core message stats — GlobalAdmin/Owner only *@
-                @if (_canSeeGlobalStats && _stats != null)
-                {
-                    <MudItem xs="12" sm="6" md="3">
+                @* Row 1: Core message stats — GlobalAdmin/Owner only; greyed shell for Admin *@
+                <MudItem xs="12" sm="6" md="3">
+                    @if (_canSeeGlobalStats && _stats != null)
+                    {
                         <MudStack AlignItems="AlignItems.Center">
                             <MudIcon Icon="@Icons.Material.Filled.Message" Size="Size.Large" Color="Color.Primary" />
                             <MudText Typo="Typo.h5">@_stats.TotalMessages</MudText>
                             <MudText Typo="Typo.caption" Color="Color.Secondary">Total Messages</MudText>
                         </MudStack>
-                    </MudItem>
-                    <MudItem xs="12" sm="6" md="3">
+                    }
+                    else
+                    {
+                        <MudStack AlignItems="AlignItems.Center" Style="opacity:0.45">
+                            <MudIcon Icon="@Icons.Material.Filled.Message" Size="Size.Large" Color="Color.Default" />
+                            <MudIcon Icon="@Icons.Material.Filled.Lock" Size="Size.Small" Color="Color.Default" />
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Total Messages</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">GlobalAdmin only</MudText>
+                        </MudStack>
+                    }
+                </MudItem>
+                <MudItem xs="12" sm="6" md="3">
+                    @if (_canSeeGlobalStats && _stats != null)
+                    {
                         <MudStack AlignItems="AlignItems.Center">
                             <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Large" Color="Color.Secondary" />
                             <MudText Typo="Typo.h5">@_stats.UniqueUsers</MudText>
                             <MudText Typo="Typo.caption" Color="Color.Secondary">Unique Users</MudText>
                         </MudStack>
-                    </MudItem>
-                    <MudItem xs="12" sm="6" md="3">
+                    }
+                    else
+                    {
+                        <MudStack AlignItems="AlignItems.Center" Style="opacity:0.45">
+                            <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Large" Color="Color.Default" />
+                            <MudIcon Icon="@Icons.Material.Filled.Lock" Size="Size.Small" Color="Color.Default" />
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Unique Users</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">GlobalAdmin only</MudText>
+                        </MudStack>
+                    }
+                </MudItem>
+                <MudItem xs="12" sm="6" md="3">
+                    @if (_canSeeGlobalStats && _stats != null)
+                    {
                         <MudStack AlignItems="AlignItems.Center">
                             <MudIcon Icon="@Icons.Material.Filled.Image" Size="Size.Large" Color="Color.Info" />
                             <MudText Typo="Typo.h5">@_stats.PhotoCount</MudText>
                             <MudText Typo="Typo.caption" Color="Color.Secondary">Images</MudText>
                         </MudStack>
-                    </MudItem>
-                    <MudItem xs="12" sm="6" md="3">
+                    }
+                    else
+                    {
+                        <MudStack AlignItems="AlignItems.Center" Style="opacity:0.45">
+                            <MudIcon Icon="@Icons.Material.Filled.Image" Size="Size.Large" Color="Color.Default" />
+                            <MudIcon Icon="@Icons.Material.Filled.Lock" Size="Size.Small" Color="Color.Default" />
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Images</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">GlobalAdmin only</MudText>
+                        </MudStack>
+                    }
+                </MudItem>
+                <MudItem xs="12" sm="6" md="3">
+                    @if (_canSeeGlobalStats && _stats != null)
+                    {
                         <MudStack AlignItems="AlignItems.Center">
                             <MudIcon Icon="@Icons.Material.Filled.Update" Size="Size.Large" Color="Color.Tertiary" />
                             <MudText Typo="Typo.h5">@GetTimeRangeDisplay()</MudText>
                             <MudText Typo="Typo.caption" Color="Color.Secondary">Data Range</MudText>
                         </MudStack>
-                    </MudItem>
-                }
+                    }
+                    else
+                    {
+                        <MudStack AlignItems="AlignItems.Center" Style="opacity:0.45">
+                            <MudIcon Icon="@Icons.Material.Filled.Update" Size="Size.Large" Color="Color.Default" />
+                            <MudIcon Icon="@Icons.Material.Filled.Lock" Size="Size.Small" Color="Color.Default" />
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Data Range</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">GlobalAdmin only</MudText>
+                        </MudStack>
+                    }
+                </MudItem>
 
-                @* Row 2: Detection and moderation stats *@
-                @if (_canSeeGlobalStats)
-                {
-                    <MudItem xs="12" sm="6" md="3">
+                @* Row 2: Detection and moderation stats — Spam Today greyed for Admin *@
+                <MudItem xs="12" sm="6" md="3">
+                    @if (_canSeeGlobalStats)
+                    {
                         <MudStack AlignItems="AlignItems.Center">
                             <MudIcon Icon="@Icons.Material.Filled.Warning" Size="Size.Large" Color="Color.Error" />
                             <MudText Typo="Typo.h5">@(_dailySpamSummary?.TodaySpamCount ?? 0)</MudText>
@@ -101,8 +146,17 @@
                             }
                             <MudText Typo="Typo.caption" Color="Color.Secondary">Spam Today</MudText>
                         </MudStack>
-                    </MudItem>
-                }
+                    }
+                    else
+                    {
+                        <MudStack AlignItems="AlignItems.Center" Style="opacity:0.45">
+                            <MudIcon Icon="@Icons.Material.Filled.Warning" Size="Size.Large" Color="Color.Default" />
+                            <MudIcon Icon="@Icons.Material.Filled.Lock" Size="Size.Small" Color="Color.Default" />
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Spam Today</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">GlobalAdmin only</MudText>
+                        </MudStack>
+                    }
+                </MudItem>
                 <MudItem xs="12" sm="6" md="3">
                     <MudStack AlignItems="AlignItems.Center">
                         <MudIcon Icon="@Icons.Material.Filled.Block" Size="Size.Large" Color="Color.Error" />
@@ -171,11 +225,11 @@
             </MudPaper>
         </MudItem>
 
-        @if (_canSeeGlobalStats)
-        {
-            <MudItem xs="12" md="6">
-                <MudPaper Class="pa-4 mb-4" Elevation="2" Style="height: 100%;">
-                    <MudText Typo="Typo.h6" Class="mb-3">Recent Activity</MudText>
+        <MudItem xs="12" md="6">
+            <MudPaper Class="pa-4 mb-4" Elevation="2" Style="height: 100%;">
+                <MudText Typo="Typo.h6" Class="mb-3">Recent Activity</MudText>
+                @if (_canSeeGlobalStats)
+                {
                     @if (_recentActions == null || _recentActions.Count == 0)
                     {
                         <MudText Typo="Typo.body2" Color="Color.Secondary">No recent moderation activity</MudText>
@@ -205,9 +259,16 @@
                             </MudLink>
                         }
                     }
-                </MudPaper>
-            </MudItem>
-        }
+                }
+                else
+                {
+                    <MudStack AlignItems="AlignItems.Center" Class="py-4" Style="opacity:0.45">
+                        <MudIcon Icon="@Icons.Material.Filled.Lock" Size="Size.Large" Color="Color.Default" />
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">Requires GlobalAdmin to view</MudText>
+                    </MudStack>
+                }
+            </MudPaper>
+        </MudItem>
     </MudGrid>
 
     @if (_stats is { TotalMessages: 0 })

--- a/TelegramGroupsAdmin/Components/Pages/Home.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Home.razor
@@ -3,6 +3,7 @@
 @using TelegramGroupsAdmin.Core.Repositories
 @using TelegramGroupsAdmin.Telegram.Models
 @using TelegramGroupsAdmin.Telegram.Services
+@using TelegramGroupsAdmin.Telegram.Repositories
 @using TelegramGroupsAdmin.Core.Utilities
 @using TelegramGroupsAdmin.Models.Analytics
 @using TelegramGroupsAdmin.Repositories
@@ -12,6 +13,7 @@
 @inject IReportsRepository ReportsRepository
 @inject IUserActionsRepository UserActionsRepository
 @inject ITelegramUserManagementService UserManagementService
+@inject IManagedChatsRepository ManagedChatsRepository
 @inject NavigationManager Navigation
 @inject ILogger<Home> Logger
 @attribute [Authorize]
@@ -27,73 +29,79 @@
     }
 
     @* Stats Summary *@
-    @if (_stats != null)
+    @if (!_loading)
     {
         <MudPaper Class="pa-4 mb-4" Elevation="2">
             <MudText Typo="Typo.h6" Class="mb-3">Overview</MudText>
             <MudGrid>
-                @* Row 1: Core message stats *@
-                <MudItem xs="12" sm="6" md="3">
-                    <MudStack AlignItems="AlignItems.Center">
-                        <MudIcon Icon="@Icons.Material.Filled.Message" Size="Size.Large" Color="Color.Primary" />
-                        <MudText Typo="Typo.h5">@_stats.TotalMessages</MudText>
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">Total Messages</MudText>
-                    </MudStack>
-                </MudItem>
-                <MudItem xs="12" sm="6" md="3">
-                    <MudStack AlignItems="AlignItems.Center">
-                        <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Large" Color="Color.Secondary" />
-                        <MudText Typo="Typo.h5">@_stats.UniqueUsers</MudText>
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">Unique Users</MudText>
-                    </MudStack>
-                </MudItem>
-                <MudItem xs="12" sm="6" md="3">
-                    <MudStack AlignItems="AlignItems.Center">
-                        <MudIcon Icon="@Icons.Material.Filled.Image" Size="Size.Large" Color="Color.Info" />
-                        <MudText Typo="Typo.h5">@_stats.PhotoCount</MudText>
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">Images</MudText>
-                    </MudStack>
-                </MudItem>
-                <MudItem xs="12" sm="6" md="3">
-                    <MudStack AlignItems="AlignItems.Center">
-                        <MudIcon Icon="@Icons.Material.Filled.Update" Size="Size.Large" Color="Color.Tertiary" />
-                        <MudText Typo="Typo.h5">@GetTimeRangeDisplay()</MudText>
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">Data Range</MudText>
-                    </MudStack>
-                </MudItem>
+                @* Row 1: Core message stats — GlobalAdmin/Owner only *@
+                @if (_canSeeGlobalStats && _stats != null)
+                {
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudStack AlignItems="AlignItems.Center">
+                            <MudIcon Icon="@Icons.Material.Filled.Message" Size="Size.Large" Color="Color.Primary" />
+                            <MudText Typo="Typo.h5">@_stats.TotalMessages</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Total Messages</MudText>
+                        </MudStack>
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudStack AlignItems="AlignItems.Center">
+                            <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Large" Color="Color.Secondary" />
+                            <MudText Typo="Typo.h5">@_stats.UniqueUsers</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Unique Users</MudText>
+                        </MudStack>
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudStack AlignItems="AlignItems.Center">
+                            <MudIcon Icon="@Icons.Material.Filled.Image" Size="Size.Large" Color="Color.Info" />
+                            <MudText Typo="Typo.h5">@_stats.PhotoCount</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Images</MudText>
+                        </MudStack>
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudStack AlignItems="AlignItems.Center">
+                            <MudIcon Icon="@Icons.Material.Filled.Update" Size="Size.Large" Color="Color.Tertiary" />
+                            <MudText Typo="Typo.h5">@GetTimeRangeDisplay()</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Data Range</MudText>
+                        </MudStack>
+                    </MudItem>
+                }
 
                 @* Row 2: Detection and moderation stats *@
-                <MudItem xs="12" sm="6" md="3">
-                    <MudStack AlignItems="AlignItems.Center">
-                        <MudIcon Icon="@Icons.Material.Filled.Warning" Size="Size.Large" Color="Color.Error" />
-                        <MudText Typo="Typo.h5">@(_dailySpamSummary?.TodaySpamCount ?? 0)</MudText>
-                        @if (_dailySpamSummary?.HasYesterdayData == true)
-                        {
-                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                @if (_dailySpamSummary.IsImproving)
-                                {
-                                    <MudIcon Icon="@Icons.Material.Filled.TrendingDown" Size="Size.Small" Color="Color.Success" />
-                                    <MudText Typo="Typo.caption" Color="Color.Success">
-                                        @Math.Abs(_dailySpamSummary.SpamCountChange!.Value) less
-                                    </MudText>
-                                }
-                                else if (_dailySpamSummary.IsWorsening)
-                                {
-                                    <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Small" Color="Color.Error" />
-                                    <MudText Typo="Typo.caption" Color="Color.Error">
-                                        @_dailySpamSummary.SpamCountChange!.Value more
-                                    </MudText>
-                                }
-                                else
-                                {
-                                    <MudIcon Icon="@Icons.Material.Filled.TrendingFlat" Size="Size.Small" Color="Color.Default" />
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">same</MudText>
-                                }
-                            </MudStack>
-                        }
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">Spam Today</MudText>
-                    </MudStack>
-                </MudItem>
+                @if (_canSeeGlobalStats)
+                {
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudStack AlignItems="AlignItems.Center">
+                            <MudIcon Icon="@Icons.Material.Filled.Warning" Size="Size.Large" Color="Color.Error" />
+                            <MudText Typo="Typo.h5">@(_dailySpamSummary?.TodaySpamCount ?? 0)</MudText>
+                            @if (_dailySpamSummary?.HasYesterdayData == true)
+                            {
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                                    @if (_dailySpamSummary.IsImproving)
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.TrendingDown" Size="Size.Small" Color="Color.Success" />
+                                        <MudText Typo="Typo.caption" Color="Color.Success">
+                                            @Math.Abs(_dailySpamSummary.SpamCountChange!.Value) less
+                                        </MudText>
+                                    }
+                                    else if (_dailySpamSummary.IsWorsening)
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Small" Color="Color.Error" />
+                                        <MudText Typo="Typo.caption" Color="Color.Error">
+                                            @_dailySpamSummary.SpamCountChange!.Value more
+                                        </MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudIcon Icon="@Icons.Material.Filled.TrendingFlat" Size="Size.Small" Color="Color.Default" />
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">same</MudText>
+                                    }
+                                </MudStack>
+                            }
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Spam Today</MudText>
+                        </MudStack>
+                    </MudItem>
+                }
                 <MudItem xs="12" sm="6" md="3">
                     <MudStack AlignItems="AlignItems.Center">
                         <MudIcon Icon="@Icons.Material.Filled.Block" Size="Size.Large" Color="Color.Error" />
@@ -162,40 +170,43 @@
             </MudPaper>
         </MudItem>
 
-        <MudItem xs="12" md="6">
-            <MudPaper Class="pa-4 mb-4" Elevation="2" Style="height: 100%;">
-                <MudText Typo="Typo.h6" Class="mb-3">Recent Activity</MudText>
-                @if (_recentActions == null || _recentActions.Count == 0)
-                {
-                    <MudText Typo="Typo.body2" Color="Color.Secondary">No recent moderation activity</MudText>
-                }
-                else
-                {
-                    <MudList T="UserActionRecord" Dense="true">
-                        @foreach (var action in _recentActions.Take(5))
-                        {
-                            <MudListItem Icon="@GetActionIcon(action.ActionType)"
-                                         IconColor="@GetActionColor(action.ActionType)">
-                                <MudStack Spacing="0">
-                                    <MudText Typo="Typo.body2">
-                                        <strong>@action.ActionType</strong> @action.TargetDisplayName
-                                    </MudText>
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        @DateTimeUtilities.FormatRelativeTimeCompact(action.IssuedAt) by @action.IssuedBy.DisplayName
-                                    </MudText>
-                                </MudStack>
-                            </MudListItem>
-                        }
-                    </MudList>
-                    @if (_recentActions.Count > 5)
+        @if (_canSeeGlobalStats)
+        {
+            <MudItem xs="12" md="6">
+                <MudPaper Class="pa-4 mb-4" Elevation="2" Style="height: 100%;">
+                    <MudText Typo="Typo.h6" Class="mb-3">Recent Activity</MudText>
+                    @if (_recentActions == null || _recentActions.Count == 0)
                     {
-                        <MudLink Href="/moderation" Typo="Typo.caption" Class="mt-2">
-                            View all @_recentActions.Count actions →
-                        </MudLink>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">No recent moderation activity</MudText>
                     }
-                }
-            </MudPaper>
-        </MudItem>
+                    else
+                    {
+                        <MudList T="UserActionRecord" Dense="true">
+                            @foreach (var action in _recentActions.Take(5))
+                            {
+                                <MudListItem Icon="@GetActionIcon(action.ActionType)"
+                                             IconColor="@GetActionColor(action.ActionType)">
+                                    <MudStack Spacing="0">
+                                        <MudText Typo="Typo.body2">
+                                            <strong>@action.ActionType</strong> @action.TargetDisplayName
+                                        </MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                            @DateTimeUtilities.FormatRelativeTimeCompact(action.IssuedAt) by @action.IssuedBy.DisplayName
+                                        </MudText>
+                                    </MudStack>
+                                </MudListItem>
+                            }
+                        </MudList>
+                        @if (_recentActions.Count > 5)
+                        {
+                            <MudLink Href="/moderation" Typo="Typo.caption" Class="mt-2">
+                                View all @_recentActions.Count actions →
+                            </MudLink>
+                        }
+                    }
+                </MudPaper>
+            </MudItem>
+        }
     </MudGrid>
 
     @if (_stats is { TotalMessages: 0 })
@@ -210,8 +221,12 @@
     private const int MaxRecentActivityItems = 10;
     private const string DefaultTimeZoneId = "America/New_York";
 
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+
+    private bool _canSeeGlobalStats;
+    private List<long> _accessibleChatIds = [];
+
     private HistoryStats? _stats;
-    private SpamSummaryStats? _detectionStats;
     private DailySpamSummary? _dailySpamSummary;
     private List<UserActionRecord>? _recentActions;
     private int _pendingReportsCount;
@@ -239,27 +254,39 @@
 
         try
         {
-            // Load all dashboard data in parallel for fast loading
-            var statsTask = MessageStatsService.GetStatsAsync();
-            var detectionStatsTask = MessageStatsService.GetDetectionStatsAsync();
-            var dailySpamTask = AnalyticsRepository.GetDailySpamSummaryAsync(DefaultTimeZoneId);
-            var pendingReportsTask = ReportsRepository.GetPendingCountAsync();
-            var recentActionsTask = UserActionsRepository.GetRecentAsync(MaxRecentActivityItems);
-            var tabCountsTask = UserManagementService.GetUserTabCountsAsync(chatIds: null, searchText: null);
+            _canSeeGlobalStats = WebUser?.IsGlobalAdminOrHigher ?? false;
+            _accessibleChatIds = _canSeeGlobalStats || WebUser is null
+                ? []
+                : (await ManagedChatsRepository.GetUserAccessibleChatsAsync(WebUser.Id, WebUser.PermissionLevel))
+                    .Select(c => c.Identity.Id)
+                    .ToList();
 
-            await Task.WhenAll(
-                statsTask,
-                detectionStatsTask,
-                dailySpamTask,
-                pendingReportsTask,
-                recentActionsTask,
-                tabCountsTask);
+            // Scoped widgets (always shown) — restricted to accessible chats for non-global viewers.
+            var pendingReportsTask = _canSeeGlobalStats
+                ? ReportsRepository.GetPendingCountAsync()
+                : ReportsRepository.GetPendingCountAsync(_accessibleChatIds);
+            var tabCountsTask = UserManagementService.GetUserTabCountsAsync(
+                chatIds: _canSeeGlobalStats ? null : _accessibleChatIds, searchText: null);
 
-            _stats = await statsTask;
-            _detectionStats = await detectionStatsTask;
-            _dailySpamSummary = await dailySpamTask;
+            if (_canSeeGlobalStats)
+            {
+                // Global widgets — GlobalAdmin/Owner only (hidden for Admin; proper per-chat scoping is #510).
+                var statsTask = MessageStatsService.GetStatsAsync();
+                var dailySpamTask = AnalyticsRepository.GetDailySpamSummaryAsync(DefaultTimeZoneId);
+                var recentActionsTask = UserActionsRepository.GetRecentAsync(MaxRecentActivityItems);
+
+                await Task.WhenAll(pendingReportsTask, tabCountsTask, statsTask, dailySpamTask, recentActionsTask);
+
+                _stats = await statsTask;
+                _dailySpamSummary = await dailySpamTask;
+                _recentActions = await recentActionsTask;
+            }
+            else
+            {
+                await Task.WhenAll(pendingReportsTask, tabCountsTask);
+            }
+
             _pendingReportsCount = await pendingReportsTask;
-            _recentActions = await recentActionsTask;
 
             var tabCounts = await tabCountsTask;
             _trustedUsersCount = tabCounts.TrustedCount;

--- a/TelegramGroupsAdmin/Components/Pages/Home.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Home.razor
@@ -4,6 +4,7 @@
 @using TelegramGroupsAdmin.Telegram.Models
 @using TelegramGroupsAdmin.Telegram.Services
 @using TelegramGroupsAdmin.Telegram.Repositories
+@using TelegramGroupsAdmin.Telegram.Constants
 @using TelegramGroupsAdmin.Core.Utilities
 @using TelegramGroupsAdmin.Models.Analytics
 @using TelegramGroupsAdmin.Repositories
@@ -262,11 +263,13 @@
                     .ToList();
 
             // Scoped widgets (always shown) — restricted to accessible chats for non-global viewers.
-            var pendingReportsTask = _canSeeGlobalStats
-                ? ReportsRepository.GetPendingCountAsync()
-                : ReportsRepository.GetPendingCountAsync(_accessibleChatIds);
-            var tabCountsTask = UserManagementService.GetUserTabCountsAsync(
-                chatIds: _canSeeGlobalStats ? null : _accessibleChatIds, searchText: null);
+            // GlobalAdmin/Owner ⇒ [GlobalChatId] means "no filter" (all pending). Admin ⇒ exact chat list
+            // (may be empty ⇒ 0 rows if the admin has no accessible chats yet).
+            var globalScope = new List<long> { ModerationConstants.GlobalChatId };
+            var scope = _canSeeGlobalStats ? globalScope : _accessibleChatIds;
+
+            var pendingReportsTask = ReportsRepository.GetPendingCountAsync(scope);
+            var tabCountsTask = UserManagementService.GetUserTabCountsAsync(scope, searchText: null);
 
             if (_canSeeGlobalStats)
             {

--- a/TelegramGroupsAdmin/Components/Pages/Login.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Login.razor
@@ -177,7 +177,7 @@
             {
                 new(ClaimTypes.NameIdentifier, result.UserId!),
                 new(ClaimTypes.Email, result.Email!),
-                new(ClaimTypes.Role, GetRoleName(result.PermissionLevel!.Value)),
+                new(ClaimTypes.Role, result.PermissionLevel!.Value.GetDisplayName()),
                 new(CustomClaimTypes.PermissionLevel, ((int)result.PermissionLevel.Value).ToString())
             };
 
@@ -204,14 +204,6 @@
             Logger.LogError(ex, "Unexpected error during login for email {Email}", Model.Email);
         }
     }
-
-    private static string GetRoleName(PermissionLevel permissionLevel) => permissionLevel switch
-    {
-        PermissionLevel.Admin => "Admin",
-        PermissionLevel.GlobalAdmin => "GlobalAdmin",
-        PermissionLevel.Owner => "Owner",
-        _ => "Admin"
-    };
 
     public class LoginModel
     {

--- a/TelegramGroupsAdmin/Components/Pages/NotificationDebug.razor
+++ b/TelegramGroupsAdmin/Components/Pages/NotificationDebug.razor
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using TelegramGroupsAdmin.Core.Models
 @using TelegramGroupsAdmin.Core.Services
-@attribute [Authorize(Policy = "OwnerOnly")]
+@attribute [Authorize(Policy = AuthenticationConstants.PolicyOwnerOnly)]
 
 @inject INotificationService NotificationService
 @inject IWebPushNotificationService WebPushService

--- a/TelegramGroupsAdmin/Components/Pages/Profile.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Profile.razor
@@ -348,7 +348,7 @@
 
             <!-- Notification Preferences -->
             <MudItem xs="12">
-                <NotificationPreferencesCard UserId="@_user.WebUser.Id" UserPermissionLevel="@_user.PermissionLevelInt" />
+                <NotificationPreferencesCard UserId="@_user.WebUser.Id" UserPermissionLevel="@_user.WebUser.PermissionLevel" />
             </MudItem>
         </MudGrid>
     }

--- a/TelegramGroupsAdmin/Components/Pages/Profile.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Profile.razor
@@ -34,7 +34,7 @@
                     <MudText Typo="Typo.h6" Class="mb-3">Account Information</MudText>
                     <MudStack Spacing="2">
                         <MudTextField Label="Email" Value="@_user.WebUser.Email" ReadOnly="true" Variant="Variant.Outlined" />
-                        <MudTextField Label="Permission Level" Value="@GetPermissionName(_user.PermissionLevelInt)" ReadOnly="true" Variant="Variant.Outlined" />
+                        <MudTextField Label="Permission Level" Value="@_user.WebUser.PermissionLevel.GetDisplayName()" ReadOnly="true" Variant="Variant.Outlined" />
                         <MudTextField Label="Account Created" Value="@FormatDate(_user.CreatedAt)" ReadOnly="true" Variant="Variant.Outlined" />
                         <MudTextField Label="Last Login" Value="@FormatDate(_user.LastLoginAt)" ReadOnly="true" Variant="Variant.Outlined" />
                     </MudStack>
@@ -783,14 +783,6 @@
         var base64 = Convert.ToBase64String(qrCodeBytes);
         return $"data:image/png;base64,{base64}";
     }
-
-    private static string GetPermissionName(int level) => level switch
-    {
-        0 => "Admin",
-        1 => "GlobalAdmin",
-        2 => "Owner",
-        _ => "Unknown"
-    };
 
     private static string FormatDate(DateTimeOffset? timestamp)
     {

--- a/TelegramGroupsAdmin/Components/Pages/Settings.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Settings.razor
@@ -1,6 +1,6 @@
 @page "/settings"
 @page "/settings/{Section?}/{SubSection?}"
-@attribute [Authorize(Policy = "GlobalAdminOrOwner")]
+@attribute [Authorize(Policy = AuthenticationConstants.PolicyGlobalAdminOrOwner)]
 @using TelegramGroupsAdmin.Components.Shared.ContentDetection
 @using TelegramGroupsAdmin.Components.Shared.Settings
 @using TelegramGroupsAdmin.Constants

--- a/TelegramGroupsAdmin/Components/Pages/Tools.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Tools.razor
@@ -1,5 +1,5 @@
 @page "/tools"
-@attribute [Authorize(Policy = "GlobalAdminOrOwner")]
+@attribute [Authorize(Policy = AuthenticationConstants.PolicyGlobalAdminOrOwner)]
 @using TelegramGroupsAdmin.Components.Shared.ContentDetection
 
 <PageTitle>Tools</PageTitle>

--- a/TelegramGroupsAdmin/Components/Pages/Users.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Users.razor
@@ -5,6 +5,7 @@
 @using TelegramGroupsAdmin.Core.Extensions
 @using TelegramGroupsAdmin.Core.Models
 @using TelegramGroupsAdmin.Telegram.Models
+@using TelegramGroupsAdmin.Telegram.Constants
 @inject ITelegramUserManagementService UserManagementService
 @inject IManagedChatsRepository ManagedChatsRepository
 @inject ISnackbar Snackbar
@@ -308,11 +309,12 @@
         var accessibleChats = await ManagedChatsRepository.GetUserAccessibleChatsAsync(
             WebUser.Id,
             WebUser.PermissionLevel);
-        _chatIds = accessibleChats.Select(c => c.Identity.Id).ToList();
 
-        // Empty list means all chats (GlobalAdmin/Owner) — normalize to null
-        if (_chatIds.Count == 0)
-            _chatIds = null;
+        // GlobalAdmin/Owner ⇒ [GlobalChatId] = global / no filter.
+        // Admin ⇒ exact accessible chats (may be empty ⇒ 0 rows if unlinked).
+        _chatIds = WebUser.IsGlobalAdminOrHigher
+            ? new List<long> { ModerationConstants.GlobalChatId }
+            : accessibleChats.Select(c => c.Identity.Id).ToList();
 
         // Load tab counts (tables load lazily via ServerData)
         _tabCounts = await UserManagementService.GetUserTabCountsAsync(_chatIds, null);

--- a/TelegramGroupsAdmin/Components/Pages/Users.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Users.razor
@@ -296,7 +296,7 @@
     private MudTable<TelegramUserListItem> _kickedTable = null!;
 
     private UserTabCounts _tabCounts = new();
-    private List<long>? _chatIds;
+    private List<long>? _scopedChatIds;
     private bool _loading = true;
     private string _searchText = string.Empty;
     private CancellationTokenSource _searchCts = new();
@@ -312,12 +312,12 @@
 
         // GlobalAdmin/Owner ⇒ [GlobalChatId] = global / no filter.
         // Admin ⇒ exact accessible chats (may be empty ⇒ 0 rows if unlinked).
-        _chatIds = WebUser.IsGlobalAdminOrHigher
+        _scopedChatIds = WebUser.IsGlobalAdminOrHigher
             ? new List<long> { ModerationConstants.GlobalChatId }
             : accessibleChats.Select(c => c.Identity.Id).ToList();
 
         // Load tab counts (tables load lazily via ServerData)
-        _tabCounts = await UserManagementService.GetUserTabCountsAsync(_chatIds, null);
+        _tabCounts = await UserManagementService.GetUserTabCountsAsync(_scopedChatIds, null);
         _loading = false;
     }
 
@@ -347,7 +347,7 @@
                 skip: state.Page * state.PageSize,
                 take: state.PageSize,
                 searchText: string.IsNullOrWhiteSpace(_searchText) ? null : _searchText,
-                chatIds: _chatIds,
+                chatIds: _scopedChatIds,
                 sortLabel: state.SortLabel,
                 sortDescending: state.SortDirection == SortDirection.Descending,
                 cancellationToken: cancellationToken);
@@ -397,7 +397,7 @@
         {
             // Refresh tab counts with search filter
             _tabCounts = await UserManagementService.GetUserTabCountsAsync(
-                _chatIds,
+                _scopedChatIds,
                 string.IsNullOrWhiteSpace(_searchText) ? null : _searchText,
                 _searchCts.Token);
 
@@ -508,7 +508,7 @@
     private async Task RefreshAfterActionAsync()
     {
         _tabCounts = await UserManagementService.GetUserTabCountsAsync(
-            _chatIds,
+            _scopedChatIds,
             string.IsNullOrWhiteSpace(_searchText) ? null : _searchText);
         await ReloadAllTablesAsync();
         StateHasChanged();

--- a/TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor
@@ -46,7 +46,7 @@
                     </MudTd>
                     <MudTd DataLabel="Created">@FormatDate(context.CreatedAt)</MudTd>
                     <MudTd DataLabel="Permission">
-                        <MudChip T="string" Size="Size.Small" Color="@GetPermissionColor((int)context.PermissionLevel)">
+                        <MudChip T="string" Size="Size.Small" Color="@GetPermissionColor(context.PermissionLevel)">
                             @context.PermissionLevel.GetDisplayName()
                         </MudChip>
                     </MudTd>
@@ -226,11 +226,11 @@
         MudDialog?.Close(DialogResult.Ok(true));
     }
 
-    private static Color GetPermissionColor(int level) => level switch
+    private static Color GetPermissionColor(PermissionLevel level) => level switch
     {
-        0 => Color.Primary,
-        1 => Color.Info,
-        2 => Color.Secondary,
+        PermissionLevel.Admin => Color.Primary,
+        PermissionLevel.GlobalAdmin => Color.Info,
+        PermissionLevel.Owner => Color.Secondary,
         _ => Color.Error
     };
 

--- a/TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor
@@ -47,7 +47,7 @@
                     <MudTd DataLabel="Created">@FormatDate(context.CreatedAt)</MudTd>
                     <MudTd DataLabel="Permission">
                         <MudChip T="string" Size="Size.Small" Color="@GetPermissionColor((int)context.PermissionLevel)">
-                            @GetPermissionName((int)context.PermissionLevel)
+                            @context.PermissionLevel.GetDisplayName()
                         </MudChip>
                     </MudTd>
                     <MudTd DataLabel="Expires">@FormatDate(context.ExpiresAt)</MudTd>
@@ -225,14 +225,6 @@
     {
         MudDialog?.Close(DialogResult.Ok(true));
     }
-
-    private static string GetPermissionName(int level) => level switch
-    {
-        0 => "Admin",
-        1 => "GlobalAdmin",
-        2 => "Owner",
-        _ => "Unknown"
-    };
 
     private static Color GetPermissionColor(int level) => level switch
     {

--- a/TelegramGroupsAdmin/Components/Shared/NotificationPreferencesCard.razor
+++ b/TelegramGroupsAdmin/Components/Shared/NotificationPreferencesCard.razor
@@ -166,7 +166,7 @@
     public string UserId { get; set; } = string.Empty;
 
     [Parameter]
-    public int UserPermissionLevel { get; set; }
+    public PermissionLevel UserPermissionLevel { get; set; }
 
     private NotificationConfig? _config;
     private bool _hasTelegramLinked;
@@ -328,7 +328,7 @@
         foreach (var eventType in Enum.GetValues<NotificationEventType>())
         {
             // Owner-only events hidden for non-owners
-            if (IsOwnerOnlyEvent(eventType) && UserPermissionLevel < 2)
+            if (IsOwnerOnlyEvent(eventType) && UserPermissionLevel < PermissionLevel.Owner)
                 continue;
             yield return eventType;
         }

--- a/TelegramGroupsAdmin/Components/Shared/Settings/WebAdminAccounts.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/WebAdminAccounts.razor
@@ -76,7 +76,7 @@
                 </MudTd>
                 <MudTd DataLabel="Permission Level">
                     <MudChip T="string" Size="Size.Small" Color="@GetPermissionColor((PermissionLevel)context.PermissionLevelInt)">
-                        @GetPermissionName((PermissionLevel)context.PermissionLevelInt)
+                        @((PermissionLevel)context.PermissionLevelInt).GetDisplayName()
                     </MudChip>
                 </MudTd>
                 <MudTd DataLabel="Status">
@@ -289,7 +289,7 @@
             try
             {
                 await UserManagementService.UpdatePermissionLevelAsync(user.WebUser.Id, (int)newLevel, WebUser!.Id, (int)WebUser!.PermissionLevel);
-                Snackbar.Add($"Updated {user.WebUser.Email} to {GetPermissionName(newLevel)}", Severity.Success);
+                Snackbar.Add($"Updated {user.WebUser.Email} to {newLevel.GetDisplayName()}", Severity.Success);
                 await LoadUsersAsync();
             }
             catch (Exception ex)
@@ -382,14 +382,6 @@
             }
         }
     }
-
-    private static string GetPermissionName(PermissionLevel level) => level switch
-    {
-        PermissionLevel.Admin => "Admin",
-        PermissionLevel.GlobalAdmin => "GlobalAdmin",
-        PermissionLevel.Owner => "Owner",
-        _ => "Unknown"
-    };
 
     private static Color GetPermissionColor(PermissionLevel level) => level switch
     {

--- a/TelegramGroupsAdmin/Components/_Imports.razor
+++ b/TelegramGroupsAdmin/Components/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.JSInterop
 @using TelegramGroupsAdmin
+@using TelegramGroupsAdmin.Constants
 @using TelegramGroupsAdmin.Components
 @using TelegramGroupsAdmin.Services
 @using TelegramGroupsAdmin.Components.Layout

--- a/TelegramGroupsAdmin/Constants/AuthenticationConstants.cs
+++ b/TelegramGroupsAdmin/Constants/AuthenticationConstants.cs
@@ -76,4 +76,9 @@ public static class AuthenticationConstants
     /// Authorization policy name for global admin or owner access.
     /// </summary>
     public const string PolicyGlobalAdminOrOwner = "GlobalAdminOrOwner";
+
+    /// <summary>
+    /// Authorization policy name for owner-only access (infra/system settings).
+    /// </summary>
+    public const string PolicyOwnerOnly = "OwnerOnly";
 }

--- a/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
@@ -87,7 +87,7 @@ public static class ServiceCollectionExtensions
             services.AddAuthorizationBuilder()
                 .AddPolicy(AuthenticationConstants.PolicyGlobalAdminOrOwner, policy =>
                     policy.RequireRole("GlobalAdmin", "Owner"))
-                .AddPolicy("OwnerOnly", policy =>
+                .AddPolicy(AuthenticationConstants.PolicyOwnerOnly, policy =>
                     policy.RequireRole("Owner"));
 
             services.AddCascadingAuthenticationState();

--- a/TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs
@@ -86,7 +86,7 @@ public class AuthCookieService : IAuthCookieService
         {
             new(ClaimTypes.NameIdentifier, user.Id),
             new(ClaimTypes.Email, user.Email ?? ""),
-            new(ClaimTypes.Role, GetRoleName(user.PermissionLevel)),
+            new(ClaimTypes.Role, user.PermissionLevel.GetDisplayName()),
             new(CustomClaimTypes.PermissionLevel, ((int)user.PermissionLevel).ToString())
         };
 
@@ -95,14 +95,4 @@ public class AuthCookieService : IAuthCookieService
         return new ClaimsPrincipal(identity);
     }
 
-    /// <summary>
-    /// Converts permission level enum to role name string.
-    /// </summary>
-    private static string GetRoleName(PermissionLevel permissionLevel) => permissionLevel switch
-    {
-        PermissionLevel.Admin => "Admin",
-        PermissionLevel.GlobalAdmin => "GlobalAdmin",
-        PermissionLevel.Owner => "Owner",
-        _ => "Admin" // Default to lowest permission level
-    };
 }

--- a/docs/superpowers/plans/2026-06-01-unified-permission-model.md
+++ b/docs/superpowers/plans/2026-06-01-unified-permission-model.md
@@ -1,0 +1,907 @@
+# Unified Permission Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Telegram bot and web UI share one permission model — a single `PermissionLevel` tier ladder (`Member`/`Admin`/`GlobalAdmin`/`Owner`) plus a chat-scope rule — fixing the audited deviations without a DB migration.
+
+**Architecture:** Extend the existing `PermissionLevel` enum with `Member = -1` (computed, never persisted; same int values for the stored tiers, so web claims/policies are unchanged). Introduce one pure resolver that maps `(web tier, is-chat-admin)` → effective tier, used by `CommandRouter`. Re-type bot command thresholds to the enum, render all labels from the enum's `[Display]` name (deleting three duplicate mappers), fix web magic-int checks, and contain the analytics/dashboard cross-chat leak with interim Admin-tier hiding (proper per-chat scoping deferred to issue #510).
+
+**Tech Stack:** .NET 10, Blazor Server, MudBlazor 9, EF Core 10, NUnit, Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-unified-permission-model-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `TelegramGroupsAdmin.Core/Models/PermissionLevel.cs` — add `Member = -1`.
+- `TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs` (Create) — `GetDisplayName()` (single source of label text).
+- `TelegramGroupsAdmin.Telegram/Services/BotCommands/PermissionResolver.cs` (Create) — pure resolver.
+- `TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs` — resolver wiring, enum gating, label, delete `GetPermissionName`.
+- `TelegramGroupsAdmin.Telegram/Services/BotCommands/IBotCommand.cs` — `MinPermissionLevel`/`ExecuteAsync` typed `PermissionLevel`.
+- `TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/*.cs` (15 files) — thresholds + signature.
+- `TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs` — footer + filter, delete `GetPermissionName`.
+- `TelegramGroupsAdmin.Telegram/Repositories/IChatAdminsRepository.cs` + `ChatAdminsRepository.cs` — delete int `GetPermissionLevelAsync`.
+- `TelegramGroupsAdmin.Telegram/Constants/ModerationConstants.cs` — delete `AdminPermissionLevel`.
+- `TelegramGroupsAdmin/Constants/AuthenticationConstants.cs` — add `PolicyOwnerOnly`.
+- `TelegramGroupsAdmin/ServiceCollectionExtensions.cs` — use the constant.
+- `TelegramGroupsAdmin/Components/Pages/Audit.razor` — Roles → Policy.
+- `TelegramGroupsAdmin/Components/Shared/NotificationPreferencesCard.razor` + `Components/Layout/NavMenu.razor` — magic-int → enum.
+- `TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs` + `Components/Pages/Login.razor` — dedup `GetRoleName`.
+- `TelegramGroupsAdmin/Components/Pages/Analytics.razor` — hide 3 leaky tabs for Admin.
+- `TelegramGroupsAdmin/Components/Pages/Home.razor` — scope/hide dashboard widgets for Admin.
+- `TelegramGroupsAdmin.Core/Repositories/ReportsRepository.cs` (+ interface) — multi-chat pending-count overload.
+
+**Test:**
+- `TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/PermissionResolverTests.cs` (Create).
+- `TelegramGroupsAdmin.UnitTests/Core/Models/PermissionLevelTests.cs` (Create).
+- `TelegramGroupsAdmin.E2ETests/Tests/Dashboard/DashboardTests.cs` + `Tests/Analytics/AnalyticsTests.cs` — update/add.
+
+---
+
+## Task 1: Add `Member` to `PermissionLevel` + `GetDisplayName()`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Core/Models/PermissionLevel.cs`
+- Create: `TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs`
+- Test: `TelegramGroupsAdmin.UnitTests/Core/Models/PermissionLevelTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `TelegramGroupsAdmin.UnitTests/Core/Models/PermissionLevelTests.cs`:
+
+```csharp
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.UnitTests.Core.Models;
+
+[TestFixture]
+public class PermissionLevelTests
+{
+    [Test]
+    public void Member_IsMinusOne_AndBelowAdmin()
+    {
+        Assert.That((int)PermissionLevel.Member, Is.EqualTo(-1));
+        Assert.That(PermissionLevel.Member, Is.LessThan(PermissionLevel.Admin));
+    }
+
+    [TestCase(PermissionLevel.Member, "Member")]
+    [TestCase(PermissionLevel.Admin, "Admin")]
+    [TestCase(PermissionLevel.GlobalAdmin, "GlobalAdmin")]
+    [TestCase(PermissionLevel.Owner, "Owner")]
+    public void GetDisplayName_ReturnsDisplayAttributeName(PermissionLevel level, string expected)
+    {
+        Assert.That(level.GetDisplayName(), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void StoredTiers_KeepExistingIntValues()
+    {
+        // Web claims/policies depend on these — must not change.
+        Assert.That((int)PermissionLevel.Admin, Is.EqualTo(0));
+        Assert.That((int)PermissionLevel.GlobalAdmin, Is.EqualTo(1));
+        Assert.That((int)PermissionLevel.Owner, Is.EqualTo(2));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~PermissionLevelTests"`
+Expected: FAIL — `PermissionLevel.Member` does not exist / `GetDisplayName` not defined.
+
+- [ ] **Step 3: Add `Member` to the enum**
+
+In `TelegramGroupsAdmin.Core/Models/PermissionLevel.cs`, add as the first member (keep existing members and their `[Display]` attributes unchanged):
+
+```csharp
+    /// <summary>No privileges — regular member. Computed at request time; never persisted.</summary>
+    [Display(Name = "Member")]
+    Member = -1,
+```
+
+- [ ] **Step 4: Create the `GetDisplayName` extension**
+
+Create `TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs`:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace TelegramGroupsAdmin.Core.Models;
+
+/// <summary>
+/// Single source of truth for the human-readable name of a <see cref="PermissionLevel"/>.
+/// Replaces the previously duplicated GetPermissionName / GetRoleName mappers.
+/// </summary>
+public static class PermissionLevelExtensions
+{
+    public static string GetDisplayName(this PermissionLevel level)
+    {
+        var member = typeof(PermissionLevel).GetMember(level.ToString()).FirstOrDefault();
+        var display = member?.GetCustomAttribute<DisplayAttribute>();
+        return display?.Name ?? level.ToString();
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~PermissionLevelTests"`
+Expected: PASS (4 cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Core/Models/PermissionLevel.cs TelegramGroupsAdmin.Core/Models/PermissionLevelExtensions.cs TelegramGroupsAdmin.UnitTests/Core/Models/PermissionLevelTests.cs
+git commit -m "feat(permissions): add Member tier and GetDisplayName to PermissionLevel"
+```
+
+---
+
+## Task 2: Pure permission resolver + truth-table tests
+
+**Files:**
+- Create: `TelegramGroupsAdmin.Telegram/Services/BotCommands/PermissionResolver.cs`
+- Test: `TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/PermissionResolverTests.cs`
+
+- [ ] **Step 1: Write the failing test (the canonical truth table)**
+
+Create `TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/PermissionResolverTests.cs`:
+
+```csharp
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Telegram.Services.BotCommands;
+
+namespace TelegramGroupsAdmin.UnitTests.Telegram.Services.BotCommands;
+
+[TestFixture]
+public class PermissionResolverTests
+{
+    // webTier, isChatAdminOrCreator -> effective
+    [TestCase(null, false, PermissionLevel.Member)]                       // unknown user
+    [TestCase(null, true, PermissionLevel.Admin)]                        // native TG admin/creator
+    [TestCase(PermissionLevel.Admin, false, PermissionLevel.Member)]     // web Admin in a chat they don't administer
+    [TestCase(PermissionLevel.Admin, true, PermissionLevel.Admin)]       // web Admin who is also a chat admin
+    [TestCase(PermissionLevel.GlobalAdmin, false, PermissionLevel.GlobalAdmin)] // global, any chat
+    [TestCase(PermissionLevel.GlobalAdmin, true, PermissionLevel.GlobalAdmin)]
+    [TestCase(PermissionLevel.Owner, false, PermissionLevel.Owner)]      // global, any chat
+    [TestCase(PermissionLevel.Owner, true, PermissionLevel.Owner)]
+    public void Resolve_MatchesCanonicalModel(PermissionLevel? webTier, bool isChatAdmin, PermissionLevel expected)
+    {
+        Assert.That(PermissionResolver.Resolve(webTier, isChatAdmin), Is.EqualTo(expected));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~PermissionResolverTests"`
+Expected: FAIL — `PermissionResolver` not defined.
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `TelegramGroupsAdmin.Telegram/Services/BotCommands/PermissionResolver.cs`:
+
+```csharp
+using TelegramGroupsAdmin.Core.Models;
+
+namespace TelegramGroupsAdmin.Telegram.Services.BotCommands;
+
+/// <summary>
+/// Resolves a user's effective permission tier in a specific chat from the two sources
+/// of authority: their stored web tier (if any) and their Telegram admin status in that chat.
+///
+/// GlobalAdmin/Owner apply globally (any chat). Admin is chat-scoped — it applies only
+/// where the user is a Telegram admin/creator. Everyone else is Member.
+/// This naturally yields the MAX of the two sources.
+/// </summary>
+public static class PermissionResolver
+{
+    public static PermissionLevel Resolve(PermissionLevel? webTier, bool isChatAdminOrCreator)
+        => webTier is PermissionLevel.GlobalAdmin or PermissionLevel.Owner
+            ? webTier.Value
+            : isChatAdminOrCreator
+                ? PermissionLevel.Admin
+                : PermissionLevel.Member;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~PermissionResolverTests"`
+Expected: PASS (8 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/BotCommands/PermissionResolver.cs TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/PermissionResolverTests.cs
+git commit -m "feat(permissions): add pure PermissionResolver with canonical truth table"
+```
+
+---
+
+## Task 3: Type the bot command contract to `PermissionLevel`
+
+This is a compiler-driven sweep: change the interface, then every command + caller the compiler flags. Public commands → `Member`, moderation commands → `Admin`.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BotCommands/IBotCommand.cs`
+- Modify: all 15 files in `TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/`
+- Modify: `TelegramGroupsAdmin.Telegram/Constants/ModerationConstants.cs`
+
+- [ ] **Step 1: Change the interface**
+
+In `IBotCommand.cs`, add `using TelegramGroupsAdmin.Core.Models;` and change:
+
+```csharp
+    /// <summary>Minimum permission tier required to run this command.</summary>
+    PermissionLevel MinPermissionLevel { get; }
+```
+
+and the execute signature:
+
+```csharp
+    Task<CommandResult> ExecuteAsync(
+        Message message,
+        string[] args,
+        PermissionLevel userPermission,
+        CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 2: Update every command's threshold and signature**
+
+For each command file, add `using TelegramGroupsAdmin.Core.Models;` if missing, change `int userPermissionLevel` → `PermissionLevel userPermission` in `ExecuteAsync` (rename internal references), and set `MinPermissionLevel`:
+
+Public (`=> PermissionLevel.Member`): `HelpCommand`, `StartCommand`, `MyStatusCommand`, `ReportCommand`, `LinkCommand`, `InviteCommand`.
+
+Moderation (`=> PermissionLevel.Admin`): `BanCommand`, `DeleteCommand`, `SpamCommand`, `MuteCommand`, `TempBanCommand`, `TrustCommand`, `UnbanCommand`, `WarnCommand`.
+
+Example (`BanCommand.cs`):
+
+```csharp
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Admin; // chat admin or higher
+```
+
+Example (`HelpCommand.cs`):
+
+```csharp
+    public PermissionLevel MinPermissionLevel => PermissionLevel.Member; // everyone
+```
+
+For `MuteCommand` and `TempBanCommand`, replace `ModerationConstants.AdminPermissionLevel` with `PermissionLevel.Admin`.
+
+- [ ] **Step 3: Delete the obsolete constant**
+
+In `TelegramGroupsAdmin.Telegram/Constants/ModerationConstants.cs`, delete:
+
+```csharp
+    public const int AdminPermissionLevel = 1;
+```
+
+(Confirm no remaining references: `grep -rn "AdminPermissionLevel" --include="*.cs"` returns nothing.)
+
+- [ ] **Step 4: Build to surface every remaining call site**
+
+Run: `dotnet build TelegramGroupsAdmin.Telegram`
+Expected: errors only in `CommandRouter.cs` (handled in Task 4) and `HelpCommand.cs` body (Task 5). Fix any command-body references to the renamed parameter so only the router/help errors remain.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/BotCommands/IBotCommand.cs TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/ TelegramGroupsAdmin.Telegram/Constants/ModerationConstants.cs
+git commit -m "refactor(permissions): type IBotCommand on PermissionLevel; drop AdminPermissionLevel"
+```
+
+---
+
+## Task 4: Wire `CommandRouter` to the resolver + delete the int chat-admin method
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs`
+- Modify: `TelegramGroupsAdmin.Telegram/Repositories/IChatAdminsRepository.cs`, `ChatAdminsRepository.cs`
+
+- [ ] **Step 1: Replace `GetPermissionLevelAsync` (lines ~178–217)**
+
+Replace the private resolver and the `GetPermissionName` method with:
+
+```csharp
+    private async Task<PermissionLevel> GetPermissionLevelAsync(long chatId, long telegramId, CancellationToken cancellationToken = default)
+    {
+        using var scope = _serviceProvider.CreateScope();
+
+        var mappingRepository = scope.ServiceProvider.GetRequiredService<ITelegramUserMappingRepository>();
+        var webTier = await mappingRepository.GetPermissionLevelByTelegramIdAsync(telegramId, cancellationToken);
+
+        var chatAdminsRepository = scope.ServiceProvider.GetRequiredService<IChatAdminsRepository>();
+        var isChatAdmin = await chatAdminsRepository.IsAdminAsync(chatId, telegramId, cancellationToken);
+
+        var effective = PermissionResolver.Resolve(webTier, isChatAdmin);
+        _logger.LogDebug(
+            "Resolved permission for {TelegramId} in chat {ChatId}: {Tier} (web={WebTier}, chatAdmin={IsChatAdmin})",
+            telegramId, chatId, effective, webTier, isChatAdmin);
+        return effective;
+    }
+```
+
+(`GetPermissionName` is deleted — labels now come from `PermissionLevel.GetDisplayName()`.)
+
+- [ ] **Step 2: Update the gating block (lines ~88–136)**
+
+Replace the resolution + gating with the enum-based version (removes the `bypassPermissionCheck`/`Math.Max` special-case):
+
+```csharp
+            var permissionLevel = await GetPermissionLevelAsync(message.Chat.Id, message.From.Id, cancellationToken);
+
+            if (permissionLevel < command.MinPermissionLevel)
+            {
+                _logger.LogWarning(
+                    "User {User} attempted /{Command} without sufficient permission (has {UserLevel}, needs {RequiredLevel})",
+                    TelegramDisplayName.Format(message.From.FirstName, message.From.LastName, message.From.Username, message.From.Id),
+                    commandName, permissionLevel, command.MinPermissionLevel);
+
+                var permissionMessage = command.MinPermissionLevel >= PermissionLevel.Admin
+                    ? "❌ This command is only available to group administrators."
+                    : "❌ You don't have permission to use this command.";
+
+                return new CommandResult(TelegramMessage.Plain(permissionMessage), true);
+            }
+```
+
+And the execute call (line ~136) now passes the enum:
+
+```csharp
+            var result = await command.ExecuteAsync(message, args, permissionLevel, cancellationToken);
+```
+
+Add `using TelegramGroupsAdmin.Core.Models;` to `CommandRouter.cs` if missing.
+
+- [ ] **Step 3: Delete the now-unused int chat-admin method**
+
+In `IChatAdminsRepository.cs` remove:
+
+```csharp
+    Task<int> GetPermissionLevelAsync(long chatId, long telegramId, CancellationToken cancellationToken = default);
+```
+
+In `ChatAdminsRepository.cs` remove its implementation (the `admin.IsCreator ? 2 : 1` method — this was deviation #2's source).
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build TelegramGroupsAdmin.Telegram`
+Expected: PASS (HelpCommand body still references old label helper — fixed next task; if HelpCommand errors, proceed to Task 5 before building green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/BotCommands/CommandRouter.cs TelegramGroupsAdmin.Telegram/Repositories/IChatAdminsRepository.cs TelegramGroupsAdmin.Telegram/Repositories/ChatAdminsRepository.cs
+git commit -m "refactor(permissions): resolve command authority via PermissionResolver; remove int chat-admin level"
+```
+
+---
+
+## Task 5: Fix `HelpCommand` label + filtering; delete its duplicate mapper
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs`
+- Test: `TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/Commands/HelpCommandTests.cs` (create or extend)
+
+- [ ] **Step 1: Write a failing test for the footer label**
+
+Add to (or create) `HelpCommandTests.cs` a test that builds help for a `PermissionLevel.Admin` user and asserts the footer contains `Permission: Admin` (not `GlobalAdmin`). Use the existing command test pattern in that folder for construction. Example assertion:
+
+```csharp
+[Test]
+public async Task Help_Footer_ShowsAdmin_ForAdminTier()
+{
+    var result = await _command.ExecuteAsync(_message, [], PermissionLevel.Admin);
+    Assert.That(result.Message.Text, Does.Contain("Permission: Admin"));
+    Assert.That(result.Message.Text, Does.Not.Contain("Permission: GlobalAdmin"));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~HelpCommandTests"`
+Expected: FAIL (currently maps Admin-tier int to a wrong label / won't compile against new signature).
+
+- [ ] **Step 3: Update `HelpCommand`**
+
+- Change `ExecuteAsync` to `PermissionLevel userPermission` (done in Task 3).
+- Replace the command filter and footer:
+
+```csharp
+        var availableCommands = allCommands
+            .Where(c => c.MinPermissionLevel <= userPermission)
+            .ToList();
+        // ...
+        builder.LineBreak().Italic($"Permission: {userPermission.GetDisplayName()}");
+```
+
+- Delete the private `GetPermissionName` method at the bottom of the file.
+- Add `using TelegramGroupsAdmin.Core.Models;` if missing.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~HelpCommandTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Build the whole solution + run bot tests**
+
+Run: `dotnet build` then `dotnet test TelegramGroupsAdmin.UnitTests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Telegram/Services/BotCommands/Commands/HelpCommand.cs TelegramGroupsAdmin.UnitTests/Telegram/Services/BotCommands/Commands/HelpCommandTests.cs
+git commit -m "fix(permissions): help footer labels tier via GetDisplayName; delete duplicate mapper (#507)"
+```
+
+---
+
+## Task 6: Web — `PolicyOwnerOnly` constant + `Audit.razor` policy
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Constants/AuthenticationConstants.cs`
+- Modify: `TelegramGroupsAdmin/ServiceCollectionExtensions.cs`
+- Modify: `TelegramGroupsAdmin/Components/Pages/Audit.razor`
+
+- [ ] **Step 1: Add the constant**
+
+In `AuthenticationConstants.cs`, after `PolicyGlobalAdminOrOwner`:
+
+```csharp
+    /// <summary>Authorization policy name for owner-only access (infra/system settings).</summary>
+    public const string PolicyOwnerOnly = "OwnerOnly";
+```
+
+- [ ] **Step 2: Use the constant in policy registration**
+
+In `ServiceCollectionExtensions.cs:90`, change the literal:
+
+```csharp
+                .AddPolicy(AuthenticationConstants.PolicyOwnerOnly, policy =>
+                    policy.RequireRole("Owner"));
+```
+
+- [ ] **Step 3: Update `Audit.razor` to use the policy**
+
+In `Audit.razor:11`, change:
+
+```razor
+@attribute [Authorize(Policy = AuthenticationConstants.PolicyGlobalAdminOrOwner)]
+```
+
+Add `@using TelegramGroupsAdmin.Constants` if not already imported (check `_Imports.razor`).
+
+- [ ] **Step 4: Find and update any other `"OwnerOnly"` literal**
+
+Run: `grep -rn '"OwnerOnly"' --include="*.razor" --include="*.cs" TelegramGroupsAdmin/`
+Replace each with `AuthenticationConstants.PolicyOwnerOnly` (e.g. `NotificationDebug.razor`).
+
+- [ ] **Step 5: Build**
+
+Run: `dotnet build TelegramGroupsAdmin`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Constants/AuthenticationConstants.cs TelegramGroupsAdmin/ServiceCollectionExtensions.cs TelegramGroupsAdmin/Components/Pages/Audit.razor TelegramGroupsAdmin/Components/Pages/NotificationDebug.razor
+git commit -m "refactor(auth): add PolicyOwnerOnly constant; Audit page uses policy attribute"
+```
+
+---
+
+## Task 7: Web — magic-int checks → enum comparisons
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Shared/NotificationPreferencesCard.razor`
+- Modify: `TelegramGroupsAdmin/Components/Layout/NavMenu.razor`
+
+- [ ] **Step 1: Fix `NotificationPreferencesCard.razor:331`**
+
+Change `UserPermissionLevel < 2` to compare the enum. If `UserPermissionLevel` is an `int` parameter, cast it:
+
+```csharp
+            if (IsOwnerOnlyEvent(eventType) && (PermissionLevel)UserPermissionLevel < PermissionLevel.Owner)
+```
+
+Add `@using TelegramGroupsAdmin.Core.Models` if needed.
+
+- [ ] **Step 2: Fix `NavMenu.razor:55`**
+
+Change:
+
+```csharp
+                _isGlobalAdminOrOwner = (PermissionLevel)level >= PermissionLevel.GlobalAdmin;
+```
+
+Add `@using TelegramGroupsAdmin.Core.Models`. (The `/analytics` nav link stays visible to all — tab-level hiding handles Admin containment, not the nav link.)
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build TelegramGroupsAdmin`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Shared/NotificationPreferencesCard.razor TelegramGroupsAdmin/Components/Layout/NavMenu.razor
+git commit -m "refactor(auth): replace magic-int permission checks with PermissionLevel comparisons"
+```
+
+---
+
+## Task 8: Web — dedup `GetRoleName` to `GetDisplayName`
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs`
+- Modify: `TelegramGroupsAdmin/Components/Pages/Login.razor`
+
+- [ ] **Step 1: Replace `AuthCookieService.GetRoleName` usage**
+
+At `AuthCookieService.cs:89`, change the role claim to use the display name and delete the private `GetRoleName` method:
+
+```csharp
+            new(ClaimTypes.Role, user.PermissionLevel.GetDisplayName()),
+```
+
+Add `using TelegramGroupsAdmin.Core.Models;` if missing. (Display names for Admin/GlobalAdmin/Owner are exactly the strings the policies' `RequireRole` expects.)
+
+- [ ] **Step 2: Replace `Login.razor` `GetRoleName`**
+
+At `Login.razor:180`, change the role claim construction to `result.PermissionLevel!.Value.GetDisplayName()` and delete the duplicate private `GetRoleName` (lines ~208–214). Add the `@using` if needed.
+
+- [ ] **Step 3: Build + run auth unit tests**
+
+Run: `dotnet build TelegramGroupsAdmin && dotnet test TelegramGroupsAdmin.UnitTests --filter "FullyQualifiedName~Auth"`
+Expected: PASS (role claims unchanged: "Admin"/"GlobalAdmin"/"Owner").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs TelegramGroupsAdmin/Components/Pages/Login.razor
+git commit -m "refactor(auth): derive role-name claim from PermissionLevel.GetDisplayName (dedup)"
+```
+
+---
+
+## Task 9: Interim — hide the 3 leaky analytics tabs from Admin
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Pages/Analytics.razor`
+
+- [ ] **Step 1: Add the permission context to `Analytics.razor`**
+
+In the `@code` block, add the cascading web user and a flag (mirror how other pages obtain it, e.g. `WebAdminAccounts.razor`):
+
+```csharp
+    [CascadingParameter] public WebUserIdentity? WebUser { get; set; }
+    private bool CanSeeGlobalAnalytics => WebUser?.IsGlobalAdminOrHigher ?? false;
+```
+
+Add `@using TelegramGroupsAdmin.Core.Models` if needed.
+
+- [ ] **Step 2: Conditionally render the leaky tab panels**
+
+Wrap the three leaky `MudTabPanel`s (lines 15–17 Content Detection, 23–26 Performance, 28–31 Welcome Analytics) so they are emitted only for GlobalAdmin+. Leave Message Trends (19–21) unconditional:
+
+```razor
+        @if (CanSeeGlobalAnalytics)
+        {
+            <MudTabPanel Text="Content Detection" Icon="@Icons.Material.Filled.Shield">
+                <ContentDetectionAnalytics />
+            </MudTabPanel>
+        }
+
+        <MudTabPanel Text="Message Trends" Icon="@Icons.Material.Filled.TrendingUp">
+            <MessageTrends />
+        </MudTabPanel>
+
+        @if (CanSeeGlobalAnalytics)
+        {
+            <MudTabPanel Text="Performance" Icon="@Icons.Material.Filled.Speed">
+                <PerformanceMetrics />
+            </MudTabPanel>
+
+            <MudTabPanel Text="Welcome Analytics" Icon="@Icons.Material.Filled.People">
+                <WelcomeAnalytics />
+            </MudTabPanel>
+        }
+```
+
+(Because the panels aren't emitted for Admin, their components never render and the unscoped repository methods are never invoked for an Admin — the leak is contained.)
+
+- [ ] **Step 3: Verify tab-index logic still resolves**
+
+If `_activeTabIndex` / `OnTabChanged` assumes 4 panels, confirm Message Trends (now possibly index 0 for Admin) still activates without an out-of-range default. If a fixed default index is used, guard it: default to the Message Trends panel for Admin.
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build TelegramGroupsAdmin`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Pages/Analytics.razor
+git commit -m "fix(analytics): hide cross-chat leaky tabs from Admin tier (interim, #510 fixes properly)"
+```
+
+---
+
+## Task 10: Multi-chat pending-count overload
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.Core/Repositories/ReportsRepository.cs` (+ its interface)
+- Test: `TelegramGroupsAdmin.IntegrationTests/.../ReportsRepositoryTests.cs` (extend)
+
+- [ ] **Step 1: Write the failing integration test**
+
+In the existing `ReportsRepositoryTests`, add a test seeding pending reports across chats A, B, C and asserting the count filtered to `[A, B]` excludes C's. Follow the existing fixture pattern in that file.
+
+```csharp
+[Test]
+public async Task GetPendingCountAsync_FiltersByAccessibleChats()
+{
+    // seed pending reports in chatA, chatB, chatC (use existing TestReportBuilder/fixture)
+    var count = await _repository.GetPendingCountAsync(new[] { chatA, chatB });
+    Assert.That(count, Is.EqualTo(/* pending in A + B */));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~GetPendingCountAsync_FiltersByAccessibleChats"`
+Expected: FAIL — overload not defined.
+
+- [ ] **Step 3: Add the overload**
+
+In `IReportsRepository` add:
+
+```csharp
+    Task<int> GetPendingCountAsync(IReadOnlyCollection<long> chatIds, ReportType? type = null, CancellationToken cancellationToken = default);
+```
+
+In `ReportsRepository.cs` implement (mirror the existing single-chat method at line 103, but filter with `Contains`):
+
+```csharp
+    public async Task<int> GetPendingCountAsync(
+        IReadOnlyCollection<long> chatIds,
+        ReportType? type = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Reports
+            .AsNoTracking()
+            .Where(r => r.Status == (int)ReportStatus.Pending);
+
+        if (chatIds.Count > 0)
+            query = query.Where(r => chatIds.Contains(r.ChatId));
+
+        if (type.HasValue)
+            query = query.Where(r => r.Type == (int)type.Value);
+
+        return await query.CountAsync(cancellationToken);
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests --filter "FullyQualifiedName~GetPendingCountAsync_FiltersByAccessibleChats"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.Core/Repositories/ReportsRepository.cs TelegramGroupsAdmin.IntegrationTests
+git commit -m "feat(reports): add accessible-chats overload for pending count"
+```
+
+---
+
+## Task 11: Interim — dashboard scope-or-hide for Admin
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Pages/Home.razor`
+
+- [ ] **Step 1: Add permission context + accessible chats**
+
+In the `@code` block add the cascading user, a flag, and (for Admin) the accessible chat IDs loaded via `ManagedChatsRepository.GetUserAccessibleChatsAsync` (inject `IManagedChatsRepository` if not present):
+
+```csharp
+    [CascadingParameter] public WebUserIdentity? WebUser { get; set; }
+    private bool _canSeeGlobalStats;
+    private List<long> _accessibleChatIds = [];
+```
+
+In `OnInitializedAsync`/load, before the data tasks:
+
+```csharp
+        _canSeeGlobalStats = WebUser?.IsGlobalAdminOrHigher ?? false;
+        if (!_canSeeGlobalStats && WebUser is not null)
+        {
+            var chats = await ManagedChatsRepository.GetUserAccessibleChatsAsync(WebUser.Id, WebUser.PermissionLevel);
+            _accessibleChatIds = chats.Select(c => c.Identity.Id).ToList();
+        }
+```
+
+- [ ] **Step 2: Scope the kept widgets; skip the hidden ones**
+
+Change the data load (around line 243–258) so that for Admin only the scoped calls run:
+
+```csharp
+            var pendingReportsTask = _canSeeGlobalStats
+                ? ReportsRepository.GetPendingCountAsync()
+                : ReportsRepository.GetPendingCountAsync(_accessibleChatIds);
+
+            var tabCountsTask = UserManagementService.GetUserTabCountsAsync(
+                chatIds: _canSeeGlobalStats ? null : _accessibleChatIds, searchText: null);
+
+            if (_canSeeGlobalStats)
+            {
+                var statsTask = MessageStatsService.GetStatsAsync();
+                var detectionStatsTask = MessageStatsService.GetDetectionStatsAsync();
+                var dailySpamTask = AnalyticsRepository.GetDailySpamSummaryAsync(DefaultTimeZoneId);
+                var recentActionsTask = UserActionsRepository.GetRecentAsync(MaxRecentActivityItems);
+                // await + assign as today
+            }
+            // always await pendingReportsTask + tabCountsTask
+```
+
+(Adapt to the file's existing `Task.WhenAll` shape; the key change is that the four global calls are gated behind `_canSeeGlobalStats`.)
+
+- [ ] **Step 3: Hide the global widgets in markup**
+
+Wrap the Total Messages / Unique Users / Images / Data Range cards, the Spam Today card, and the entire Recent Activity panel in `@if (_canSeeGlobalStats)`. Keep Pending Reports, Active Bans, Trusted Users visible (they come from the scoped pending-count + tab-counts). Ensure the stats `<MudGrid>` (line 34) still renders its remaining cards for Admin so it is non-empty.
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build TelegramGroupsAdmin`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Pages/Home.razor
+git commit -m "fix(dashboard): scope pending-reports/user-counts for Admin; hide global widgets (interim, #510)"
+```
+
+---
+
+## Task 12: E2E — update and add permission tests
+
+**Files:**
+- Modify: `TelegramGroupsAdmin.E2ETests/Tests/Dashboard/DashboardTests.cs`
+- Modify: `TelegramGroupsAdmin.E2ETests/Tests/Analytics/AnalyticsTests.cs`
+- Modify (if a new locator is needed): `TelegramGroupsAdmin.E2ETests/PageObjects/HomePage.cs`, `PageObjects/AnalyticsPage.cs`
+
+- [ ] **Step 1: Update `Dashboard_AccessibleByAdmin`**
+
+Change it to assert the *scoped* view for an Admin rather than full stats:
+
+```csharp
+    [Test]
+    public async Task Dashboard_AccessibleByAdmin_ShowsScopedCards_HidesGlobalWidgets()
+    {
+        await LoginAsAdminAsync();
+        await _homePage.NavigateAsync();
+        await _homePage.WaitForLoadAsync();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await _homePage.GetPendingReportsCountAsync(), Is.Not.Null.And.Not.Empty,
+                "Admin should still see the scoped Pending Reports card");
+            Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.False,
+                "Admin should NOT see the global Total Messages card");
+            Assert.That(await _homePage.IsActivityFeedVisibleAsync(), Is.False,
+                "Admin should NOT see the global Recent Activity feed");
+        }
+    }
+```
+
+Add `IsTotalMessagesCardVisibleAsync()` to `HomePage` if absent (mirror `GetTotalMessagesAsync`'s locator with `.IsVisibleAsync()`).
+
+- [ ] **Step 2: Add the GlobalAdmin dashboard test**
+
+```csharp
+    [Test]
+    public async Task Dashboard_GlobalAdmin_ShowsAllWidgets()
+    {
+        await LoginAsGlobalAdminAsync();
+        await _homePage.NavigateAsync();
+        await _homePage.WaitForLoadAsync();
+        Assert.That(await _homePage.IsTotalMessagesCardVisibleAsync(), Is.True);
+        Assert.That(await _homePage.IsActivityFeedVisibleAsync(), Is.True);
+    }
+```
+
+- [ ] **Step 3: Add analytics tab-visibility tests**
+
+In `AnalyticsTests.cs`, add a `GetTabNamesAsync` helper usage (already present per `Analytics_ShowsAllFourTabs`):
+
+```csharp
+    [Test]
+    public async Task Analytics_Admin_SeesOnlyMessageTrends()
+    {
+        await LoginAsAdminAsync();
+        await _analyticsPage.NavigateAsync();
+        var tabs = await _analyticsPage.GetTabNamesAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tabs, Does.Contain("Message Trends"));
+            Assert.That(tabs, Does.Not.Contain("Content Detection"));
+            Assert.That(tabs, Does.Not.Contain("Performance"));
+            Assert.That(tabs, Does.Not.Contain("Welcome Analytics"));
+        }
+    }
+
+    [Test]
+    public async Task Analytics_GlobalAdmin_SeesAllFourTabs()
+    {
+        await LoginAsGlobalAdminAsync();
+        await _analyticsPage.NavigateAsync();
+        var tabs = await _analyticsPage.GetTabNamesAsync();
+        Assert.That(tabs.Count, Is.EqualTo(4));
+    }
+```
+
+- [ ] **Step 4: Verify the existing `Analytics_PageLoads_ForAdmin` still passes**
+
+It only asserts the tab container is visible; Message Trends still renders for Admin, so leave it. Run the analytics suite to confirm.
+
+Run: `dotnet test TelegramGroupsAdmin.E2ETests --filter "FullyQualifiedName~AnalyticsTests|FullyQualifiedName~DashboardTests"`
+Expected: PASS (updated + new + existing GlobalAdmin/Owner cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin.E2ETests/
+git commit -m "test(e2e): admin dashboard hides global widgets; analytics shows only Message Trends"
+```
+
+---
+
+## Task 13: Full verification + `PermissionBoundaryTests` regression check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the whole solution**
+
+Run: `dotnet build`
+Expected: PASS, no warnings about unused `GetPermissionName`/`AdminPermissionLevel`.
+
+- [ ] **Step 2: Run unit + integration suites**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests` and `dotnet test TelegramGroupsAdmin.IntegrationTests`
+Expected: PASS.
+
+- [ ] **Step 3: Run permission-boundary + navigation E2E**
+
+Run: `dotnet test TelegramGroupsAdmin.E2ETests --filter "FullyQualifiedName~PermissionBoundaryTests|FullyQualifiedName~NavigationTests"`
+Expected: PASS — the `NavMenu` enum refactor preserved the GlobalAdmin+ threshold, so Admin still sees Reports/Users and not Settings/Audit/Chats.
+
+- [ ] **Step 4: Grep for orphans**
+
+Run: `grep -rn "GetPermissionName\|AdminPermissionLevel\|\"OwnerOnly\"\|< 2\|>= 1" --include="*.cs" --include="*.razor" TelegramGroupsAdmin TelegramGroupsAdmin.Telegram`
+Expected: no permission-related hits (only unrelated numeric comparisons, if any).
+
+- [ ] **Step 5: Final commit (if any cleanup)**
+
+```bash
+git add -A
+git commit -m "chore(permissions): final cleanup and verification for unified model"
+```
+
+---
+
+## Notes for the implementer
+
+- **No DB migration in this plan.** If you find yourself writing one, stop — stored `permission_level` values must stay `0/1/2`.
+- **`Member` is never persisted.** It only appears as a *resolved* value for unprivileged Telegram users.
+- **Default E2E user is `PermissionLevel.Admin`** (`TestUserBuilder`). Tests that don't care about tier inherit Admin; elevate explicitly with `LoginAsGlobalAdminAsync`/`LoginAsOwnerAsync` when a test needs broader access.
+- **Per-chat analytics/dashboard scoping is deliberately deferred** to issue #510 (needs DB view migrations). This plan only *hides* those surfaces from Admins.

--- a/docs/superpowers/specs/2026-06-01-unified-permission-model-design.md
+++ b/docs/superpowers/specs/2026-06-01-unified-permission-model-design.md
@@ -209,9 +209,9 @@ declare `PermissionLevel.Admin` directly and the constant is deleted).
 | 12 | `Audit.razor` uses `Roles=` not `Policy` | `Audit.razor:11` | §7 |
 | 13 | 3 copies of role/permission-name mapping | `CommandRouter`, `HelpCommand`, `AuthCookieService`/`Login` | §4, §8 |
 
-## Out of Scope (new follow-up issue)
+## Out of Scope (follow-up issue #510)
 
-**"Per-chat scope analytics & detection data"** — fix deviations #5–#8 properly: scope the
+**"Per-chat scope analytics & detection data"** ([#510](https://github.com/musicislife08/TelegramGroupsAdmin/issues/510)) — fix deviations #5–#8 properly: scope the
 three leaky analytics tabs' repository methods, **un-hide those tabs for Admin**, and
 un-hide the dashboard widgets. This is deferred because it requires **DB view migrations**,
 which would otherwise pull migration risk into this migration-free PR:

--- a/docs/superpowers/specs/2026-06-01-unified-permission-model-design.md
+++ b/docs/superpowers/specs/2026-06-01-unified-permission-model-design.md
@@ -64,6 +64,24 @@ Consequences (all conformant with the model):
 - A native Telegram **creator** → **Admin** (not Owner).
 - A **GlobalAdmin/Owner** → their tier in **every** chat, administered or not.
 
+### Performance note (resolver ordering)
+
+The resolver does up to two DB lookups (web mapping, then `chat_admins`); neither is
+cached today, and it runs **only on slash-commands** (guarded by `IsCommand` in
+`MessageProcessingService`), not per message — so it is not a throughput hot path.
+
+We deliberately keep the **accurate, web-tier-first** ordering rather than a
+"chat-admin-first, skip the web lookup" short-circuit. The short-circuit would save one
+query for non-web chat admins, but would mislabel a Global/Owner web user who is *also* a
+chat admin of a chat as "Admin" in that chat — re-introducing a smaller form of the very
+#507 bug this work fixes (e.g., the Owner is a chat admin/creator in ~19 chats and would
+show "Admin" in most of them).
+
+If lower latency is ever wanted without sacrificing accuracy, the safe lever is to run the
+two lookups **concurrently** (`Task.WhenAll`) or fold them into one joined query — not to
+reorder-and-skip. A fully unified single-source lookup would be a larger storage-layer
+change and is explicitly out of scope here (worth revisiting later).
+
 ### Reference implementation already in the codebase
 
 `ManagedChatsRepository.GetUserAccessibleChatsAsync` already implements the scope rule
@@ -101,6 +119,14 @@ A `+1` renumber to a contiguous `Member=0` ladder was considered and **rejected*
 permission-column migration is high-risk (a silent off-by-one is a security incident)
 for a purely cosmetic gain, since the enum is the single source of truth either way.
 
+**No orphaned enum.** The solution has exactly one permission enum (`PermissionLevel`);
+unification *extends* it (adds `Member`) and adopts it on the bot side, rather than
+collapsing two enums into one. So nothing is deleted *as an enum*. What is removed are the
+redundant **bare-int** artifacts the unification replaces — most notably
+`ModerationConstants.AdminPermissionLevel = 1` (an obsolete magic int that encodes the old
+scale where Admin was `1`; under the unified enum Admin is `0`, so moderation commands
+declare `PermissionLevel.Admin` directly and the constant is deleted).
+
 ## Architecture changes
 
 ### Bot side (Telegram)
@@ -118,7 +144,8 @@ for a purely cosmetic gain, since the enum is the single source of truth either 
      `PermissionLevel.Member`,
    - moderation commands (`ban`, `spam`, `mute`, `tempban`, `trust`, `unban`, `warn`,
      `delete`) → `PermissionLevel.Admin`.
-   (`ModerationConstants.AdminPermissionLevel` updated accordingly.)
+   (`ModerationConstants.AdminPermissionLevel = 1` is **deleted** — moderation commands
+   declare `PermissionLevel.Admin` directly.)
 3. **Uniform gating.** Gate on `effectiveTier >= command.MinPermissionLevel` (enum
    comparison). Because public commands require `Member`, everyone passes them naturally —
    the existing `bypassPermissionCheck`/`Math.Max` special-case (`CommandRouter.cs:92–93`)
@@ -143,10 +170,17 @@ for a purely cosmetic gain, since the enum is the single source of truth either 
 
 ### Interim leak containment (proper fix deferred — see *Out of Scope*)
 
-9. **`/analytics` gated to GlobalAdmin+.** `Analytics.razor` `[Authorize]` →
-   `[Authorize(Policy = PolicyGlobalAdminOrOwner)]`. Stops the cross-chat data leak from
-   the unscoped widgets (`ContentDetectionAnalytics`, `WelcomeAnalytics`,
-   `PerformanceMetrics`, `SpamTrendComparison`) for Admin-tier users.
+9. **`/analytics` — hide only the leaky tabs for Admin (not a page gate).** The page has
+   four tabs; **Message Trends is already correctly chat-scoped** (`MessageTrends` uses
+   `GetUserAccessibleChatsAsync`) and stays visible to Admins. The three leaky tabs —
+   **Content Detection, Performance, Welcome** (`ContentDetectionAnalytics`,
+   `PerformanceMetrics`, `WelcomeAnalytics`, plus `SpamTrendComparison`) — are
+   **conditionally rendered only for `WebUser.IsGlobalAdminOrHigher`**. Their
+   `MudTabPanel`s are *not emitted* for Admins, so the unscoped repository methods are
+   never invoked on their behalf → leak contained without removing Admins' working
+   analytics. `Analytics.razor` keeps `[Authorize]` (all authenticated); the `/analytics`
+   nav link stays visible to everyone. (This supersedes the earlier "gate the whole page"
+   idea — gating would have discarded the already-correct Message Trends tab.)
 10. **Dashboard (`Home.razor`, route `/`) — scope cheap, hide the rest for Admin.** The
     landing page can't be gated. For **Admin** tier:
     - **Scope** pending-reports count and user-tab-counts to the user's accessible chat
@@ -168,7 +202,7 @@ for a purely cosmetic gain, since the enum is the single source of truth either 
 | 2 | Creator → `2` (Owner-equiv) instead of Admin | `ChatAdminsRepository.cs:42` | resolver (Arch §1) |
 | 3 | Bare-int flatten → `/help` mislabels chat admin/creator | `CommandRouter.cs:88–93`, `HelpCommand.cs:80` | enum + name source (§1, §4) |
 | 4 | Web-Admin in unadministered chat resolves to stored `0` not Member | `CommandRouter.cs:178–209` | resolver (§1) |
-| 5–8 | `/analytics` widgets query globally (cross-chat leak) | `Analytics.razor` + `AnalyticsRepository`/`DetectionResultsRepository` | **interim gate (§9)**; proper fix in follow-up issue |
+| 5–8 | `/analytics` widgets query globally (cross-chat leak) | `Analytics.razor` + `AnalyticsRepository`/`DetectionResultsRepository` | **interim: hide 3 leaky tabs for Admin (§9)**; proper fix in follow-up issue |
 | 9 | Magic int `< 2` for Owner | `NotificationPreferencesCard.razor:331` | §5 |
 | 10 | Magic int `>= 1` for GlobalAdmin | `NavMenu.razor:55` | §5 |
 | 11 | `"OwnerOnly"` bare string literal | `ServiceCollectionExtensions.cs:90` | §6 |
@@ -177,10 +211,10 @@ for a purely cosmetic gain, since the enum is the single source of truth either 
 
 ## Out of Scope (new follow-up issue)
 
-**"Per-chat scope analytics & detection data"** — fix deviations #5–#8 properly and
-remove the interim `/analytics` gate + un-hide the dashboard widgets. This is deferred
-because it requires **DB view migrations**, which would otherwise pull migration risk into
-this migration-free PR:
+**"Per-chat scope analytics & detection data"** — fix deviations #5–#8 properly: scope the
+three leaky analytics tabs' repository methods, **un-hide those tabs for Admin**, and
+un-hide the dashboard widgets. This is deferred because it requires **DB view migrations**,
+which would otherwise pull migration risk into this migration-free PR:
 - `detection_accuracy` view (feeds `PerformanceMetrics`) has **no `chat_id`** column.
 - `hourly_detection_stats` and the spam-trend aggregates **pre-aggregate without
   `chat_id`** — scoping them changes the view grain (row cardinality), rippling into
@@ -214,8 +248,12 @@ Also out of scope: any change to the persisted `users.permission_level` represen
 - [ ] Magic-int permission comparisons (`< 2`, `>= 1`) are replaced with enum comparisons;
       `OwnerOnly` is referenced via `AuthenticationConstants.PolicyOwnerOnly`;
       `Audit.razor` uses the policy attribute.
-- [ ] `/analytics` is gated to GlobalAdmin+; the dashboard scopes pending-reports and
-      user-tab-counts for Admins and hides the global-aggregate widgets from Admins.
+- [ ] On `/analytics`, an Admin sees **only the Message Trends tab** (Content Detection,
+      Performance, Welcome tabs are not rendered for Admin); GlobalAdmin/Owner see all
+      four. The page stays `[Authorize]`; the nav link stays visible to all.
+- [ ] The dashboard scopes pending-reports and user-tab-counts for Admins and hides the
+      global-aggregate widgets (message stats, spam-today, recent-activity) from Admins,
+      keeping a non-empty scoped stats grid; GlobalAdmin/Owner dashboard unchanged.
 - [ ] Existing web authorization behavior (infra Owner-only, account mgmt GlobalAdmin+,
       page gates) is unchanged/verified.
 - [ ] A new issue is filed for the analytics/detection per-chat scoping follow-up.
@@ -231,8 +269,38 @@ Also out of scope: any change to the persisted `users.permission_level` represen
 - **Integration:** a web-Admin linked to a TG account that admins chat X can run `/ban` in
   X and is denied in chat Y; an unlinked GlobalAdmin (the unlinked-global-admin case) — confirm the
   *operational* expectation is documented (link required) and not masked by code.
-- **Web:** verify `/analytics` returns 403 for Admin, 200 for GlobalAdmin+; dashboard shows
-  scoped pending-reports count for an Admin and hides global widgets.
+- **Web (component):** verify the dashboard renders scoped pending-reports for an Admin and
+  omits the global widgets; verify `Analytics.razor` emits only the Message Trends tab for
+  Admin and all four for GlobalAdmin+.
+
+### E2E (Playwright) — existing suite impact
+
+**Important:** the default E2E user is **`PermissionLevel.Admin`**
+(`TestUserBuilder._permissionLevel`), and tests authenticate per-tier via
+`LoginAsAdminAsync` / `LoginAsGlobalAdminAsync` / `LoginAsOwnerAsync`. The Admin-tier
+changes therefore directly touch Admin-authenticated tests.
+
+Tests to **update**:
+- `DashboardTests.Dashboard_AccessibleByAdmin` — currently asserts `AreStatsVisibleAsync`
+  (`.mud-paper .mud-grid`). Adjust to assert the *scoped* cards (Pending Reports) are shown
+  and the global ones (Total Messages / Spam Today / Recent Activity) are **not** — and keep
+  the stats grid non-empty so the locator still resolves.
+
+Tests expected to **still pass** (verify):
+- `AnalyticsTests.Analytics_PageLoads_ForAdmin` — asserts the tab *container* is visible;
+  Message Trends still renders for Admin, so this should remain green. Confirm
+  `IsTabsVisibleAsync` doesn't require a leaky tab.
+- `PermissionBoundaryTests` (nav menu) — survives iff the `NavMenu` `level >= 1` →
+  `>= PermissionLevel.GlobalAdmin` refactor is behavior-preserving.
+- `NavigationTests` — first-run redirect tests, unaffected.
+- `AnalyticsTests`/`DashboardTests` GlobalAdmin & Owner cases — those tiers keep full access.
+
+Tests to **add**:
+- `Analytics_Admin_SeesOnlyMessageTrends` — Admin: Message Trends tab present; Content
+  Detection / Performance / Welcome tabs absent. `Analytics_GlobalAdmin_SeesAllFourTabs`.
+- `Dashboard_Admin_HidesGlobalWidgets_ShowsPendingReports` — Admin: Pending Reports + Active
+  Bans + Trusted Users visible (scoped); Total Messages / Spam Today / Recent Activity
+  hidden. `Dashboard_GlobalAdmin_ShowsAllWidgets`.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-06-01-unified-permission-model-design.md
+++ b/docs/superpowers/specs/2026-06-01-unified-permission-model-design.md
@@ -1,0 +1,245 @@
+# Unified Permission Model — Design
+
+**Date:** 2026-06-01
+**Branch:** `feat/unified-permission-model`
+**Supersedes/expands:** Issue #507 (permission-label inconsistency + `GetPermissionName` duplication)
+**Spawns follow-up:** new issue — "Per-chat scope analytics & detection data" (see *Out of Scope*)
+
+## Origin
+
+Issue #507 reported that the `/help` footer mislabels a per-chat Telegram admin as
+"GlobalAdmin", plus a duplicated `GetPermissionName`. While confirming a related
+real-world complaint ("a global admin was refused `/ban` in a chat they don't
+administer"), we discovered the complaint was **operational, not a code bug**: the
+user (a GlobalAdmin) had never linked their Telegram account, so
+they resolved with no web permission and fell through to the per-chat admin path.
+
+That investigation surfaced the real problem: **the bot has two overlapping permission
+scales that assign different numbers to the same conceptual tier.** A Telegram chat
+admin resolves to `1`; a web "Admin" is stored as `0` — yet they are meant to be the
+*same* Admin tier. Every downstream inconsistency (mislabeling, a latent web-Admin
+moderation gap, creator over-privilege, magic-int checks, cross-chat analytics leaks)
+flows from that one mismatch.
+
+This work codifies the permission model **that was always intended**, and treats every
+deviation from it as a bug to fix.
+
+## Canonical Permission Model (the source of truth)
+
+A permission decision is two questions: **tier** ("how powerful are you?") and **scope**
+("here?"). The intended model:
+
+| Tier | Can do | Scope | How you get it |
+|---|---|---|---|
+| **Member** | public commands only (`/help`, `/report`, `/link`, `/start`, `/mystatus`, `/invite`) | the chat they're in | everyone, by default |
+| **Admin** | all moderation *except* infra | **only chats their (linked or native) Telegram account administers** | being a Telegram admin/creator of a chat — *or* a web "Admin" role whose linked Telegram account is an admin there |
+| **GlobalAdmin** | all moderation *except* infra | **every chat** | web role, linked account |
+| **Owner** | everything **incl. infra/system settings** | every chat + web infra | web role, linked account |
+
+Rules that fall out of this:
+
+- **"Telegram chat admin" ≡ "web Admin."** Same tier, same powers, same chat-scope. The
+  only difference is whether the person also has a web login for richer context. Per-chat
+  command authority on Telegram comes from `chat_admins`; the web "Admin" *role* grants
+  portal access scoped to those same chats.
+- **Telegram creator → Admin tier** ("treated like admin"), not a higher tier.
+- **GlobalAdmin and Owner are indistinguishable on Telegram** — there are no infra
+  commands on Telegram. Owner's extra power is web-only (infra/system settings editing).
+- **Effective tier in a chat = the canonical resolver below**, which naturally implements
+  the "max of the user's web tier and their in-chat Telegram tier", scope-aware.
+
+### Canonical resolver
+
+```
+EffectivePermission(telegramId, chatId):
+    webTier = (linked active web account?) -> stored PermissionLevel : null   // Admin/GlobalAdmin/Owner
+    if webTier is GlobalAdmin or Owner:        return webTier                  // global, any chat
+    if isTelegramAdminOrCreator(chatId, telegramId): return Admin             // chat-scoped
+    return Member
+```
+
+Consequences (all conformant with the model):
+- A web **Admin in a chat they don't administer** resolves to **Member** (Admin is
+  chat-scoped). In a chat they *do* administer → **Admin**.
+- A native Telegram **creator** → **Admin** (not Owner).
+- A **GlobalAdmin/Owner** → their tier in **every** chat, administered or not.
+
+### Reference implementation already in the codebase
+
+`ManagedChatsRepository.GetUserAccessibleChatsAsync` already implements the scope rule
+correctly on the web (GlobalAdmin/Owner → all chats; Admin → chats joined via
+`telegram_user_mappings → chat_admins`; unlinked → none). It is the canonical
+chat-scope rule; the analytics follow-up reuses it.
+
+## The unified enum (no DB migration)
+
+We **extend the existing `PermissionLevel` enum** (already used by the web, already
+carrying `[Display]` names that match the role claims) with a `Member` floor, and use
+that same enum on the bot side. We keep the name `PermissionLevel` to minimize churn.
+
+```csharp
+public enum PermissionLevel
+{
+    [Display(Name = "Member")]      Member      = -1,  // computed; never persisted
+    [Display(Name = "Admin")]       Admin       = 0,
+    [Display(Name = "GlobalAdmin")] GlobalAdmin = 1,
+    [Display(Name = "Owner")]       Owner       = 2,
+}
+```
+
+Why this is migration-free and safe:
+- The persisted `users.permission_level` column only ever holds `0/1/2`
+  (Admin/GlobalAdmin/Owner). `Member` is the *absence* of privilege — computed at
+  request time, **never stored**. So the column needs no change.
+- `Member = -1` matches the sentinel the Telegram side already uses for "no permission",
+  so the two scales converge on the same numbers with zero data churn.
+- The `[Display]` names remain exactly `"Admin"/"GlobalAdmin"/"Owner"`, so the web role
+  claims and `RequireRole("GlobalAdmin","Owner")` / `"Owner"` policies keep working
+  unchanged.
+
+A `+1` renumber to a contiguous `Member=0` ladder was considered and **rejected**: a
+permission-column migration is high-risk (a silent off-by-one is a security incident)
+for a purely cosmetic gain, since the enum is the single source of truth either way.
+
+## Architecture changes
+
+### Bot side (Telegram)
+
+1. **Single resolver.** `CommandRouter.GetPermissionLevelAsync` returns
+   `PermissionLevel` (incl. `Member`) per the canonical resolver. This fixes:
+   - the **early-return-on-web-link** bug (`CommandRouter.cs:187–191`) — it no longer
+     skips `chat_admins`,
+   - **creator → Owner** (`ChatAdminsRepository.cs:42`) — creator now maps to Admin tier,
+   - **web-Admin in an unadministered chat** now correctly resolves to `Member`.
+2. **Command thresholds re-typed.** `IBotCommand.MinPermissionLevel` becomes
+   `PermissionLevel` (was `int`). `ExecuteAsync(... int userPermissionLevel ...)` becomes
+   `ExecuteAsync(... PermissionLevel userPermission ...)`. Re-map across the ~15 commands:
+   - public commands (`help`, `report`, `link`, `start`, `mystatus`, `invite`) →
+     `PermissionLevel.Member`,
+   - moderation commands (`ban`, `spam`, `mute`, `tempban`, `trust`, `unban`, `warn`,
+     `delete`) → `PermissionLevel.Admin`.
+   (`ModerationConstants.AdminPermissionLevel` updated accordingly.)
+3. **Uniform gating.** Gate on `effectiveTier >= command.MinPermissionLevel` (enum
+   comparison). Because public commands require `Member`, everyone passes them naturally —
+   the existing `bypassPermissionCheck`/`Math.Max` special-case (`CommandRouter.cs:92–93`)
+   is **removed** as redundant. `/help` still receives the resolved tier to filter the
+   command list and render the footer.
+4. **Single name source.** Delete both bot-side `GetPermissionName` copies
+   (`CommandRouter.cs:211`, `HelpCommand.cs:107`); render labels from
+   `PermissionLevel.GetDisplayName()`. This fixes #507's headline: a per-chat admin now
+   shows **"Admin"**, a creator shows **"Admin"** (not "GlobalAdmin"/"Owner").
+
+### Web side
+
+5. **Magic ints → enum compares.**
+   - `NotificationPreferencesCard.razor:331` `UserPermissionLevel < 2` → `< PermissionLevel.Owner`.
+   - `NavMenu.razor:55` `level >= 1` → `>= PermissionLevel.GlobalAdmin`.
+6. **Policy constant.** Add `AuthenticationConstants.PolicyOwnerOnly = "OwnerOnly"`; replace
+   the bare string literal at `ServiceCollectionExtensions.cs:90` and update references.
+7. **Consistent authorization attribute.** `Audit.razor:11`
+   `[Authorize(Roles="GlobalAdmin,Owner")]` → `[Authorize(Policy = PolicyGlobalAdminOrOwner)]`.
+8. **Dedup web role-name mapping.** `Login.razor` and `AuthCookieService` each have a
+   private `GetRoleName`; collapse to one source backed by `PermissionLevel.GetDisplayName()`.
+
+### Interim leak containment (proper fix deferred — see *Out of Scope*)
+
+9. **`/analytics` gated to GlobalAdmin+.** `Analytics.razor` `[Authorize]` →
+   `[Authorize(Policy = PolicyGlobalAdminOrOwner)]`. Stops the cross-chat data leak from
+   the unscoped widgets (`ContentDetectionAnalytics`, `WelcomeAnalytics`,
+   `PerformanceMetrics`, `SpamTrendComparison`) for Admin-tier users.
+10. **Dashboard (`Home.razor`, route `/`) — scope cheap, hide the rest for Admin.** The
+    landing page can't be gated. For **Admin** tier:
+    - **Scope** pending-reports count and user-tab-counts to the user's accessible chat
+      IDs. `GetUserTabCountsAsync(chatIds: …)` already takes a collection (the dashboard
+      currently passes `null`). `ReportsRepository.GetPendingCountAsync(long? chatId)`
+      takes only a single `chatId`, so add a small overload accepting the accessible chat
+      IDs (or sum across them) — cheap, no migration. *Pending reports is the
+      operationally-useful card for Admins.*
+    - **Hide** the global-aggregate widgets that need new overloads or are view-backed:
+      `GetStatsAsync`, `GetDetectionStatsAsync`, `GetRecentAsync`, and
+      `GetDailySpamSummaryAsync` — render them only for GlobalAdmin+.
+    - **GlobalAdmin/Owner:** dashboard unchanged.
+
+## Deviation inventory → where each is fixed
+
+| # | Deviation | Location | Fixed by |
+|---|---|---|---|
+| 1 | Early-return on web link skips `chat_admins` (web-Admin who's also a TG admin can't moderate) | `CommandRouter.cs:187–191` | resolver (Arch §1) |
+| 2 | Creator → `2` (Owner-equiv) instead of Admin | `ChatAdminsRepository.cs:42` | resolver (Arch §1) |
+| 3 | Bare-int flatten → `/help` mislabels chat admin/creator | `CommandRouter.cs:88–93`, `HelpCommand.cs:80` | enum + name source (§1, §4) |
+| 4 | Web-Admin in unadministered chat resolves to stored `0` not Member | `CommandRouter.cs:178–209` | resolver (§1) |
+| 5–8 | `/analytics` widgets query globally (cross-chat leak) | `Analytics.razor` + `AnalyticsRepository`/`DetectionResultsRepository` | **interim gate (§9)**; proper fix in follow-up issue |
+| 9 | Magic int `< 2` for Owner | `NotificationPreferencesCard.razor:331` | §5 |
+| 10 | Magic int `>= 1` for GlobalAdmin | `NavMenu.razor:55` | §5 |
+| 11 | `"OwnerOnly"` bare string literal | `ServiceCollectionExtensions.cs:90` | §6 |
+| 12 | `Audit.razor` uses `Roles=` not `Policy` | `Audit.razor:11` | §7 |
+| 13 | 3 copies of role/permission-name mapping | `CommandRouter`, `HelpCommand`, `AuthCookieService`/`Login` | §4, §8 |
+
+## Out of Scope (new follow-up issue)
+
+**"Per-chat scope analytics & detection data"** — fix deviations #5–#8 properly and
+remove the interim `/analytics` gate + un-hide the dashboard widgets. This is deferred
+because it requires **DB view migrations**, which would otherwise pull migration risk into
+this migration-free PR:
+- `detection_accuracy` view (feeds `PerformanceMetrics`) has **no `chat_id`** column.
+- `hourly_detection_stats` and the spam-trend aggregates **pre-aggregate without
+  `chat_id`** — scoping them changes the view grain (row cardinality), rippling into
+  consumers.
+- `enriched_detections` *does* carry `chat_id` (query-level `WHERE` is enough there).
+- Requires threading accessible-chat-IDs into `AnalyticsRepository` and
+  `DetectionResultsRepository` method signatures, then re-verifying every `/analytics`
+  widget scopes like `MessageTrends` already does.
+
+Also out of scope: any change to the persisted `users.permission_level` representation
+(no migration); the previously-discussed `#478` Snackbar/`ex.Message` sweep (dropped).
+
+## Acceptance Criteria
+
+- [ ] A single `PermissionLevel` enum (with `Member = -1`) is used by **both** the bot and
+      the web; no separate bot-side numeric scale remains.
+- [ ] No DB migration; `users.permission_level` values unchanged; web role claims and
+      `RequireRole`/policy strings unchanged.
+- [ ] `CommandRouter.GetPermissionLevelAsync` implements the canonical resolver: web
+      Global/Owner → tier in any chat; else Admin if TG admin/creator here; else Member.
+      A web-Admin who is also a TG admin of a chat **can** moderate that chat. A creator
+      resolves to **Admin**.
+- [ ] `/help` footer (and permission-denied messages) label a per-chat admin as **"Admin"**
+      and a creator as **"Admin"** — never "GlobalAdmin"/"Owner" by accident.
+- [ ] All bot command `MinPermissionLevel` values are typed `PermissionLevel`; public →
+      `Member`, moderation → `Admin`. Gating is `tier >= MinPermissionLevel`; the
+      `bypassPermissionCheck`/`Math.Max` special-case is removed without behavior change
+      for public commands.
+- [ ] Both bot-side `GetPermissionName` copies and the duplicated web `GetRoleName` are
+      eliminated in favor of `PermissionLevel.GetDisplayName()` (one source).
+- [ ] Magic-int permission comparisons (`< 2`, `>= 1`) are replaced with enum comparisons;
+      `OwnerOnly` is referenced via `AuthenticationConstants.PolicyOwnerOnly`;
+      `Audit.razor` uses the policy attribute.
+- [ ] `/analytics` is gated to GlobalAdmin+; the dashboard scopes pending-reports and
+      user-tab-counts for Admins and hides the global-aggregate widgets from Admins.
+- [ ] Existing web authorization behavior (infra Owner-only, account mgmt GlobalAdmin+,
+      page gates) is unchanged/verified.
+- [ ] A new issue is filed for the analytics/detection per-chat scoping follow-up.
+
+## Testing
+
+- **Unit:** resolver truth table — for each (web role ∈ {none, Admin, GlobalAdmin, Owner}) ×
+  (TG status in chat ∈ {none, admin, creator}) × (chat administered? y/n), assert the
+  expected effective `PermissionLevel`. Explicitly cover: web-Admin + TG-admin-here → Admin;
+  web-Admin + not-admin-here → Member; creator → Admin; GlobalAdmin/unlinked-here → GlobalAdmin.
+- **Unit:** command gating — Member denied moderation, allowed public; Admin allowed
+  moderation; label rendering via `GetDisplayName()`.
+- **Integration:** a web-Admin linked to a TG account that admins chat X can run `/ban` in
+  X and is denied in chat Y; an unlinked GlobalAdmin (the unlinked-global-admin case) — confirm the
+  *operational* expectation is documented (link required) and not masked by code.
+- **Web:** verify `/analytics` returns 403 for Admin, 200 for GlobalAdmin+; dashboard shows
+  scoped pending-reports count for an Admin and hides global widgets.
+
+## Risks
+
+- **Security-sensitive.** Mistakes change who can run moderation commands / see data.
+  Mitigated by the resolver truth-table tests and by keeping persisted values + web claims
+  untouched.
+- **Removing the bypass special-case** must preserve public-command access for `Member`;
+  covered by gating tests.
+- **Breadth of the enum rename touchpoints** (~20 web sites + 15 commands) is mechanical
+  but wide; rely on the compiler (typed `MinPermissionLevel`) to surface every site.


### PR DESCRIPTION
Closes #507

## Why

The bot had **two overlapping permission scales** that assigned different numbers to the same conceptual tier — a Telegram chat admin resolved to `1`, a web "Admin" was stored as `0`, yet both are meant to be the *same* Admin tier. Every downstream inconsistency flowed from that one mismatch: `/help` mislabeling a per-chat admin as "GlobalAdmin", a latent web-Admin moderation gap, creator over-privilege, magic-int checks scattered across the web, and cross-chat analytics/dashboard data leaks.

This PR codifies the permission model **that was always intended** and treats every deviation from it as a bug to fix — **with no DB migration** (`users.permission_level` values, web role claims, and policy strings are all untouched).

## The unified model

One tier ladder, shared by the Telegram bot and the web UI:

| Tier | Scope | How you get it |
|---|---|---|
| **Member** (`-1`, computed, never persisted) | the chat they're in | everyone |
| **Admin** (`0`) | only chats their Telegram account administers | TG admin/creator **or** web "Admin" role |
| **GlobalAdmin** (`1`) | every chat | web role, linked account |
| **Owner** (`2`) | every chat + web infra | web role, linked account |

Resolution collapses to one pure function — `PermissionResolver.Resolve(webTier, isChatAdminOrCreator)`: web Global/Owner → their tier in any chat; else Admin if TG admin/creator here; else Member. `Member = -1` reuses the sentinel the bot already used, so the two scales converge with **zero data churn**.

## What changed

**Bot side**
- New pure `PermissionResolver` + truth-table tests; `CommandRouter.GetPermissionLevelAsync` uses it. Fixes the early-return-on-web-link bug (web-Admin who is also a TG admin can now moderate), creator → Owner-equiv (now Admin), and web-Admin-in-unadministered-chat (now correctly Member).
- `IBotCommand.MinPermissionLevel` / `ExecuteAsync` re-typed `int` → `PermissionLevel` across all commands; public → `Member`, moderation → `Admin`. The `bypassPermissionCheck`/`Math.Max` special-case is gone (redundant under enum gating). Deleted the obsolete `ModerationConstants.AdminPermissionLevel` magic int.
- `/help` is now **driven off the live command registry** instead of a drifted static metadata list — this restores `/mute` and `/mystatus`, which the static list had silently dropped. Labels render from `PermissionLevel.GetDisplayName()` (deletes both bot-side `GetPermissionName` copies).

**Web side**
- Magic-int permission comparisons (`< 2`, `>= 1`) → enum comparisons; `OwnerOnly` → `AuthenticationConstants.PolicyOwnerOnly`; `Audit.razor` uses the policy attribute instead of `Roles=`.
- All permission/role labels derive from `PermissionLevel.GetDisplayName()` — collapsed 5 duplicate mappers (incl. `Login.razor`/`AuthCookieService` `GetRoleName`) into one source. `InviteManagementDialog` color mapper re-typed to the enum (last magic-int permission site).

**Cross-chat leak containment (interim — proper per-chat scoping deferred to #510)**
- **Security fix:** "zero accessible chats" used to collapse to "no filter = everything", leaking **global** Pending/Bans/Trusted counts to an unlinked Admin on the dashboard and Users page. Fixed by adopting the **`chatId = 0` (`GlobalChatId`) = global** convention for these scoping methods — a set containing `0` ⇒ global; **empty ⇒ nothing (0)**; non-empty without `0` ⇒ those chats. Applied to `GetPendingCountAsync`, `GetUserTabCountsAsync`, and `GetPagedUsersAsync`.
- Global analytics tabs (Content Detection, Performance, Welcome) and global dashboard widgets now render **disabled + greyed with no data** for Admins, rather than being hidden — so the layout/affordance is visible but the data is never fetched (leaky child components stay `@if`-gated; a disabled `MudTabPanel` still renders its body). Message Trends (already chat-scoped) stays fully usable.

**Cleanups**
- Removed `UnbanCommand`'s unused `_serviceProvider` field; de-`[TEST]`'d `/delete` (real description/logging now that it surfaces in registry-driven `/help`).

## Tests
- New: `PermissionResolver` truth table, `CommandRouter` resolve→gate authorization tests (Member denied / native chat-admin allowed / web-Admin in foreign chat denied / GlobalAdmin allowed), registry-driven `HelpCommand` tier tests, `PermissionLevel` value/label tests.
- Strengthened: `NotificationPreferencesCard` owner-only-event hiding (was vacuous; now asserts the events are absent, + a GlobalAdmin case).
- E2E flipped to the disable/grey UX: Admin now sees all 4 analytics tab labels (asserts 3 disabled) and the global dashboard cards (asserts greyed placeholders, no numeric value); Expect-based sync points before assertions.
- Full gate green: build 0/0, unit 2008, integration 687, component 1057, E2E 53.

## Follow-up issues (deliberately out of scope here)
- **#510** — per-chat scope analytics & detection data (needs DB view migrations).
- **#511** — standardize on `chatId = 0` (`GlobalChatId`) as the single global sentinel app-wide (retire `null`-as-global and the remaining empty-as-global in `MessageStatsService`).
- **#512** — extend the proven `/ban` username/fuzzy-name target + inline picker to the other user-target commands (`/trust`, `/warn`, `/mute`, `/tempban`, `/unban`).
- **#478** — commented with the bot `CommandRouter` raw-`ex.Message` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
