### PR TITLE
feat(auth): revalidate sessions against the DB + unify WebUser cascade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ tmp/
 
 # Local test/build logs
 logs/
+
+# Triage skill working artifacts (regenerated per /triage run)
+.triage-template.md
+.triage-body-*.md

--- a/TelegramGroupsAdmin.E2ETests/Fixtures/AuthenticatedTestBase.cs
+++ b/TelegramGroupsAdmin.E2ETests/Fixtures/AuthenticatedTestBase.cs
@@ -101,7 +101,7 @@ public abstract class AuthenticatedTestBase : E2ETestBase
 
         // Generate the encrypted cookie value
         var cookieValue = authCookieService.GenerateCookieValue(
-            new WebUserIdentity(user.Id, user.Email, user.PermissionLevel));
+            new WebUserIdentity(user.Id, user.Email, user.PermissionLevel), user.Record.SecurityStamp);
 
         // Extract host and port from the server address
         var baseUri = new Uri(Factory.ServerAddress);

--- a/TelegramGroupsAdmin.E2ETests/Fixtures/SharedAuthenticatedTestBase.cs
+++ b/TelegramGroupsAdmin.E2ETests/Fixtures/SharedAuthenticatedTestBase.cs
@@ -111,7 +111,7 @@ public abstract class SharedAuthenticatedTestBase : SharedE2ETestBase
 
         // Generate the encrypted cookie value
         var cookieValue = authCookieService.GenerateCookieValue(
-            new WebUserIdentity(user.Id, user.Email, user.PermissionLevel));
+            new WebUserIdentity(user.Id, user.Email, user.PermissionLevel), user.Record.SecurityStamp);
 
         // Extract host and port from the server address
         var baseUri = new Uri(SharedFactory.ServerAddress);

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/ProfilePage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/ProfilePage.cs
@@ -40,14 +40,25 @@ public class ProfilePage
     {
         await _page.GotoAsync(BasePath);
         await Expect(_page.Locator(PageTitle)).ToBeVisibleAsync();
+        await WaitForLoadAsync();
     }
 
     /// <summary>
-    /// Waits for the page to fully load.
+    /// Waits for the page to fully load, including all content sections past the render gate.
     /// </summary>
     public async Task WaitForLoadAsync(int timeoutMs = 15000)
     {
         await Expect(_page.Locator(AccountInfoSection)).ToBeVisibleAsync(new() { Timeout = timeoutMs });
+        await Expect(_page.Locator(TotpSection)).ToBeVisibleAsync(new() { Timeout = timeoutMs });
+        await Expect(_page.Locator(TelegramLinkingSection)).ToBeVisibleAsync(new() { Timeout = timeoutMs });
+        // Wait for the Telegram section's content (table or empty state) to have rendered, not just the paper frame.
+        var telegramTable = _page.Locator($"{TelegramLinkingSection} .mud-table");
+        var telegramNoAccounts = _page.Locator($"{TelegramLinkingSection} .mud-alert");
+        await telegramTable.Or(telegramNoAccounts).WaitForAsync(new LocatorWaitForOptions
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = timeoutMs
+        });
     }
 
     #endregion
@@ -601,9 +612,32 @@ public class ProfilePage
     {
         var unlinkButton = _page.Locator($"{TelegramLinkingSection} .mud-table-body tr").Nth(rowIndex)
             .GetByRole(AriaRole.Button, new() { Name = "Unlink" });
+        // Confirm the button is enabled before clicking — ensures the Blazor circuit is live and
+        // the row is fully interactive, not just painted.
+        await Expect(unlinkButton).ToBeEnabledAsync(new() { Timeout = 10000 });
         await unlinkButton.ClickAsync();
-        // Wait for snackbar to appear (indicates operation completed)
-        await Expect(_page.Locator(".mud-snackbar").First).ToBeVisibleAsync();
+        // Wait for snackbar to appear (indicates operation completed).
+        // If the circuit briefly dropped and swallowed the click, the button remains and we retry once.
+        var snackbarLocator = _page.Locator(".mud-snackbar").First;
+        try
+        {
+            await Expect(snackbarLocator).ToBeVisibleAsync(new() { Timeout = 10000 });
+        }
+        catch (PlaywrightException)
+        {
+            // Circuit may have reconnected without processing the click — retry if the row is still there.
+            if (await unlinkButton.IsVisibleAsync())
+            {
+                await Expect(unlinkButton).ToBeEnabledAsync(new() { Timeout = 10000 });
+                await unlinkButton.ClickAsync();
+                await Expect(snackbarLocator).ToBeVisibleAsync(new() { Timeout = 15000 });
+            }
+            else
+            {
+                // Row is gone — the unlink succeeded silently; re-throw to surface any other issue.
+                throw;
+            }
+        }
     }
 
     #endregion

--- a/TelegramGroupsAdmin.E2ETests/PageObjects/Settings/SettingsPage.cs
+++ b/TelegramGroupsAdmin.E2ETests/PageObjects/Settings/SettingsPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.Playwright;
+using static Microsoft.Playwright.Assertions;
 
 namespace TelegramGroupsAdmin.E2ETests.PageObjects.Settings;
 
@@ -13,7 +14,7 @@ public class SettingsPage
     // Selectors
     private const string PageTitle = ".mud-typography-h4";
     private const string LoadingIndicator = ".mud-progress-linear";
-    private const string NavMenu = ".mud-nav-menu";
+    private const string SettingsSidebarHeading = ".mud-typography-h6:has-text('Settings')";
     private const string AccessDeniedAlert = ".mud-alert-error";
 
     // Settings navigation links (in sidebar)
@@ -65,6 +66,15 @@ public class SettingsPage
         {
             // Loading indicator may have already disappeared
         }
+
+        // Wait for the settings sidebar heading to confirm the page body has rendered past the auth gate.
+        // The sidebar "Settings" h6 is always present for any authorised user (it lives outside the
+        // permission-gated nav links), so it is safe to wait on regardless of role.
+        var isAccessDenied = await _page.Locator(AccessDeniedAlert).IsVisibleAsync();
+        if (!isAccessDenied)
+        {
+            await Expect(_page.Locator(SettingsSidebarHeading).First).ToBeVisibleAsync(new() { Timeout = 15000 });
+        }
     }
 
     /// <summary>
@@ -88,11 +98,20 @@ public class SettingsPage
 
     /// <summary>
     /// Returns true if infrastructure settings links are visible (Owner only).
+    /// Uses auto-retrying assertion to avoid races after the render gate.
     /// </summary>
     public async Task<bool> AreInfrastructureSettingsVisibleAsync()
     {
         var generalSettings = _page.Locator(GeneralSettingsLink);
-        return await generalSettings.IsVisibleAsync();
+        try
+        {
+            await Expect(generalSettings).ToBeVisibleAsync(new() { Timeout = 5000 });
+            return true;
+        }
+        catch (PlaywrightException)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/TelegramGroupsAdmin.E2ETests/Tests/Authentication/SessionRevocationE2ETests.cs
+++ b/TelegramGroupsAdmin.E2ETests/Tests/Authentication/SessionRevocationE2ETests.cs
@@ -1,0 +1,87 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.E2ETests.Infrastructure;
+using TelegramGroupsAdmin.Repositories;
+using TelegramGroupsAdmin.Services;
+using static Microsoft.Playwright.Assertions;
+
+namespace TelegramGroupsAdmin.E2ETests.Tests.Authentication;
+
+/// <summary>
+/// End-to-end verification that an active browser session is revoked when its
+/// security stamp no longer matches the database. Exercises the real pipeline:
+/// encrypted cookie -> cookie middleware -> OnValidatePrincipal -> IUserSessionValidator
+/// -> DB -> RejectPrincipal/SignOut -> [Authorize] redirect to /login.
+///
+/// Full-page navigation (Page.GotoAsync) is used deliberately so the HTTP-edge
+/// OnValidatePrincipal handler runs on the next request, rather than waiting on the
+/// 2-minute in-circuit revalidation timer.
+/// </summary>
+[TestFixture]
+public class SessionRevocationE2ETests : AuthenticatedTestBase
+{
+    private static readonly Regex LoginUrl = new("/(login|register)");
+
+    /// <summary>
+    /// Rotating the user's security stamp in the DB (as password/TOTP/permission
+    /// changes do) must invalidate an already-issued cookie on the next request.
+    /// </summary>
+    [Test]
+    public async Task SecurityStampRotation_InvalidatesActiveSession()
+    {
+        // Arrange - authenticated session via cookie carrying the user's current stamp
+        var user = await LoginAsAdminAsync();
+
+        await NavigateToAsync("/");
+        await Expect(Page).Not.ToHaveURLAsync(LoginUrl);
+
+        // Act - rotate the security stamp out from under the live cookie
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var users = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+            await users.UpdateSecurityStampAsync(user.Id);
+        }
+
+        // Assert - the next full-page load is rejected and redirected to login
+        await NavigateToAsync("/");
+        await Expect(Page).ToHaveURLAsync(LoginUrl, new() { Timeout = 10000 });
+    }
+
+    /// <summary>
+    /// Changing a user's permission level rotates the security stamp (forced re-login),
+    /// so an existing elevated session is invalidated rather than retaining stale access.
+    /// Exercises the real UserManagementService path end to end.
+    /// </summary>
+    [Test]
+    public async Task PermissionChange_InvalidatesActiveSession()
+    {
+        // Arrange - authenticated Admin session, plus a real Owner to act as the modifier
+        // (the audit log has a FK on the actor, so the modifier must be a real user).
+        var user = await LoginAsAdminAsync();
+        var owner = await new TestUserBuilder(Factory.Services)
+            .WithEmail(TestCredentials.GenerateEmail("owner"))
+            .WithStandardPassword()
+            .WithEmailVerified()
+            .AsOwner()
+            .BuildAsync();
+
+        await NavigateToAsync("/");
+        await Expect(Page).Not.ToHaveURLAsync(LoginUrl);
+
+        // Act - the Owner changes this user's permission level (rotates the stamp)
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var userManagement = scope.ServiceProvider.GetRequiredService<IUserManagementService>();
+            await userManagement.UpdatePermissionLevelAsync(
+                user.Id,
+                permissionLevel: (int)PermissionLevel.GlobalAdmin,
+                modifiedBy: owner.Id,
+                modifierPermissionLevel: (int)PermissionLevel.Owner);
+        }
+
+        // Assert - the existing session no longer validates and is redirected to login
+        await NavigateToAsync("/");
+        await Expect(Page).ToHaveURLAsync(LoginUrl, new() { Timeout = 10000 });
+    }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/Repositories/SecurityStampRotationRepositoryTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Repositories/SecurityStampRotationRepositoryTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
+using TelegramGroupsAdmin.Repositories;
+
+namespace TelegramGroupsAdmin.IntegrationTests.Repositories;
+
+/// <summary>
+/// Verifies the security-stamp rotation invariant folded into the sensitive
+/// <see cref="IUserRepository"/> mutations. Each method that changes 2FA state or
+/// permission level must rotate the user's <c>SecurityStamp</c> in the same single-row
+/// UPDATE, invalidating existing sessions (forced re-login). Exercises the REAL repository
+/// against real Postgres.
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+public class SecurityStampRotationRepositoryTests
+{
+    private MigrationTestHelper? _testHelper;
+    private IServiceProvider? _serviceProvider;
+
+    [TearDown]
+    public void TearDown()
+    {
+        (_serviceProvider as IDisposable)?.Dispose();
+        _testHelper?.Dispose();
+    }
+
+    private async Task<IServiceProvider> SetUpServicesAsync()
+    {
+        _testHelper = new MigrationTestHelper();
+        await _testHelper.CreateDatabaseFromEmptyTemplateAsync();
+
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>(o => o.UseNpgsql(_testHelper.ConnectionString));
+        services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        services.AddScoped<IUserRepository, UserRepository>();
+        _serviceProvider = services.BuildServiceProvider();
+        return _serviceProvider;
+    }
+
+    [Test]
+    public async Task UpdatePermissionLevelAsync_RotatesSecurityStamp()
+    {
+        var sp = await SetUpServicesAsync();
+        await using var scope = sp.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+
+        var userId = await SeedActiveUserAsync(repo, totpEnabled: false);
+        var before = await repo.GetByIdAsync(userId);
+        Assert.That(before, Is.Not.Null);
+
+        await repo.UpdatePermissionLevelAsync(userId, (int)PermissionLevel.Owner, "admin");
+
+        var after = await repo.GetByIdAsync(userId);
+        Assert.That(after, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after!.SecurityStamp, Is.Not.EqualTo(before!.SecurityStamp), "security stamp must rotate");
+            Assert.That(after.WebUser.PermissionLevel, Is.EqualTo(PermissionLevel.Owner), "permission level must change");
+        });
+    }
+
+    [Test]
+    public async Task EnableTotpAsync_RotatesSecurityStamp()
+    {
+        var sp = await SetUpServicesAsync();
+        await using var scope = sp.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+
+        var userId = await SeedActiveUserAsync(repo, totpEnabled: false);
+        var before = await repo.GetByIdAsync(userId);
+        Assert.That(before, Is.Not.Null);
+
+        await repo.EnableTotpAsync(userId);
+
+        var after = await repo.GetByIdAsync(userId);
+        Assert.That(after, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after!.SecurityStamp, Is.Not.EqualTo(before!.SecurityStamp), "security stamp must rotate");
+            Assert.That(after.TotpEnabled, Is.True, "TOTP must be enabled");
+        });
+    }
+
+    [Test]
+    public async Task DisableTotpAsync_RotatesSecurityStamp()
+    {
+        var sp = await SetUpServicesAsync();
+        await using var scope = sp.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+
+        var userId = await SeedActiveUserAsync(repo, totpEnabled: true, totpSecret: "seeded-secret");
+        var before = await repo.GetByIdAsync(userId);
+        Assert.That(before, Is.Not.Null);
+
+        await repo.DisableTotpAsync(userId);
+
+        var after = await repo.GetByIdAsync(userId);
+        Assert.That(after, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after!.SecurityStamp, Is.Not.EqualTo(before!.SecurityStamp), "security stamp must rotate");
+            Assert.That(after.TotpEnabled, Is.False, "TOTP must be disabled");
+            Assert.That(after.TotpSecret, Is.EqualTo("seeded-secret"), "secret must be preserved on disable");
+        });
+    }
+
+    [Test]
+    public async Task ResetTotpAsync_RotatesSecurityStamp()
+    {
+        var sp = await SetUpServicesAsync();
+        await using var scope = sp.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+
+        var userId = await SeedActiveUserAsync(repo, totpEnabled: true, totpSecret: "seeded-secret");
+        var before = await repo.GetByIdAsync(userId);
+        Assert.That(before, Is.Not.Null);
+
+        await repo.ResetTotpAsync(userId);
+
+        var after = await repo.GetByIdAsync(userId);
+        Assert.That(after, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(after!.SecurityStamp, Is.Not.EqualTo(before!.SecurityStamp), "security stamp must rotate");
+            Assert.That(after.TotpEnabled, Is.False, "TOTP must be disabled");
+            Assert.That(after.TotpSecret, Is.Null, "secret must be cleared on reset");
+        });
+    }
+
+    /// <summary>
+    /// Seeds a minimal Active + EmailVerified user via <see cref="IUserRepository.CreateAsync"/>
+    /// and returns its ID. TOTP fields are configurable per test. No password hashing is needed —
+    /// any non-null hash string satisfies the NOT NULL constraint.
+    /// </summary>
+    private static async Task<string> SeedActiveUserAsync(
+        IUserRepository repo,
+        bool totpEnabled,
+        string? totpSecret = null)
+    {
+        var userId = Guid.NewGuid().ToString();
+        var email = $"stamp-test-{userId}@integration.test";
+        var now = DateTimeOffset.UtcNow;
+
+        var userRecord = new UserRecord(
+            WebUser: new WebUserIdentity(userId, email, PermissionLevel.Admin),
+            NormalizedEmail: email.ToUpperInvariant(),
+            PasswordHash: "not-a-real-hash",
+            SecurityStamp: Guid.NewGuid().ToString(),
+            InvitedBy: null,
+            IsActive: true,
+            TotpSecret: totpSecret,
+            TotpEnabled: totpEnabled,
+            TotpSetupStartedAt: null,
+            CreatedAt: now,
+            LastLoginAt: null,
+            Status: UserStatus.Active,
+            ModifiedBy: null,
+            ModifiedAt: null,
+            EmailVerified: true,
+            EmailVerificationToken: null,
+            EmailVerificationTokenExpiresAt: null,
+            PasswordResetToken: null,
+            PasswordResetTokenExpiresAt: null,
+            FailedLoginAttempts: 0,
+            LockedUntil: null
+        );
+
+        await repo.CreateAsync(userRecord);
+        return userId;
+    }
+}

--- a/TelegramGroupsAdmin.IntegrationTests/Services/Auth/SessionRevocationTests.cs
+++ b/TelegramGroupsAdmin.IntegrationTests/Services/Auth/SessionRevocationTests.cs
@@ -1,0 +1,123 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Security.Claims;
+using TelegramGroupsAdmin.Auth;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
+using TelegramGroupsAdmin.Repositories;
+using TelegramGroupsAdmin.Services.Auth;
+
+namespace TelegramGroupsAdmin.IntegrationTests.Services.Auth;
+
+[TestFixture]
+[Category("Integration")]
+public class SessionRevocationTests
+{
+    private MigrationTestHelper? _testHelper;
+    private IServiceProvider? _serviceProvider;
+
+    [TearDown]
+    public void TearDown()
+    {
+        (_serviceProvider as IDisposable)?.Dispose();
+        _testHelper?.Dispose();
+    }
+
+    private async Task<IServiceProvider> SetUpServicesAsync()
+    {
+        _testHelper = new MigrationTestHelper();
+        await _testHelper.CreateDatabaseFromEmptyTemplateAsync();
+
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>(o => o.UseNpgsql(_testHelper.ConnectionString));
+        services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IUserSessionValidator, UserSessionValidator>();
+        _serviceProvider = services.BuildServiceProvider();
+        return _serviceProvider;
+    }
+
+    private static ClaimsPrincipal PrincipalFor(string userId, string stamp) =>
+        new(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(CustomClaimTypes.SecurityStamp, stamp)
+        ], "test"));
+
+    [Test]
+    public async Task ValidatorRejectsAfterStampRotation()
+    {
+        var sp = await SetUpServicesAsync();
+        await using var scope = sp.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+        var validator = scope.ServiceProvider.GetRequiredService<IUserSessionValidator>();
+
+        var userId = await SeedActiveUserAsync(repo);
+        var user = await repo.GetByIdAsync(userId);
+        Assert.That(user, Is.Not.Null);
+
+        var principal = PrincipalFor(userId, user!.SecurityStamp);
+        Assert.That(await validator.IsStillValidAsync(principal), Is.True, "fresh session should be valid");
+
+        await repo.UpdateSecurityStampAsync(userId);
+        Assert.That(await validator.IsStillValidAsync(principal), Is.False, "session with old stamp must be rejected");
+    }
+
+    [Test]
+    public async Task ValidatorRejectsAfterDisable()
+    {
+        var sp = await SetUpServicesAsync();
+        await using var scope = sp.CreateAsyncScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+        var validator = scope.ServiceProvider.GetRequiredService<IUserSessionValidator>();
+
+        var userId = await SeedActiveUserAsync(repo);
+        var user = await repo.GetByIdAsync(userId);
+        var principal = PrincipalFor(userId, user!.SecurityStamp);
+        Assert.That(await validator.IsStillValidAsync(principal), Is.True);
+
+        await repo.UpdateStatusAsync(userId, UserStatus.Disabled, "admin");
+        Assert.That(await validator.IsStillValidAsync(principal), Is.False);
+    }
+
+    /// <summary>
+    /// Seeds a minimal Active + EmailVerified user via <see cref="IUserRepository.CreateAsync"/>
+    /// and returns its ID. No password hashing is needed for these validator tests —
+    /// any non-null hash string satisfies the NOT NULL constraint.
+    /// </summary>
+    private static async Task<string> SeedActiveUserAsync(IUserRepository repo)
+    {
+        var userId = Guid.NewGuid().ToString();
+        var email = $"session-test-{userId}@integration.test";
+        var now = DateTimeOffset.UtcNow;
+
+        var userRecord = new UserRecord(
+            WebUser: new WebUserIdentity(userId, email, PermissionLevel.Admin),
+            NormalizedEmail: email.ToUpperInvariant(),
+            PasswordHash: "not-a-real-hash",
+            SecurityStamp: Guid.NewGuid().ToString(),
+            InvitedBy: null,
+            IsActive: true,
+            TotpSecret: null,
+            TotpEnabled: false,
+            TotpSetupStartedAt: null,
+            CreatedAt: now,
+            LastLoginAt: null,
+            Status: UserStatus.Active,
+            ModifiedBy: null,
+            ModifiedAt: null,
+            EmailVerified: true,
+            EmailVerificationToken: null,
+            EmailVerificationTokenExpiresAt: null,
+            PasswordResetToken: null,
+            PasswordResetTokenExpiresAt: null,
+            FailedLoginAttempts: 0,
+            LockedUntil: null
+        );
+
+        await repo.CreateAsync(userRecord);
+        return userId;
+    }
+}

--- a/TelegramGroupsAdmin.UnitTests/Services/Auth/AuthCookieServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/Auth/AuthCookieServiceTests.cs
@@ -70,7 +70,7 @@ public class AuthCookieServiceTests
         };
 
         // Act
-        await _service.SignInAsync(httpContext, TestIdentity());
+        await _service.SignInAsync(httpContext, TestIdentity(), "test-stamp");
 
         // Assert
         await mockAuthService.Received(1).SignInAsync(
@@ -98,7 +98,7 @@ public class AuthCookieServiceTests
         var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
 
         // Act
-        await _service.SignInAsync(httpContext, TestIdentity());
+        await _service.SignInAsync(httpContext, TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(capturedPrincipal, Is.Not.Null);
@@ -125,7 +125,7 @@ public class AuthCookieServiceTests
         var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
 
         // Act
-        await _service.SignInAsync(httpContext, TestIdentity());
+        await _service.SignInAsync(httpContext, TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(capturedPrincipal, Is.Not.Null);
@@ -152,7 +152,7 @@ public class AuthCookieServiceTests
         var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
 
         // Act
-        await _service.SignInAsync(httpContext, TestIdentity(PermissionLevel.GlobalAdmin));
+        await _service.SignInAsync(httpContext, TestIdentity(PermissionLevel.GlobalAdmin), "test-stamp");
 
         // Assert
         Assert.That(capturedPrincipal, Is.Not.Null);
@@ -181,7 +181,7 @@ public class AuthCookieServiceTests
         var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
 
         // Act
-        await _service.SignInAsync(httpContext, TestIdentity(level));
+        await _service.SignInAsync(httpContext, TestIdentity(level), "test-stamp");
 
         // Assert
         Assert.That(capturedPrincipal, Is.Not.Null);
@@ -208,7 +208,7 @@ public class AuthCookieServiceTests
         var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
 
         // Act
-        await _service.SignInAsync(httpContext, TestIdentity());
+        await _service.SignInAsync(httpContext, TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(capturedProps, Is.Not.Null);
@@ -235,7 +235,7 @@ public class AuthCookieServiceTests
         var beforeCall = DateTimeOffset.UtcNow;
 
         // Act
-        await _service.SignInAsync(httpContext, TestIdentity());
+        await _service.SignInAsync(httpContext, TestIdentity(), "test-stamp");
 
         var afterCall = DateTimeOffset.UtcNow;
 
@@ -290,7 +290,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Any<AuthenticationTicket>()).Returns("encrypted-cookie-value");
 
         // Act
-        var result = _service.GenerateCookieValue(TestIdentity());
+        var result = _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         // Assert
         _mockTicketDataFormat.Received(1).Protect(Arg.Any<AuthenticationTicket>());
@@ -304,7 +304,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Any<AuthenticationTicket>()).Returns(expectedEncryptedValue);
 
         // Act
-        var result = _service.GenerateCookieValue(TestIdentity());
+        var result = _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(result, Is.EqualTo(expectedEncryptedValue));
@@ -318,7 +318,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(TestIdentity());
+        _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);
@@ -335,7 +335,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(TestIdentity());
+        _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);
@@ -354,7 +354,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(TestIdentity(level));
+        _service.GenerateCookieValue(TestIdentity(level), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);
@@ -373,7 +373,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(TestIdentity(level));
+        _service.GenerateCookieValue(TestIdentity(level), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);
@@ -390,7 +390,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(TestIdentity());
+        _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);
@@ -405,7 +405,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(TestIdentity());
+        _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);
@@ -422,7 +422,7 @@ public class AuthCookieServiceTests
         var beforeCall = DateTimeOffset.UtcNow;
 
         // Act
-        _service.GenerateCookieValue(TestIdentity());
+        _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         var afterCall = DateTimeOffset.UtcNow;
 
@@ -446,7 +446,7 @@ public class AuthCookieServiceTests
         var beforeCall = DateTimeOffset.UtcNow;
 
         // Act
-        _service.GenerateCookieValue(TestIdentity());
+        _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         var afterCall = DateTimeOffset.UtcNow;
 
@@ -470,7 +470,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(TestIdentity());
+        _service.GenerateCookieValue(TestIdentity(), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);
@@ -483,6 +483,23 @@ public class AuthCookieServiceTests
 
     #endregion
 
+    [Test]
+    public void GenerateCookieValue_IncludesSecurityStampClaim()
+    {
+        // Arrange
+        const string stamp = "stamp-abc-123";
+        AuthenticationTicket? captured = null;
+        _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => captured = t)).Returns("protected");
+
+        // Act
+        _service.GenerateCookieValue(TestIdentity(), stamp);
+
+        // Assert
+        Assert.That(captured, Is.Not.Null);
+        var stampClaim = captured!.Principal.FindFirst(CustomClaimTypes.SecurityStamp);
+        Assert.That(stampClaim?.Value, Is.EqualTo(stamp));
+    }
+
     #region Edge Cases
 
     [Test]
@@ -494,7 +511,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(new WebUserIdentity(TestUserId, emailWithSpecialChars, PermissionLevel.Admin));
+        _service.GenerateCookieValue(new WebUserIdentity(TestUserId, emailWithSpecialChars, PermissionLevel.Admin), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);
@@ -511,7 +528,7 @@ public class AuthCookieServiceTests
         _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => capturedTicket = t)).Returns("cookie");
 
         // Act
-        _service.GenerateCookieValue(new WebUserIdentity(guidUserId, TestEmail, PermissionLevel.Owner));
+        _service.GenerateCookieValue(new WebUserIdentity(guidUserId, TestEmail, PermissionLevel.Owner), "test-stamp");
 
         // Assert
         Assert.That(capturedTicket, Is.Not.Null);

--- a/TelegramGroupsAdmin.UnitTests/Services/Auth/UserSessionValidatorTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/Auth/UserSessionValidatorTests.cs
@@ -1,0 +1,106 @@
+using System.Security.Claims;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using TelegramGroupsAdmin.Auth;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Repositories;
+using TelegramGroupsAdmin.Services.Auth;
+
+namespace TelegramGroupsAdmin.UnitTests.Services.Auth;
+
+[TestFixture]
+public class UserSessionValidatorTests
+{
+    private IUserRepository _userRepository = null!;
+    private UserSessionValidator _validator = null!;
+
+    private const string UserId = "user-1";
+    private const string Stamp = "stamp-1";
+
+    [SetUp]
+    public void SetUp()
+    {
+        _userRepository = Substitute.For<IUserRepository>();
+        _validator = new UserSessionValidator(_userRepository, NullLogger<UserSessionValidator>.Instance);
+    }
+
+    private static ClaimsPrincipal Principal(string? userId, string? stamp)
+    {
+        var claims = new List<Claim>();
+        if (userId is not null) claims.Add(new Claim(ClaimTypes.NameIdentifier, userId));
+        if (stamp is not null) claims.Add(new Claim(CustomClaimTypes.SecurityStamp, stamp));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+    }
+
+    private static UserRecord UserWith(UserStatus status, string stamp) => new(
+        WebUser: new WebUserIdentity(UserId, "u@example.com", PermissionLevel.Admin),
+        NormalizedEmail: "U@EXAMPLE.COM",
+        PasswordHash: "x",
+        SecurityStamp: stamp,
+        InvitedBy: null,
+        IsActive: status == UserStatus.Active,
+        TotpSecret: null,
+        TotpEnabled: false,
+        TotpSetupStartedAt: null,
+        CreatedAt: DateTimeOffset.UnixEpoch,
+        LastLoginAt: null,
+        Status: status,
+        ModifiedBy: null,
+        ModifiedAt: null,
+        EmailVerified: true,
+        EmailVerificationToken: null,
+        EmailVerificationTokenExpiresAt: null,
+        PasswordResetToken: null,
+        PasswordResetTokenExpiresAt: null,
+        FailedLoginAttempts: 0,
+        LockedUntil: null);
+
+    [Test]
+    public async Task ValidUser_ReturnsTrue()
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>())
+            .Returns(UserWith(UserStatus.Active, Stamp));
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.True);
+    }
+
+    [Test]
+    public async Task MissingUserIdClaim_ReturnsFalse()
+        => Assert.That(await _validator.IsStillValidAsync(Principal(null, Stamp)), Is.False);
+
+    [Test]
+    public async Task MissingStampClaim_ReturnsFalse()
+        => Assert.That(await _validator.IsStillValidAsync(Principal(UserId, null)), Is.False);
+
+    [Test]
+    public async Task UserNotFound_ReturnsFalse()
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>()).Returns((UserRecord?)null);
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.False);
+    }
+
+    [TestCase(UserStatus.Disabled)]
+    [TestCase(UserStatus.Deleted)]
+    [TestCase(UserStatus.Pending)]
+    public async Task NonActiveStatus_ReturnsFalse(UserStatus status)
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>())
+            .Returns(UserWith(status, Stamp));
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.False);
+    }
+
+    [Test]
+    public async Task StampMismatch_ReturnsFalse()
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>())
+            .Returns(UserWith(UserStatus.Active, "different-stamp"));
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.False);
+    }
+
+    [Test]
+    public async Task RepositoryThrows_FailsClosed()
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>())
+            .Returns<UserRecord?>(_ => throw new InvalidOperationException("db down"));
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.False);
+    }
+}

--- a/TelegramGroupsAdmin.UnitTests/Services/UserManagementServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/UserManagementServiceTests.cs
@@ -21,13 +21,13 @@ public class UserManagementServiceTests
     }
 
     [Test]
-    public async Task UpdatePermissionLevelAsync_RotatesSecurityStamp()
+    public async Task UpdatePermissionLevelAsync_DelegatesToRepository()
     {
         // Act: modifier is Owner (level 2) downgrading a user to Admin (level 0)
         await _service.UpdatePermissionLevelAsync("target-user", permissionLevel: 0, modifiedBy: "owner-user", modifierPermissionLevel: 2);
 
-        // Assert
+        // Assert: the repository method now rotates the security stamp atomically within the
+        // same single-row UPDATE, so the service no longer makes a separate rotation call.
         await _userRepository.Received(1).UpdatePermissionLevelAsync("target-user", 0, "owner-user", Arg.Any<CancellationToken>());
-        await _userRepository.Received(1).UpdateSecurityStampAsync("target-user", Arg.Any<CancellationToken>());
     }
 }

--- a/TelegramGroupsAdmin.UnitTests/Services/UserManagementServiceTests.cs
+++ b/TelegramGroupsAdmin.UnitTests/Services/UserManagementServiceTests.cs
@@ -1,0 +1,33 @@
+using NSubstitute;
+using TelegramGroupsAdmin.Core.Services;
+using TelegramGroupsAdmin.Repositories;
+using TelegramGroupsAdmin.Services;
+
+namespace TelegramGroupsAdmin.UnitTests.Services;
+
+[TestFixture]
+public class UserManagementServiceTests
+{
+    private IUserRepository _userRepository = null!;
+    private IAuditService _auditService = null!;
+    private UserManagementService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _userRepository = Substitute.For<IUserRepository>();
+        _auditService = Substitute.For<IAuditService>();
+        _service = new UserManagementService(_userRepository, _auditService);
+    }
+
+    [Test]
+    public async Task UpdatePermissionLevelAsync_RotatesSecurityStamp()
+    {
+        // Act: modifier is Owner (level 2) downgrading a user to Admin (level 0)
+        await _service.UpdatePermissionLevelAsync("target-user", permissionLevel: 0, modifiedBy: "owner-user", modifierPermissionLevel: 2);
+
+        // Assert
+        await _userRepository.Received(1).UpdatePermissionLevelAsync("target-user", 0, "owner-user", Arg.Any<CancellationToken>());
+        await _userRepository.Received(1).UpdateSecurityStampAsync("target-user", Arg.Any<CancellationToken>());
+    }
+}

--- a/TelegramGroupsAdmin/Auth/CustomClaimTypes.cs
+++ b/TelegramGroupsAdmin/Auth/CustomClaimTypes.cs
@@ -9,4 +9,10 @@ public static class CustomClaimTypes
     /// Permission level claim (0=Admin, 1=GlobalAdmin, 2=Owner).
     /// </summary>
     public const string PermissionLevel = "PermissionLevel";
+
+    /// <summary>
+    /// Security stamp claim. Compared against the DB on every session revalidation;
+    /// a mismatch (stamp rotated by password/TOTP/permission change) invalidates the session.
+    /// </summary>
+    public const string SecurityStamp = "SecurityStamp";
 }

--- a/TelegramGroupsAdmin/Auth/RevalidatingUserAuthenticationStateProvider.cs
+++ b/TelegramGroupsAdmin/Auth/RevalidatingUserAuthenticationStateProvider.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server;
+using Microsoft.Extensions.DependencyInjection;
+using TelegramGroupsAdmin.Constants;
+using TelegramGroupsAdmin.Services.Auth;
+
+namespace TelegramGroupsAdmin.Auth;
+
+/// <summary>
+/// Tears down a live Blazor circuit when its session is no longer valid (user
+/// disabled/deleted, or security stamp rotated by password/TOTP/permission change).
+/// Complements the cookie OnValidatePrincipal handler, which only runs at the HTTP edge.
+/// </summary>
+public sealed class RevalidatingUserAuthenticationStateProvider(
+    ILoggerFactory loggerFactory,
+    IServiceScopeFactory scopeFactory)
+    : RevalidatingServerAuthenticationStateProvider(loggerFactory)
+{
+    protected override TimeSpan RevalidationInterval => AuthenticationConstants.RevalidationInterval;
+
+    protected override async Task<bool> ValidateAuthenticationStateAsync(
+        AuthenticationState authenticationState, CancellationToken cancellationToken)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var validator = scope.ServiceProvider.GetRequiredService<IUserSessionValidator>();
+        return await validator.IsStillValidAsync(authenticationState.User, cancellationToken);
+    }
+}

--- a/TelegramGroupsAdmin/Components/Layout/MainLayout.razor
+++ b/TelegramGroupsAdmin/Components/Layout/MainLayout.razor
@@ -40,7 +40,16 @@
             </MudDrawer>
             <MudMainContent>
                 <MudContainer MaxWidth="MaxWidth.ExtraExtraLarge" Class="my-4">
-                    @Body
+                    @if (_authResolved)
+                    {
+                        @Body
+                    }
+                    else
+                    {
+                        <div class="d-flex justify-center my-8">
+                            <MudProgressCircular Indeterminate="true" />
+                        </div>
+                    }
                 </MudContainer>
             </MudMainContent>
         </MudLayout>
@@ -53,6 +62,7 @@
     private string? _userId;
     private bool _isAuthenticated;
     private bool _isDevelopment;
+    private bool _authResolved;
     private WebUserIdentity? _webUser;
     private TimeZoneInfo? _userTimeZone;
 
@@ -106,22 +116,31 @@
 
         if (user.Identity?.IsAuthenticated ?? false)
         {
-            _isAuthenticated = true;
-            _userEmail = user.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
             _userId = user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
 
-            var permissionLevel = PermissionLevel.Admin;
-            var permissionClaim = user.FindFirst(CustomClaimTypes.PermissionLevel);
-            if (permissionClaim != null && int.TryParse(permissionClaim.Value, out var level))
-                permissionLevel = (PermissionLevel)level;
-            _webUser = new WebUserIdentity(_userId!, _userEmail, permissionLevel);
-
-            // Initialize notification state for the authenticated user
-            if (!string.IsNullOrEmpty(_userId))
+            if (string.IsNullOrEmpty(_userId))
             {
+                // An authenticated principal with no subject id is anomalous (and possible now
+                // that principals are re-issued). Treat as not a usable session rather than
+                // constructing a half-valid identity.
+                Logger.LogWarning("Authenticated principal is missing the NameIdentifier claim; treating as unauthenticated");
+            }
+            else
+            {
+                _isAuthenticated = true;
+                _userEmail = user.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
+
+                var permissionLevel = PermissionLevel.Admin;
+                var permissionClaim = user.FindFirst(CustomClaimTypes.PermissionLevel);
+                if (permissionClaim != null && int.TryParse(permissionClaim.Value, out var level))
+                    permissionLevel = (PermissionLevel)level;
+                _webUser = new WebUserIdentity(_userId, _userEmail, permissionLevel);
+
                 await NotificationState.InitializeAsync(_userId);
             }
         }
+
+        _authResolved = true;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/TelegramGroupsAdmin/Components/Layout/NavMenu.razor
+++ b/TelegramGroupsAdmin/Components/Layout/NavMenu.razor
@@ -1,7 +1,4 @@
-﻿@using Microsoft.AspNetCore.Components.Authorization
-@using TelegramGroupsAdmin.Auth
-@inject AuthenticationStateProvider AuthStateProvider
-
+﻿
 <MudNavMenu>
     @if (_isAuthenticated)
     {
@@ -34,28 +31,10 @@
 
 @code {
     [Inject] private NavigationManager Navigation { get; set; } = null!;
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
 
-    private bool _isAuthenticated;
-    private bool _isGlobalAdminOrOwner;
-
-    protected override async Task OnInitializedAsync()
-    {
-        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        var user = authState.User;
-
-        _isAuthenticated = user.Identity?.IsAuthenticated ?? false;
-
-        if (_isAuthenticated)
-        {
-            var permissionClaim = user.FindFirst(CustomClaimTypes.PermissionLevel);
-            if (permissionClaim != null && int.TryParse(permissionClaim.Value, out var level))
-            {
-                // Member=-1, Admin=0, GlobalAdmin=1, Owner=2
-                // GlobalAdmin and Owner can see Settings, Audit, Chat Management
-                _isGlobalAdminOrOwner = (PermissionLevel)level >= PermissionLevel.GlobalAdmin;
-            }
-        }
-    }
+    private bool _isAuthenticated => WebUser is not null;
+    private bool _isGlobalAdminOrOwner => WebUser?.IsGlobalAdminOrHigher ?? false;
 
     private void LogoutAsync()
     {

--- a/TelegramGroupsAdmin/Components/Pages/Login.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Login.razor
@@ -1,13 +1,10 @@
 @page "/login"
 @using System.ComponentModel.DataAnnotations
-@using System.Security.Claims
-@using Microsoft.AspNetCore.Authentication
-@using Microsoft.AspNetCore.Authentication.Cookies
-@using TelegramGroupsAdmin.Auth
 @using TelegramGroupsAdmin.Helpers
 @using TelegramGroupsAdmin.Services
 @using TelegramGroupsAdmin.Services.Auth
 @inject IAuthService AuthService
+@inject IAuthCookieService AuthCookieService
 @inject IIntermediateAuthService IntermediateAuthService
 @inject IFeatureAvailabilityService FeatureAvailability
 @inject IHttpContextAccessor HttpContextAccessor
@@ -173,27 +170,13 @@
                 return;
             }
 
-            var claims = new List<Claim>
-            {
-                new(ClaimTypes.NameIdentifier, result.UserId!),
-                new(ClaimTypes.Email, result.Email!),
-                new(ClaimTypes.Role, result.PermissionLevel!.Value.GetDisplayName()),
-                new(CustomClaimTypes.PermissionLevel, ((int)result.PermissionLevel.Value).ToString())
-            };
-
-            var claimsIdentity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
-            var claimsPrincipal = new ClaimsPrincipal(claimsIdentity);
-
-            var authProperties = new AuthenticationProperties
-            {
-                IsPersistent = true,
-                ExpiresUtc = DateTimeOffset.UtcNow.AddDays(30)
-            };
-
-            await httpContext.SignInAsync(
-                CookieAuthenticationDefaults.AuthenticationScheme,
-                claimsPrincipal,
-                authProperties);
+            // Use the shared cookie service so the principal includes the security-stamp
+            // claim (single source of truth for cookie claims). A hand-rolled principal here
+            // would omit the stamp and be rejected by session revalidation on the next request.
+            await AuthCookieService.SignInAsync(
+                httpContext,
+                new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value),
+                result.SecurityStamp ?? throw new InvalidOperationException("SecurityStamp must be set on a successful AuthResult before sign-in"));
 
             // Redirect using HttpContext (safeReturnUrl validated at top of try block)
             httpContext.Response.Redirect(safeReturnUrl);

--- a/TelegramGroupsAdmin/Components/Pages/LoginVerify.razor
+++ b/TelegramGroupsAdmin/Components/Pages/LoginVerify.razor
@@ -196,7 +196,7 @@
                 return;
             }
 
-            await AuthCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
+            await AuthCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp ?? throw new InvalidOperationException("SecurityStamp must be set on a successful AuthResult before sign-in"));
 
             // Redirect using HttpContext (validate URL to prevent open redirect attacks)
             var safeReturnUrl = UrlHelpers.GetSafeRedirectUrl(ReturnUrl);
@@ -250,7 +250,7 @@
                 return;
             }
 
-            await AuthCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
+            await AuthCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp ?? throw new InvalidOperationException("SecurityStamp must be set on a successful AuthResult before sign-in"));
 
             Logger.LogInformation("User {UserId} logged in using recovery code", UserId);
 

--- a/TelegramGroupsAdmin/Components/Pages/LoginVerify.razor
+++ b/TelegramGroupsAdmin/Components/Pages/LoginVerify.razor
@@ -196,7 +196,7 @@
                 return;
             }
 
-            await AuthCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value));
+            await AuthCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
 
             // Redirect using HttpContext (validate URL to prevent open redirect attacks)
             var safeReturnUrl = UrlHelpers.GetSafeRedirectUrl(ReturnUrl);
@@ -250,7 +250,7 @@
                 return;
             }
 
-            await AuthCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value));
+            await AuthCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
 
             Logger.LogInformation("User {UserId} logged in using recovery code", UserId);
 

--- a/TelegramGroupsAdmin/Components/Pages/Setup2FA.razor
+++ b/TelegramGroupsAdmin/Components/Pages/Setup2FA.razor
@@ -336,7 +336,7 @@
             return;
         }
 
-        await AuthCookieService.SignInAsync(httpContext, user.WebUser);
+        await AuthCookieService.SignInAsync(httpContext, user.WebUser, user.SecurityStamp);
 
         // Redirect (validate URL to prevent open redirect attacks)
         var safeReturnUrl = UrlHelpers.GetSafeRedirectUrl(ReturnUrl);

--- a/TelegramGroupsAdmin/Components/Shared/BackupPassphraseRotationDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/BackupPassphraseRotationDialog.razor
@@ -1,9 +1,7 @@
 @using TelegramGroupsAdmin.BackgroundJobs.Services.Backup
-@using Microsoft.AspNetCore.Components.Authorization
 @inject IPassphraseManagementService PassphraseService
 @inject ISnackbar Snackbar
 @inject IJSRuntime JsRuntime
-@inject AuthenticationStateProvider AuthStateProvider
 
 <MudDialog>
     <TitleContent>
@@ -150,6 +148,7 @@
 
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
     [Parameter] public string BackupDirectory { get; set; } = "/data/backups";
 
     private enum RotationStep
@@ -181,22 +180,13 @@
 
         try
         {
-            // Get current user ID (web user GUID string)
-            var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-
-            // Get user ID claim (ClaimTypes.NameIdentifier contains the GUID string)
-            var userIdClaim = authState.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
-
-            if (userIdClaim == null)
+            if (WebUser is null)
             {
-                var availableClaims = string.Join(", ", authState.User.Claims.Select(c => c.Type));
-                throw new InvalidOperationException($"User ID claim not found. Available claims: {availableClaims}");
+                Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+                _isProcessing = false;
+                return;
             }
-
-            var userId = userIdClaim.Value; // Web user GUID string (e.g., "b388ee38-0ed3-4c09-9def-5715f9f07f56")
-
-            // Store userId for later when user confirms they saved the passphrase
-            _userId = userId;
+            _userId = WebUser.Id;
 
             // Use custom passphrase if provided, otherwise generate (but DON'T queue job yet!)
             if (_useCustomPassphrase)

--- a/TelegramGroupsAdmin/Components/Shared/ContentDetection/CriticalChecks.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ContentDetection/CriticalChecks.razor
@@ -242,7 +242,12 @@
             StateHasChanged();
 
             // Save the entire config (which now includes AlwaysRun in each sub-config)
-            var actor = WebUser!.ToActor();
+            if (WebUser is null)
+            {
+                Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+                return;
+            }
+            var actor = WebUser.ToActor();
             await ConfigService.SaveContentDetectionAsync(new ChatIdentity(0, "Global"), _config, actor);
 
             Snackbar.Add("Critical checks configuration saved successfully", Severity.Success);

--- a/TelegramGroupsAdmin/Components/Shared/ContentDetection/StopWords.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ContentDetection/StopWords.razor
@@ -1,7 +1,5 @@
-@using Microsoft.AspNetCore.Components.Authorization
 @using TelegramGroupsAdmin.ContentDetection.Repositories
 @inject IStopWordsRepository StopWordsRepository
-@inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 
@@ -129,16 +127,15 @@
 </MudContainer>
 
 @code {
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+
     private List<StopWordItem> _allStopWords = [];
     private IEnumerable<StopWordItem> _filteredStopWords = new List<StopWordItem>();
     private bool _loading = true;
     private string _searchText = string.Empty;
-    private string? _currentUserId;
 
     protected override async Task OnInitializedAsync()
     {
-        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        _currentUserId = authState.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
         await LoadStopWords();
     }
 
@@ -176,6 +173,12 @@
 
     private async Task AddStopWord()
     {
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            return;
+        }
+
         var dialog = await DialogService.ShowAsync<AddStopWordDialog>("Add Stop Word");
         var result = await dialog.Result;
 
@@ -188,7 +191,7 @@
                     Word: data.Word.ToLowerInvariant(),
                     Enabled: true,
                     AddedDate: DateTimeOffset.UtcNow,
-                    AddedBy: _currentUserId,
+                    AddedBy: WebUser.Id,
                     Notes: data.Notes
                 );
                 await StopWordsRepository.AddStopWordAsync(stopWord);

--- a/TelegramGroupsAdmin/Components/Shared/ContentDetection/TrainingData.razor
+++ b/TelegramGroupsAdmin/Components/Shared/ContentDetection/TrainingData.razor
@@ -1,9 +1,7 @@
-@using Microsoft.AspNetCore.Components.Authorization
 @using TelegramGroupsAdmin.ContentDetection.Repositories
 @using TelegramGroupsAdmin.ContentDetection.Models
 @using TelegramGroupsAdmin.Core.BackgroundJobs
 @inject IDetectionResultsRepository DetectionResultsRepository
-@inject AuthenticationStateProvider AuthStateProvider
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject TelegramGroupsAdmin.Core.Services.IJobTriggerService JobTriggerService
@@ -165,6 +163,8 @@
 </MudContainer>
 
 @code {
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+
     private List<DetectionResultRecord> _allSamples = [];
     private IEnumerable<DetectionResultRecord> _filteredSamples = new List<DetectionResultRecord>();
     private TrainingDataStats? _stats;
@@ -172,7 +172,6 @@
     private string _searchText = string.Empty;
     private string _typeFilter = "all";
     private string _sourceFilter = "all";
-    private string? _currentUserId;
     private HashSet<int> _conflictedMessageIds = [];
 
     // Translation toggle state per sample (Phase 4.20+: Show translations in training samples)
@@ -204,8 +203,6 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        _currentUserId = authState.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
         await LoadData();
     }
 
@@ -293,6 +290,12 @@
 
     private async Task AddTrainingSample()
     {
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            return;
+        }
+
         var dialog = await DialogService.ShowAsync<AddTrainingSampleDialog>("Add Training Sample");
         var result = await dialog.Result;
 
@@ -305,7 +308,7 @@
                     data.IsSpam,
                     data.Source,
                     data.Score,
-                    _currentUserId,
+                    WebUser.Id,
                     data.TranslatedText,
                     data.DetectedLanguage);
 
@@ -323,6 +326,12 @@
 
     private async Task EditTrainingSample(DetectionResultRecord sample)
     {
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            return;
+        }
+
         var parameters = new DialogParameters<EditTrainingSampleDialog>
         {
             { x => x.Sample, sample }
@@ -344,7 +353,7 @@
                     data.IsSpam,
                     data.Source,
                     data.Score,
-                    _currentUserId);
+                    WebUser.Id);
 
                 Snackbar.Add("Training sample updated successfully", Severity.Success);
                 await TriggerRetrainingAsync();

--- a/TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor
+++ b/TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor
@@ -1,9 +1,7 @@
 @using TelegramGroupsAdmin.Services
-@using Microsoft.AspNetCore.Components.Authorization
 @inject IInviteService InviteService
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation
-@inject AuthenticationStateProvider AuthStateProvider
 
 <MudDialog DefaultFocus="DefaultFocus.Element">
     <DialogContent>
@@ -107,6 +105,7 @@
 @code {
     [CascadingParameter]
     IMudDialogInstance? MudDialog { get; set; }
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
 
     /// <summary>
     /// The permission level of the current user viewing the dialog.
@@ -120,18 +119,9 @@
     private Dictionary<string, string> _userEmails = new();
     private bool _loading = true;
     private string _filter = "pending";
-    private string? _currentUserId;
 
     protected override async Task OnInitializedAsync()
     {
-        // Get current user ID
-        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        var user = authState.User;
-        if (user.Identity?.IsAuthenticated == true)
-        {
-            _currentUserId = user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
-        }
-
         await LoadInvitesAsync();
     }
 
@@ -202,9 +192,15 @@
 
     private async Task RevokeInvite(string token)
     {
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            return;
+        }
+
         try
         {
-            var success = await InviteService.RevokeInviteAsync(token, _currentUserId!);
+            var success = await InviteService.RevokeInviteAsync(token, WebUser.Id);
             if (success)
             {
                 Snackbar.Add("Invite revoked successfully", Severity.Success);

--- a/TelegramGroupsAdmin/Components/Shared/Settings/TagManagement.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/TagManagement.razor
@@ -1,9 +1,7 @@
 @using TelegramGroupsAdmin.Helpers
-@using Microsoft.AspNetCore.Components.Authorization
 @inject ITagDefinitionsRepository TagDefinitionsRepository
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
-@inject AuthenticationStateProvider AuthenticationStateProvider
 
 <MudStack Spacing="4">
     <MudPaper Class="pa-4">
@@ -94,15 +92,15 @@
 @code {
     private List<TagDefinition> _tags = [];
     private bool _loading = true;
-    private bool _canEdit;
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+
+    // Preserves prior IsInRole("Admin")||IsInRole("Owner") semantics EXACTLY:
+    // grants edit to Admin and Owner only (NOT GlobalAdmin). The GlobalAdmin exclusion
+    // looks like a pre-existing bug — flagged for a separate decision, not changed here.
+    private bool _canEdit => WebUser?.PermissionLevel is PermissionLevel.Admin or PermissionLevel.Owner;
 
     protected override async Task OnInitializedAsync()
     {
-        // Check if user has Admin or Owner role
-        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-        var user = authState.User;
-        _canEdit = user.IsInRole("Admin") || user.IsInRole("Owner");
-
         await LoadTags();
     }
 

--- a/TelegramGroupsAdmin/Components/Shared/Settings/TagManagement.razor
+++ b/TelegramGroupsAdmin/Components/Shared/Settings/TagManagement.razor
@@ -94,10 +94,10 @@
     private bool _loading = true;
     [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
 
-    // Preserves prior IsInRole("Admin")||IsInRole("Owner") semantics EXACTLY:
-    // grants edit to Admin and Owner only (NOT GlobalAdmin). The GlobalAdmin exclusion
-    // looks like a pre-existing bug — flagged for a separate decision, not changed here.
-    private bool _canEdit => WebUser?.PermissionLevel is PermissionLevel.Admin or PermissionLevel.Owner;
+    // Tag definitions are a global content setting (color preferences, not chat-scoped),
+    // so editing follows the content tier: GlobalAdmin or Owner. Chat-scoped Admins have
+    // read-only access to global settings. Matches Settings._canEditContent / CriticalChecks.
+    private bool _canEdit => WebUser?.IsGlobalAdminOrHigher ?? false;
 
     protected override async Task OnInitializedAsync()
     {

--- a/TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor
+++ b/TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor
@@ -602,7 +602,12 @@
         _saving = true;
         try
         {
-            var actor = WebUser!.ToActor();
+            if (WebUser is null)
+            {
+                Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+                return;
+            }
+            var actor = WebUser.ToActor();
             await ConfigService.SaveWelcomeAsync(Chat?.Identity ?? ChatIdentity.FromId(0), _config, actor);
             Snackbar.Add($"Welcome configuration saved {(Chat != null ? $"for {Chat.Identity.ToLogInfo()}" : "globally")}", Severity.Success);
 

--- a/TelegramGroupsAdmin/Constants/AuthenticationConstants.cs
+++ b/TelegramGroupsAdmin/Constants/AuthenticationConstants.cs
@@ -11,6 +11,12 @@ public static class AuthenticationConstants
     public static readonly TimeSpan CookieExpiration = TimeSpan.FromDays(30);
 
     /// <summary>
+    /// How often an active Blazor circuit revalidates its session against the DB.
+    /// Full-page loads and SignalR reconnects revalidate via the HTTP-edge handler regardless.
+    /// </summary>
+    public static readonly TimeSpan RevalidationInterval = TimeSpan.FromMinutes(2);
+
+    /// <summary>
     /// Intermediate authentication token lifetime (5 minutes) for TOTP/recovery code flows.
     /// </summary>
     public static readonly TimeSpan IntermediateTokenLifetime = TimeSpan.FromMinutes(5);

--- a/TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs
+++ b/TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs
@@ -69,7 +69,7 @@ public static class AuthEndpoints
             }
 
             // Sign in the user with cookie authentication (TOTP disabled by owner)
-            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
+            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp ?? throw new InvalidOperationException("SecurityStamp must be set on a successful AuthResult before sign-in"));
 
             // Check if this is a browser request (has Accept: text/html)
             var acceptHeader = httpContext.Request.Headers.Accept.ToString();
@@ -167,7 +167,7 @@ public static class AuthEndpoints
             }
 
             // Sign in the user with cookie authentication
-            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
+            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp ?? throw new InvalidOperationException("SecurityStamp must be set on a successful AuthResult before sign-in"));
 
             // Check if this is a browser request (has Accept: text/html)
             var acceptHeader = httpContext.Request.Headers.Accept.ToString();
@@ -216,7 +216,7 @@ public static class AuthEndpoints
             }
 
             // Sign in the user with cookie authentication
-            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
+            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp ?? throw new InvalidOperationException("SecurityStamp must be set on a successful AuthResult before sign-in"));
 
             // Check if this is a browser request (has Accept: text/html)
             var acceptHeader = httpContext.Request.Headers.Accept.ToString();

--- a/TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs
+++ b/TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs
@@ -69,7 +69,7 @@ public static class AuthEndpoints
             }
 
             // Sign in the user with cookie authentication (TOTP disabled by owner)
-            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value));
+            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
 
             // Check if this is a browser request (has Accept: text/html)
             var acceptHeader = httpContext.Request.Headers.Accept.ToString();
@@ -167,7 +167,7 @@ public static class AuthEndpoints
             }
 
             // Sign in the user with cookie authentication
-            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value));
+            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
 
             // Check if this is a browser request (has Accept: text/html)
             var acceptHeader = httpContext.Request.Headers.Accept.ToString();
@@ -216,7 +216,7 @@ public static class AuthEndpoints
             }
 
             // Sign in the user with cookie authentication
-            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value));
+            await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
 
             // Check if this is a browser request (has Accept: text/html)
             var acceptHeader = httpContext.Request.Headers.Accept.ToString();

--- a/TelegramGroupsAdmin/Repositories/IUserRepository.cs
+++ b/TelegramGroupsAdmin/Repositories/IUserRepository.cs
@@ -41,8 +41,14 @@ public interface IUserRepository
     Task UpdateLastLoginAsync(string userId, CancellationToken cancellationToken = default);
     Task UpdateSecurityStampAsync(string userId, CancellationToken cancellationToken = default);
     Task UpdateTotpSecretAsync(string userId, string totpSecret, CancellationToken cancellationToken = default);
+
+    /// <summary>Enables TOTP. Rotates the user's security stamp in the same UPDATE, invalidating existing sessions (forced re-login).</summary>
     Task EnableTotpAsync(string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>Disables TOTP (secret preserved). Rotates the user's security stamp in the same UPDATE, invalidating existing sessions (forced re-login).</summary>
     Task DisableTotpAsync(string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>Resets TOTP (clears secret, timestamp, disables). Rotates the user's security stamp in the same UPDATE, invalidating existing sessions (forced re-login).</summary>
     Task ResetTotpAsync(string userId, CancellationToken cancellationToken = default);
     Task DeleteRecoveryCodesAsync(string userId, CancellationToken cancellationToken = default);
     Task<List<RecoveryCodeRecord>> GetRecoveryCodesAsync(string userId, CancellationToken cancellationToken = default);
@@ -52,6 +58,7 @@ public interface IUserRepository
     Task<InviteRecord?> GetInviteByTokenAsync(string token, CancellationToken cancellationToken = default);
     Task<List<UserRecord>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<List<UserRecord>> GetAllIncludingDeletedAsync(CancellationToken cancellationToken = default);
+    /// <summary>Updates the user's permission level. Rotates the user's security stamp in the same UPDATE, invalidating existing sessions (forced re-login).</summary>
     Task UpdatePermissionLevelAsync(string userId, int permissionLevel, string modifiedBy, CancellationToken cancellationToken = default);
     Task UpdateStatusAsync(string userId, UserStatus newStatus, string modifiedBy, CancellationToken cancellationToken = default);
     Task UpdateAsync(UserRecord user, CancellationToken cancellationToken = default);

--- a/TelegramGroupsAdmin/Repositories/UserRepository.cs
+++ b/TelegramGroupsAdmin/Repositories/UserRepository.cs
@@ -238,6 +238,7 @@ public class UserRepository : IUserRepository
 
         entity.TotpEnabled = true;
         entity.TotpSetupStartedAt = null;
+        entity.SecurityStamp = Guid.NewGuid().ToString(); // Rotate stamp in the same UPDATE to invalidate existing sessions (forced re-login)
         await context.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Enabled TOTP for {User}", LogDisplayName.WebUserInfo(entity.Email, userId));
@@ -252,6 +253,7 @@ public class UserRepository : IUserRepository
         // IMPORTANT: Only set TotpEnabled=false, KEEP the secret and timestamp
         // This allows user to re-enable TOTP later without re-scanning QR code
         entity.TotpEnabled = false;
+        entity.SecurityStamp = Guid.NewGuid().ToString(); // Rotate stamp in the same UPDATE to invalidate existing sessions (forced re-login)
         await context.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Disabled TOTP for {User} (secret preserved)", LogDisplayName.WebUserInfo(entity.Email, userId));
@@ -266,6 +268,7 @@ public class UserRepository : IUserRepository
         entity.TotpSecret = null;
         entity.TotpEnabled = false;
         entity.TotpSetupStartedAt = null;
+        entity.SecurityStamp = Guid.NewGuid().ToString(); // Rotate stamp in the same UPDATE to invalidate existing sessions (forced re-login)
         await context.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Reset TOTP for {User}", LogDisplayName.WebUserInfo(entity.Email, userId));
@@ -394,6 +397,7 @@ public class UserRepository : IUserRepository
         entity.PermissionLevel = permissionLevel;
         entity.ModifiedBy = modifiedBy;
         entity.ModifiedAt = DateTimeOffset.UtcNow;
+        entity.SecurityStamp = Guid.NewGuid().ToString(); // Rotate stamp in the same UPDATE to invalidate existing sessions (forced re-login)
 
         await context.SaveChangesAsync(cancellationToken);
 

--- a/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IO;
 using MudBlazor.Services;
 using Polly;
@@ -81,6 +83,23 @@ public static class ServiceCollectionExtensions
                     options.LoginPath = "/login";
                     options.LogoutPath = "/logout";
                     options.AccessDeniedPath = "/access-denied";
+                    options.Events = new CookieAuthenticationEvents
+                    {
+                        OnValidatePrincipal = async context =>
+                        {
+                            if (context.Principal is null)
+                                return;
+
+                            var validator = context.HttpContext.RequestServices
+                                .GetRequiredService<TelegramGroupsAdmin.Services.Auth.IUserSessionValidator>();
+
+                            if (!await validator.IsStillValidAsync(context.Principal, context.HttpContext.RequestAborted))
+                            {
+                                context.RejectPrincipal();
+                                await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                            }
+                        }
+                    };
                 });
 
             // Add authorization policies
@@ -95,6 +114,7 @@ public static class ServiceCollectionExtensions
 
             // Auth cookie service for programmatic cookie generation (used by app and tests)
             services.AddScoped<TelegramGroupsAdmin.Services.Auth.IAuthCookieService, TelegramGroupsAdmin.Services.Auth.AuthCookieService>();
+            services.AddScoped<TelegramGroupsAdmin.Services.Auth.IUserSessionValidator, TelegramGroupsAdmin.Services.Auth.UserSessionValidator>();
 
             return services;
         }

--- a/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+++ b/TelegramGroupsAdmin/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.IO;
 using MudBlazor.Services;
 using Polly;
 using Polly.RateLimiting;
+using TelegramGroupsAdmin.Auth;
 using TelegramGroupsAdmin.Constants;
 using TelegramGroupsAdmin.Data.Services;
 using TelegramGroupsAdmin.Services;
@@ -110,7 +111,7 @@ public static class ServiceCollectionExtensions
                     policy.RequireRole("Owner"));
 
             services.AddCascadingAuthenticationState();
-            services.AddScoped<AuthenticationStateProvider, ServerAuthenticationStateProvider>();
+            services.AddScoped<AuthenticationStateProvider, RevalidatingUserAuthenticationStateProvider>();
 
             // Auth cookie service for programmatic cookie generation (used by app and tests)
             services.AddScoped<TelegramGroupsAdmin.Services.Auth.IAuthCookieService, TelegramGroupsAdmin.Services.Auth.AuthCookieService>();

--- a/TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs
@@ -30,9 +30,9 @@ public class AuthCookieService : IAuthCookieService
     /// Signs in a user by setting the authentication cookie via HttpContext.
     /// Use this in the running application where HttpContext is available.
     /// </summary>
-    public async Task SignInAsync(HttpContext context, WebUserIdentity user)
+    public async Task SignInAsync(HttpContext context, WebUserIdentity user, string securityStamp)
     {
-        var principal = CreateClaimsPrincipal(user);
+        var principal = CreateClaimsPrincipal(user, securityStamp);
 
         await context.SignInAsync(
             CookieAuthenticationDefaults.AuthenticationScheme,
@@ -56,11 +56,11 @@ public class AuthCookieService : IAuthCookieService
     /// Generates an encrypted cookie value without requiring HttpContext.
     /// Use this in tests to create valid auth cookies programmatically.
     /// </summary>
-    public string GenerateCookieValue(WebUserIdentity user)
+    public string GenerateCookieValue(WebUserIdentity user, string securityStamp)
     {
         var options = _cookieOptions.Get(CookieAuthenticationDefaults.AuthenticationScheme);
 
-        var principal = CreateClaimsPrincipal(user);
+        var principal = CreateClaimsPrincipal(user, securityStamp);
 
         var ticket = new AuthenticationTicket(
             principal,
@@ -80,14 +80,15 @@ public class AuthCookieService : IAuthCookieService
     /// Creates a ClaimsPrincipal with the standard claims used for authentication.
     /// This is the single source of truth for what claims are included in auth cookies.
     /// </summary>
-    private static ClaimsPrincipal CreateClaimsPrincipal(WebUserIdentity user)
+    private static ClaimsPrincipal CreateClaimsPrincipal(WebUserIdentity user, string securityStamp)
     {
         var claims = new List<Claim>
         {
             new(ClaimTypes.NameIdentifier, user.Id),
             new(ClaimTypes.Email, user.Email ?? ""),
             new(ClaimTypes.Role, user.PermissionLevel.GetDisplayName()),
-            new(CustomClaimTypes.PermissionLevel, ((int)user.PermissionLevel).ToString())
+            new(CustomClaimTypes.PermissionLevel, ((int)user.PermissionLevel).ToString()),
+            new(CustomClaimTypes.SecurityStamp, securityStamp)
         };
 
         var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme,

--- a/TelegramGroupsAdmin/Services/Auth/IAuthCookieService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/IAuthCookieService.cs
@@ -13,7 +13,8 @@ public interface IAuthCookieService
     /// </summary>
     /// <param name="context">The HTTP context to sign into</param>
     /// <param name="user">The web user identity to authenticate</param>
-    Task SignInAsync(HttpContext context, WebUserIdentity user);
+    /// <param name="securityStamp">The security stamp to embed in the cookie claims for later revalidation</param>
+    Task SignInAsync(HttpContext context, WebUserIdentity user, string securityStamp);
 
     /// <summary>
     /// Signs out a user by clearing the authentication cookie.
@@ -26,8 +27,9 @@ public interface IAuthCookieService
     /// Use this in tests to create valid auth cookies programmatically.
     /// </summary>
     /// <param name="user">The web user identity to generate a cookie for</param>
+    /// <param name="securityStamp">The security stamp to embed in the cookie claims for later revalidation</param>
     /// <returns>The encrypted cookie value that can be set in a browser</returns>
-    string GenerateCookieValue(WebUserIdentity user);
+    string GenerateCookieValue(WebUserIdentity user, string securityStamp);
 
     /// <summary>
     /// Gets the name of the authentication cookie.

--- a/TelegramGroupsAdmin/Services/Auth/IUserSessionValidator.cs
+++ b/TelegramGroupsAdmin/Services/Auth/IUserSessionValidator.cs
@@ -1,0 +1,13 @@
+using System.Security.Claims;
+
+namespace TelegramGroupsAdmin.Services.Auth;
+
+/// <summary>
+/// Single source of truth for whether an authenticated principal still corresponds to a
+/// valid, active DB user with a matching security stamp. Called by both the cookie
+/// OnValidatePrincipal handler (HTTP edge) and the in-circuit revalidating provider.
+/// </summary>
+public interface IUserSessionValidator
+{
+    Task<bool> IsStillValidAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default);
+}

--- a/TelegramGroupsAdmin/Services/Auth/TotpService.cs
+++ b/TelegramGroupsAdmin/Services/Auth/TotpService.cs
@@ -117,11 +117,8 @@ public class TotpService(
             }
         }
 
-        // Enable TOTP
+        // Enable TOTP (also rotates the security stamp atomically, invalidating existing sessions)
         await userRepository.EnableTotpAsync(user.Id, cancellationToken);
-
-        // Update security stamp
-        await userRepository.UpdateSecurityStampAsync(user.Id, cancellationToken);
 
         logger.LogInformation("TOTP enabled for {User}", user.ToLogInfo());
 
@@ -189,9 +186,9 @@ public class TotpService(
             return false;
         }
 
-        // Disable TOTP without password check (keeps secret for re-enable)
+        // Disable TOTP without password check (keeps secret for re-enable).
+        // This also rotates the security stamp atomically, invalidating existing sessions.
         await userRepository.DisableTotpAsync(target.Id, cancellationToken);
-        await userRepository.UpdateSecurityStampAsync(target.Id, cancellationToken);
 
         logger.LogWarning("TOTP admin-disabled for {Target} by Owner {Admin}",
             target.ToLogDebug(),
@@ -227,9 +224,9 @@ public class TotpService(
             return false;
         }
 
-        // Enable TOTP (works even without secret - forces setup on next login)
+        // Enable TOTP (works even without secret - forces setup on next login).
+        // This also rotates the security stamp atomically, invalidating existing sessions.
         await userRepository.EnableTotpAsync(target.Id, cancellationToken);
-        await userRepository.UpdateSecurityStampAsync(target.Id, cancellationToken);
 
         logger.LogWarning("TOTP admin-enabled for {Target} by Owner {Admin}",
             target.ToLogDebug(),
@@ -265,9 +262,9 @@ public class TotpService(
             return false;
         }
 
-        // Reset TOTP completely (wipes secret, timestamp, and sets enabled=false)
+        // Reset TOTP completely (wipes secret, timestamp, and sets enabled=false).
+        // This also rotates the security stamp atomically, invalidating existing sessions.
         await userRepository.ResetTotpAsync(target.Id, cancellationToken);
-        await userRepository.UpdateSecurityStampAsync(target.Id, cancellationToken);
 
         logger.LogWarning("TOTP reset for {Target} by Owner {Admin}",
             target.ToLogDebug(),

--- a/TelegramGroupsAdmin/Services/Auth/UserSessionValidator.cs
+++ b/TelegramGroupsAdmin/Services/Auth/UserSessionValidator.cs
@@ -1,0 +1,42 @@
+using System.Security.Claims;
+using Microsoft.Extensions.Logging;
+using TelegramGroupsAdmin.Auth;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Repositories;
+
+namespace TelegramGroupsAdmin.Services.Auth;
+
+public sealed class UserSessionValidator(
+    IUserRepository userRepository,
+    ILogger<UserSessionValidator> logger) : IUserSessionValidator
+{
+    public async Task<bool> IsStillValidAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default)
+    {
+        var userId = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var stamp = principal.FindFirst(CustomClaimTypes.SecurityStamp)?.Value;
+
+        // Fail closed: a principal without both an id and a stamp cannot be validated.
+        if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(stamp))
+            return false;
+
+        try
+        {
+            var user = await userRepository.GetByIdAsync(userId, cancellationToken);
+            if (user is null)
+                return false;
+
+            // Offboarding intent: only Active sessions survive. Disabled/Deleted/Pending are rejected.
+            // (Deliberately NOT UserRecord.CanLogin, which also folds in transient lockout/email-verify.)
+            if (user.Status != UserStatus.Active)
+                return false;
+
+            return string.Equals(user.SecurityStamp, stamp, StringComparison.Ordinal);
+        }
+        catch (Exception ex)
+        {
+            // Fail closed on any DB/transient error rather than allowing a stale session.
+            logger.LogWarning(ex, "Session validation failed for user {UserId}; rejecting session", userId);
+            return false;
+        }
+    }
+}

--- a/TelegramGroupsAdmin/Services/AuthResult.cs
+++ b/TelegramGroupsAdmin/Services/AuthResult.cs
@@ -9,5 +9,6 @@ public record AuthResult(
     PermissionLevel? PermissionLevel,
     bool TotpEnabled,
     bool RequiresTotp,
-    string? ErrorMessage
+    string? ErrorMessage,
+    string? SecurityStamp = null
 );

--- a/TelegramGroupsAdmin/Services/AuthService.cs
+++ b/TelegramGroupsAdmin/Services/AuthService.cs
@@ -159,19 +159,19 @@ public class AuthService(
             {
                 // Admin enabled TOTP but user needs to set it up (forced setup)
                 // TotpEnabled=true, RequiresTotp=false → Login.razor redirects to setup
-                return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, true, false, null);
+                return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, true, false, null, user.SecurityStamp);
             }
             else
             {
                 // Normal 2FA verification required
                 // TotpEnabled=true, RequiresTotp=true → Login.razor redirects to verify
-                return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, true, true, null);
+                return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, true, true, null, user.SecurityStamp);
             }
         }
 
         // TOTP disabled (either never set up or admin disabled for bypass)
         // TotpEnabled=false, RequiresTotp=false → Normal login
-        return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, false, false, null);
+        return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, false, false, null, user.SecurityStamp);
     }
 
     public async Task<AuthResult> VerifyTotpAsync(WebUserIdentity user, string code, CancellationToken cancellationToken = default)
@@ -189,7 +189,7 @@ public class AuthService(
         }
 
         await userRepository.UpdateLastLoginAsync(user.Id, cancellationToken);
-        return new AuthResult(true, dbUser.WebUser.Id, dbUser.WebUser.Email, dbUser.WebUser.PermissionLevel, true, false, null);
+        return new AuthResult(true, dbUser.WebUser.Id, dbUser.WebUser.Email, dbUser.WebUser.PermissionLevel, true, false, null, dbUser.SecurityStamp);
     }
 
     public async Task<bool> IsFirstRunAsync(CancellationToken cancellationToken = default)
@@ -392,7 +392,7 @@ public class AuthService(
 
         await userRepository.UpdateLastLoginAsync(user.Id, cancellationToken);
 
-        return new AuthResult(true, dbUser.WebUser.Id, dbUser.WebUser.Email, dbUser.WebUser.PermissionLevel, true, false, null);
+        return new AuthResult(true, dbUser.WebUser.Id, dbUser.WebUser.Email, dbUser.WebUser.PermissionLevel, true, false, null, dbUser.SecurityStamp);
     }
 
     public async Task AuditLogoutAsync(WebUserIdentity user, CancellationToken cancellationToken = default)

--- a/TelegramGroupsAdmin/Services/UserManagementService.cs
+++ b/TelegramGroupsAdmin/Services/UserManagementService.cs
@@ -51,6 +51,10 @@ public class UserManagementService(IUserRepository userRepository, IAuditService
 
         await userRepository.UpdatePermissionLevelAsync(userId, permissionLevel, modifiedBy, cancellationToken);
 
+        // Rotate the security stamp so existing sessions for this user are invalidated
+        // (the permission change takes effect via forced re-login). Mirrors Reset2FaAsync.
+        await userRepository.UpdateSecurityStampAsync(userId, cancellationToken);
+
         // Audit log
         var permissionName = permissionLevel switch
         {

--- a/TelegramGroupsAdmin/Services/UserManagementService.cs
+++ b/TelegramGroupsAdmin/Services/UserManagementService.cs
@@ -51,10 +51,6 @@ public class UserManagementService(IUserRepository userRepository, IAuditService
 
         await userRepository.UpdatePermissionLevelAsync(userId, permissionLevel, modifiedBy, cancellationToken);
 
-        // Rotate the security stamp so existing sessions for this user are invalidated
-        // (the permission change takes effect via forced re-login). Mirrors Reset2FaAsync.
-        await userRepository.UpdateSecurityStampAsync(userId, cancellationToken);
-
         // Audit log
         var permissionName = permissionLevel switch
         {
@@ -87,14 +83,14 @@ public class UserManagementService(IUserRepository userRepository, IAuditService
 
     public async Task Reset2FaAsync(string userId, string modifiedBy, CancellationToken cancellationToken = default)
     {
-        // Reset TOTP (clears secret, disables TOTP, clears setup timestamp)
+        // Reset TOTP (clears secret, disables TOTP, clears setup timestamp).
+        // This also rotates the security stamp atomically, invalidating existing sessions.
+        // Runs BEFORE recovery-code deletion so the security-critical state is consistent
+        // even if the (different-table) cleanup fails.
         await userRepository.ResetTotpAsync(userId, cancellationToken);
 
         // Delete all recovery codes
         await userRepository.DeleteRecoveryCodesAsync(userId, cancellationToken);
-
-        // Update security stamp to invalidate existing sessions
-        await userRepository.UpdateSecurityStampAsync(userId, cancellationToken);
 
         // Audit log
         await auditLog.LogEventAsync(

--- a/docs/superpowers/plans/2026-06-18-auth-cookie-revalidation.md
+++ b/docs/superpowers/plans/2026-06-18-auth-cookie-revalidation.md
@@ -1,0 +1,1405 @@
+# Auth Cookie Revalidation + WebUserIdentity Cascade Unification — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make web sessions reflect the database within a bounded window (revoke/disable/downgrade take effect on live sessions), and unify all components onto the single `WebUserIdentity` cascade with one explicit null-handling contract.
+
+**Architecture:** A single scoped `IUserSessionValidator` encodes the revocation rule (user exists + `Status == Active` + security-stamp matches). Two mechanisms call it: a `CookieAuthenticationEvents.OnValidatePrincipal` handler at the HTTP edge, and a `RevalidatingServerAuthenticationStateProvider` subclass for the in-circuit (~2 min) timer. The security stamp is added as a cookie claim at sign-in. Permission changes rotate the stamp (forced re-login). Then six components migrate off `AuthenticationStateProvider` to the cascaded `WebUserIdentity`.
+
+**Tech Stack:** .NET 10, Blazor Server, MudBlazor 9, EF Core 10 / PostgreSQL, NUnit + NSubstitute (unit), NUnit + Testcontainers Postgres (integration).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-18-auth-cookie-revalidation-design.md`
+
+**Conventions for every commit in this plan:**
+- Conventional commit messages, ending with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Build check command: `dotnet build TelegramGroupsAdmin.sln`
+- Unit test run: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj`
+- Integration test run: `dotnet test TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj` (requires Docker)
+
+---
+
+## File Structure
+
+**New files:**
+- `TelegramGroupsAdmin/Services/Auth/IUserSessionValidator.cs` — the validation contract.
+- `TelegramGroupsAdmin/Services/Auth/UserSessionValidator.cs` — implementation.
+- `TelegramGroupsAdmin/Auth/RevalidatingUserAuthenticationStateProvider.cs` — Blazor in-circuit revalidation.
+- `TelegramGroupsAdmin.UnitTests/Services/Auth/UserSessionValidatorTests.cs` — validator truth table.
+- `TelegramGroupsAdmin.IntegrationTests/Services/Auth/SessionRevocationTests.cs` — end-to-end revocation.
+
+**Modified files:**
+- `TelegramGroupsAdmin/Auth/CustomClaimTypes.cs` — add `SecurityStamp`.
+- `TelegramGroupsAdmin/Constants/AuthenticationConstants.cs` — add `RevalidationInterval`.
+- `TelegramGroupsAdmin/Services/AuthResult.cs` — add `SecurityStamp`.
+- `TelegramGroupsAdmin/Services/AuthService.cs` — populate stamp on success results.
+- `TelegramGroupsAdmin/Services/Auth/IAuthCookieService.cs` + `AuthCookieService.cs` — thread stamp into claims.
+- `TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs` — pass stamp at sign-in (×3).
+- `TelegramGroupsAdmin/ServiceCollectionExtensions.cs` — register validator, wire `OnValidatePrincipal`, swap auth state provider.
+- `TelegramGroupsAdmin/Services/UserManagementService.cs` — rotate stamp on permission change.
+- `TelegramGroupsAdmin/Components/Layout/MainLayout.razor` — no partial identity + render gate.
+- `TelegramGroupsAdmin/Components/Layout/NavMenu.razor`, `Components/Shared/Settings/TagManagement.razor`, `Components/Shared/BackupPassphraseRotationDialog.razor`, `Components/Shared/InviteManagementDialog.razor`, `Components/Shared/ContentDetection/StopWords.razor`, `Components/Shared/ContentDetection/TrainingData.razor` — cascade migration.
+- `TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor`, `Components/Shared/ContentDetection/CriticalChecks.razor` — guard `WebUser!.ToActor()`.
+- `TelegramGroupsAdmin.UnitTests/Services/Auth/AuthCookieServiceTests.cs` — stamp claim assertions + signature updates.
+- `TelegramGroupsAdmin.E2ETests/Fixtures/SharedAuthenticatedTestBase.cs`, `Fixtures/AuthenticatedTestBase.cs` — pass real stamp to `GenerateCookieValue`.
+
+---
+
+## Task 1: Add claim type + revalidation interval constants
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Auth/CustomClaimTypes.cs`
+- Modify: `TelegramGroupsAdmin/Constants/AuthenticationConstants.cs`
+
+- [ ] **Step 1: Add the security-stamp claim type**
+
+In `CustomClaimTypes.cs`, add inside the class after the `PermissionLevel` constant:
+
+```csharp
+    /// <summary>
+    /// Security stamp claim. Compared against the DB on every session revalidation;
+    /// a mismatch (stamp rotated by password/TOTP/permission change) invalidates the session.
+    /// </summary>
+    public const string SecurityStamp = "SecurityStamp";
+```
+
+- [ ] **Step 2: Add the revalidation interval constant**
+
+In `AuthenticationConstants.cs`, add after `CookieExpiration`:
+
+```csharp
+    /// <summary>
+    /// How often an active Blazor circuit revalidates its session against the DB.
+    /// Full-page loads and SignalR reconnects revalidate via the HTTP-edge handler regardless.
+    /// </summary>
+    public static readonly TimeSpan RevalidationInterval = TimeSpan.FromMinutes(2);
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Auth/CustomClaimTypes.cs TelegramGroupsAdmin/Constants/AuthenticationConstants.cs
+git commit -F- <<'EOF'
+feat(auth): add SecurityStamp claim type and RevalidationInterval constant
+
+Refs #518
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 2: Thread the security stamp into the cookie claims
+
+This is the prerequisite for any validation: the stamp must be *in* the cookie. We thread it from the loaded `UserRecord` → `AuthResult` → endpoint → `IAuthCookieService` → claims. The stamp is deliberately **not** added to `WebUserIdentity` (pages/cascade must not see it).
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/AuthResult.cs`
+- Modify: `TelegramGroupsAdmin/Services/AuthService.cs:162,168,174,192,395`
+- Modify: `TelegramGroupsAdmin/Services/Auth/IAuthCookieService.cs`
+- Modify: `TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs`
+- Modify: `TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs:72,170,219`
+- Test: `TelegramGroupsAdmin.UnitTests/Services/Auth/AuthCookieServiceTests.cs`
+
+- [ ] **Step 1: Write a failing test for the stamp claim**
+
+In `AuthCookieServiceTests.cs`, the existing tests call `_service.GenerateCookieValue(TestIdentity())` and `_service.SignInAsync(...)`. After this task those signatures take a stamp argument. Add a new test that asserts the principal carries the stamp claim. Because `CreateClaimsPrincipal` is private, assert via the `TicketDataFormat.Protect` capture (the existing test file already mocks `_mockTicketDataFormat`). Add:
+
+```csharp
+[Test]
+public void GenerateCookieValue_IncludesSecurityStampClaim()
+{
+    // Arrange
+    const string stamp = "stamp-abc-123";
+    AuthenticationTicket? captured = null;
+    _mockTicketDataFormat.Protect(Arg.Do<AuthenticationTicket>(t => captured = t)).Returns("protected");
+
+    // Act
+    _service.GenerateCookieValue(TestIdentity(), stamp);
+
+    // Assert
+    Assert.That(captured, Is.Not.Null);
+    var stampClaim = captured!.Principal.FindFirst(CustomClaimTypes.SecurityStamp);
+    Assert.That(stampClaim?.Value, Is.EqualTo(stamp));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (compile error)**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj --filter "FullyQualifiedName~AuthCookieServiceTests"`
+Expected: FAIL — does not compile (`GenerateCookieValue` takes 1 arg; `CustomClaimTypes.SecurityStamp` may already exist from Task 1).
+
+- [ ] **Step 3: Add `SecurityStamp` to `AuthResult` (defaulted, so failure paths are unchanged)**
+
+In `AuthResult.cs`, add a trailing defaulted parameter:
+
+```csharp
+public record AuthResult(
+    bool Success,
+    string? UserId,
+    string? Email,
+    PermissionLevel? PermissionLevel,
+    bool TotpEnabled,
+    bool RequiresTotp,
+    string? ErrorMessage,
+    string? SecurityStamp = null
+);
+```
+
+- [ ] **Step 4: Populate the stamp on the 5 success-path results in `AuthService.cs`**
+
+Lines 162, 168, 174 are in `LoginAsync` where the loaded record is `user`; lines 192 and 395 use `dbUser`. Append the stamp argument:
+
+- Line 162: `return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, true, false, null, user.SecurityStamp);`
+- Line 168: `return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, true, true, null, user.SecurityStamp);`
+- Line 174: `return new AuthResult(true, user.WebUser.Id, user.WebUser.Email, user.WebUser.PermissionLevel, false, false, null, user.SecurityStamp);`
+- Line 192: `return new AuthResult(true, dbUser.WebUser.Id, dbUser.WebUser.Email, dbUser.WebUser.PermissionLevel, true, false, null, dbUser.SecurityStamp);`
+- Line 395: `return new AuthResult(true, dbUser.WebUser.Id, dbUser.WebUser.Email, dbUser.WebUser.PermissionLevel, true, false, null, dbUser.SecurityStamp);`
+
+(Leave all `new AuthResult(false, ...)` failure constructions unchanged — `SecurityStamp` defaults to null.)
+
+- [ ] **Step 5: Update the `IAuthCookieService` signatures**
+
+In `IAuthCookieService.cs`, change the two methods that build claims:
+
+```csharp
+    Task SignInAsync(HttpContext context, WebUserIdentity user, string securityStamp);
+    string GenerateCookieValue(WebUserIdentity user, string securityStamp);
+```
+
+- [ ] **Step 6: Thread the stamp through `AuthCookieService.cs`**
+
+Update the three methods so the stamp flows into the claims:
+
+```csharp
+    public async Task SignInAsync(HttpContext context, WebUserIdentity user, string securityStamp)
+    {
+        var principal = CreateClaimsPrincipal(user, securityStamp);
+
+        await context.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            principal,
+            new AuthenticationProperties
+            {
+                IsPersistent = true,
+                ExpiresUtc = DateTimeOffset.UtcNow.Add(AuthenticationConstants.CookieExpiration)
+            });
+    }
+```
+
+```csharp
+    public string GenerateCookieValue(WebUserIdentity user, string securityStamp)
+    {
+        var options = _cookieOptions.Get(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        var principal = CreateClaimsPrincipal(user, securityStamp);
+
+        var ticket = new AuthenticationTicket(
+            principal,
+            new AuthenticationProperties
+            {
+                IsPersistent = true,
+                ExpiresUtc = DateTimeOffset.UtcNow.Add(AuthenticationConstants.CookieExpiration),
+                IssuedUtc = DateTimeOffset.UtcNow
+            },
+            CookieAuthenticationDefaults.AuthenticationScheme);
+
+        return options.TicketDataFormat.Protect(ticket);
+    }
+```
+
+```csharp
+    private static ClaimsPrincipal CreateClaimsPrincipal(WebUserIdentity user, string securityStamp)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, user.Id),
+            new(ClaimTypes.Email, user.Email ?? ""),
+            new(ClaimTypes.Role, user.PermissionLevel.GetDisplayName()),
+            new(CustomClaimTypes.PermissionLevel, ((int)user.PermissionLevel).ToString()),
+            new(CustomClaimTypes.SecurityStamp, securityStamp)
+        };
+
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme,
+            nameType: ClaimTypes.Email, roleType: ClaimTypes.Role);
+        return new ClaimsPrincipal(identity);
+    }
+```
+
+- [ ] **Step 7: Pass the stamp at the 3 endpoint sign-in sites**
+
+In `AuthEndpoints.cs`, update lines 72, 170, 219 to pass `result.SecurityStamp!` (non-null on success):
+
+```csharp
+await authCookieService.SignInAsync(httpContext, new WebUserIdentity(result.UserId!, result.Email!, result.PermissionLevel!.Value), result.SecurityStamp!);
+```
+
+- [ ] **Step 8: Fix the two existing `AuthCookieServiceTests` call sites**
+
+The existing tests call `GenerateCookieValue(TestIdentity())` and `SignInAsync(httpContext, TestIdentity())`. Add the stamp arg to every existing call, e.g.:
+
+```csharp
+var result = _service.GenerateCookieValue(TestIdentity(), "test-stamp");
+```
+```csharp
+await _service.SignInAsync(httpContext, TestIdentity(), "test-stamp");
+```
+
+(Search the file for `GenerateCookieValue(` and `SignInAsync(` and update each.)
+
+- [ ] **Step 9: Run the unit tests to verify they pass**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj --filter "FullyQualifiedName~AuthCookieServiceTests"`
+Expected: PASS (including the new `GenerateCookieValue_IncludesSecurityStampClaim`).
+
+- [ ] **Step 10: Update the E2E fixtures to pass the seeded user's real stamp**
+
+⚠️ Once revalidation is wired (Task 4) these cookies will be rejected if the stamp doesn't match the DB. Fix the fixtures now. In `SharedAuthenticatedTestBase.cs:112-114` and `AuthenticatedTestBase.cs:102-104`, the user object is seeded into the DB; pass its `SecurityStamp`:
+
+```csharp
+var cookieValue = authCookieService.GenerateCookieValue(
+    new WebUserIdentity(user.Id, user.Email, user.PermissionLevel), user.SecurityStamp);
+```
+
+If the local `user` variable in a fixture does not expose `SecurityStamp`, read it from the same `UserRecord`/seed used to create the DB row (the seed that wrote the user). The cookie stamp MUST equal the DB row's `SecurityStamp`. Do not invent a literal — that would fail revalidation.
+
+- [ ] **Step 11: Build the whole solution**
+
+Run: `dotnet build TelegramGroupsAdmin.sln`
+Expected: Build succeeded (E2E project compiles with the new signature).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Services/AuthResult.cs TelegramGroupsAdmin/Services/AuthService.cs TelegramGroupsAdmin/Services/Auth/IAuthCookieService.cs TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs TelegramGroupsAdmin/Endpoints/AuthEndpoints.cs TelegramGroupsAdmin.UnitTests/Services/Auth/AuthCookieServiceTests.cs TelegramGroupsAdmin.E2ETests/Fixtures/SharedAuthenticatedTestBase.cs TelegramGroupsAdmin.E2ETests/Fixtures/AuthenticatedTestBase.cs
+git commit -F- <<'EOF'
+feat(auth): carry security stamp into the auth cookie claims
+
+Thread SecurityStamp from the loaded UserRecord through AuthResult and
+IAuthCookieService into a new SecurityStamp claim, so sessions can be
+revalidated against the DB. Test fixtures pass the seeded user's real stamp.
+
+Refs #518
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 3: Create the shared session validator
+
+**Files:**
+- Create: `TelegramGroupsAdmin/Services/Auth/IUserSessionValidator.cs`
+- Create: `TelegramGroupsAdmin/Services/Auth/UserSessionValidator.cs`
+- Test: `TelegramGroupsAdmin.UnitTests/Services/Auth/UserSessionValidatorTests.cs`
+
+- [ ] **Step 1: Write the failing truth-table test**
+
+Create `UserSessionValidatorTests.cs`. Use NSubstitute for `IUserRepository` and a `NullLogger`. A small helper builds a `UserRecord` with a given status and stamp, and a `ClaimsPrincipal` with given id + stamp claims.
+
+```csharp
+using System.Security.Claims;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using TelegramGroupsAdmin.Auth;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Repositories;
+using TelegramGroupsAdmin.Services.Auth;
+
+namespace TelegramGroupsAdmin.UnitTests.Services.Auth;
+
+[TestFixture]
+public class UserSessionValidatorTests
+{
+    private IUserRepository _userRepository = null!;
+    private UserSessionValidator _validator = null!;
+
+    private const string UserId = "user-1";
+    private const string Stamp = "stamp-1";
+
+    [SetUp]
+    public void SetUp()
+    {
+        _userRepository = Substitute.For<IUserRepository>();
+        _validator = new UserSessionValidator(_userRepository, NullLogger<UserSessionValidator>.Instance);
+    }
+
+    private static ClaimsPrincipal Principal(string? userId, string? stamp)
+    {
+        var claims = new List<Claim>();
+        if (userId is not null) claims.Add(new Claim(ClaimTypes.NameIdentifier, userId));
+        if (stamp is not null) claims.Add(new Claim(CustomClaimTypes.SecurityStamp, stamp));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+    }
+
+    private static UserRecord UserWith(UserStatus status, string stamp) => new(
+        WebUser: new WebUserIdentity(UserId, "u@example.com", PermissionLevel.Admin),
+        NormalizedEmail: "U@EXAMPLE.COM",
+        PasswordHash: "x",
+        SecurityStamp: stamp,
+        InvitedBy: null,
+        IsActive: status == UserStatus.Active,
+        TotpSecret: null,
+        TotpEnabled: false,
+        TotpSetupStartedAt: null,
+        CreatedAt: DateTimeOffset.UnixEpoch,
+        LastLoginAt: null,
+        Status: status,
+        ModifiedBy: null,
+        ModifiedAt: null,
+        EmailVerified: true,
+        EmailVerificationToken: null,
+        EmailVerificationTokenExpiresAt: null,
+        PasswordResetToken: null,
+        PasswordResetTokenExpiresAt: null,
+        FailedLoginAttempts: 0,
+        LockedUntil: null);
+
+    [Test]
+    public async Task ValidUser_ReturnsTrue()
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>())
+            .Returns(UserWith(UserStatus.Active, Stamp));
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.True);
+    }
+
+    [Test]
+    public async Task MissingUserIdClaim_ReturnsFalse()
+        => Assert.That(await _validator.IsStillValidAsync(Principal(null, Stamp)), Is.False);
+
+    [Test]
+    public async Task MissingStampClaim_ReturnsFalse()
+        => Assert.That(await _validator.IsStillValidAsync(Principal(UserId, null)), Is.False);
+
+    [Test]
+    public async Task UserNotFound_ReturnsFalse()
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>()).Returns((UserRecord?)null);
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.False);
+    }
+
+    [TestCase(UserStatus.Disabled)]
+    [TestCase(UserStatus.Deleted)]
+    [TestCase(UserStatus.Pending)]
+    public async Task NonActiveStatus_ReturnsFalse(UserStatus status)
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>())
+            .Returns(UserWith(status, Stamp));
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.False);
+    }
+
+    [Test]
+    public async Task StampMismatch_ReturnsFalse()
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>())
+            .Returns(UserWith(UserStatus.Active, "different-stamp"));
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.False);
+    }
+
+    [Test]
+    public async Task RepositoryThrows_FailsClosed()
+    {
+        _userRepository.GetByIdAsync(UserId, Arg.Any<CancellationToken>())
+            .Returns<UserRecord?>(_ => throw new InvalidOperationException("db down"));
+        Assert.That(await _validator.IsStillValidAsync(Principal(UserId, Stamp)), Is.False);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (compile error)**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj --filter "FullyQualifiedName~UserSessionValidatorTests"`
+Expected: FAIL — `IUserSessionValidator` / `UserSessionValidator` do not exist.
+
+- [ ] **Step 3: Create the interface**
+
+`IUserSessionValidator.cs`:
+
+```csharp
+using System.Security.Claims;
+
+namespace TelegramGroupsAdmin.Services.Auth;
+
+/// <summary>
+/// Single source of truth for whether an authenticated principal still corresponds to a
+/// valid, active DB user with a matching security stamp. Called by both the cookie
+/// OnValidatePrincipal handler (HTTP edge) and the in-circuit revalidating provider.
+/// </summary>
+public interface IUserSessionValidator
+{
+    Task<bool> IsStillValidAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 4: Create the implementation**
+
+`UserSessionValidator.cs`:
+
+```csharp
+using System.Security.Claims;
+using TelegramGroupsAdmin.Auth;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Repositories;
+
+namespace TelegramGroupsAdmin.Services.Auth;
+
+public sealed class UserSessionValidator(
+    IUserRepository userRepository,
+    ILogger<UserSessionValidator> logger) : IUserSessionValidator
+{
+    public async Task<bool> IsStillValidAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default)
+    {
+        var userId = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var stamp = principal.FindFirst(CustomClaimTypes.SecurityStamp)?.Value;
+
+        // Fail closed: a principal without both an id and a stamp cannot be validated.
+        if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(stamp))
+            return false;
+
+        try
+        {
+            var user = await userRepository.GetByIdAsync(userId, cancellationToken);
+            if (user is null)
+                return false;
+
+            // Offboarding intent: only Active sessions survive. Disabled/Deleted/Pending are rejected.
+            // (Deliberately NOT UserRecord.CanLogin, which also folds in transient lockout/email-verify.)
+            if (user.Status != UserStatus.Active)
+                return false;
+
+            return string.Equals(user.SecurityStamp, stamp, StringComparison.Ordinal);
+        }
+        catch (Exception ex)
+        {
+            // Fail closed on any DB/transient error rather than allowing a stale session.
+            logger.LogWarning(ex, "Session validation failed for user {UserId}; rejecting session", userId);
+            return false;
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj --filter "FullyQualifiedName~UserSessionValidatorTests"`
+Expected: PASS (all truth-table cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Services/Auth/IUserSessionValidator.cs TelegramGroupsAdmin/Services/Auth/UserSessionValidator.cs TelegramGroupsAdmin.UnitTests/Services/Auth/UserSessionValidatorTests.cs
+git commit -F- <<'EOF'
+feat(auth): add IUserSessionValidator (status + security-stamp check, fail-closed)
+
+Refs #518
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 4: Wire OnValidatePrincipal + register the validator
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/ServiceCollectionExtensions.cs:70-97`
+
+- [ ] **Step 1: Register the validator (scoped)**
+
+In `AddCookieAuthentication`, after the `AddScoped<IAuthCookieService, AuthCookieService>()` registration (around line 97), add:
+
+```csharp
+            services.AddScoped<TelegramGroupsAdmin.Services.Auth.IUserSessionValidator, TelegramGroupsAdmin.Services.Auth.UserSessionValidator>();
+```
+
+- [ ] **Step 2: Add the `OnValidatePrincipal` handler to the cookie options**
+
+Inside the `AddCookie(options => { ... })` block (after `options.AccessDeniedPath = "/access-denied";`, before the closing `})`), add:
+
+```csharp
+                    options.Events = new CookieAuthenticationEvents
+                    {
+                        OnValidatePrincipal = async context =>
+                        {
+                            if (context.Principal is null)
+                                return;
+
+                            var validator = context.HttpContext.RequestServices
+                                .GetRequiredService<TelegramGroupsAdmin.Services.Auth.IUserSessionValidator>();
+
+                            if (!await validator.IsStillValidAsync(context.Principal, context.HttpContext.RequestAborted))
+                            {
+                                context.RejectPrincipal();
+                                await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+                            }
+                        }
+                    };
+```
+
+Ensure the file has `using Microsoft.AspNetCore.Authentication;` (for `SignOutAsync`) and `using Microsoft.Extensions.DependencyInjection;` (for `GetRequiredService`). Add any missing using.
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+git commit -F- <<'EOF'
+feat(auth): revalidate cookies against the DB via OnValidatePrincipal
+
+Rejects + signs out sessions whose user is missing/non-active or whose
+security stamp no longer matches, on every full-page load / SignalR reconnect.
+
+Refs #518
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 5: Add the in-circuit revalidating auth state provider
+
+**Files:**
+- Create: `TelegramGroupsAdmin/Auth/RevalidatingUserAuthenticationStateProvider.cs`
+- Modify: `TelegramGroupsAdmin/ServiceCollectionExtensions.cs:94`
+
+- [ ] **Step 1: Create the provider**
+
+`RevalidatingUserAuthenticationStateProvider.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server;
+using TelegramGroupsAdmin.Constants;
+using TelegramGroupsAdmin.Services.Auth;
+
+namespace TelegramGroupsAdmin.Auth;
+
+/// <summary>
+/// Tears down a live Blazor circuit when its session is no longer valid (user
+/// disabled/deleted, or security stamp rotated by password/TOTP/permission change).
+/// Complements the cookie OnValidatePrincipal handler, which only runs at the HTTP edge.
+/// </summary>
+public sealed class RevalidatingUserAuthenticationStateProvider(
+    ILoggerFactory loggerFactory,
+    IServiceScopeFactory scopeFactory)
+    : RevalidatingServerAuthenticationStateProvider(loggerFactory)
+{
+    protected override TimeSpan RevalidationInterval => AuthenticationConstants.RevalidationInterval;
+
+    protected override async Task<bool> ValidateAuthenticationStateAsync(
+        AuthenticationState authenticationState, CancellationToken cancellationToken)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var validator = scope.ServiceProvider.GetRequiredService<IUserSessionValidator>();
+        return await validator.IsStillValidAsync(authenticationState.User, cancellationToken);
+    }
+}
+```
+
+- [ ] **Step 2: Swap the registration**
+
+In `ServiceCollectionExtensions.cs`, replace line 94:
+
+```csharp
+            services.AddScoped<AuthenticationStateProvider, ServerAuthenticationStateProvider>();
+```
+
+with:
+
+```csharp
+            services.AddScoped<AuthenticationStateProvider, RevalidatingUserAuthenticationStateProvider>();
+```
+
+Add `using TelegramGroupsAdmin.Auth;` if not present.
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Auth/RevalidatingUserAuthenticationStateProvider.cs TelegramGroupsAdmin/ServiceCollectionExtensions.cs
+git commit -F- <<'EOF'
+feat(auth): revalidate live Blazor circuits every 2 minutes
+
+RevalidatingServerAuthenticationStateProvider subclass calls the shared
+session validator on a timer, tearing down circuits for revoked sessions.
+
+Refs #518
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 6: Rotate the security stamp on permission change
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Services/UserManagementService.cs:52`
+- Test: `TelegramGroupsAdmin.UnitTests/Services/UserManagementServiceTests.cs` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create or extend `UserManagementServiceTests.cs`. Mock `IUserRepository` and `IAuditService`; assert `UpdatePermissionLevelAsync` calls `UpdateSecurityStampAsync`.
+
+```csharp
+using NSubstitute;
+using TelegramGroupsAdmin.Repositories;
+using TelegramGroupsAdmin.Services;
+
+namespace TelegramGroupsAdmin.UnitTests.Services;
+
+[TestFixture]
+public class UserManagementServiceTests
+{
+    private IUserRepository _userRepository = null!;
+    private IAuditService _auditService = null!;
+    private UserManagementService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _userRepository = Substitute.For<IUserRepository>();
+        _auditService = Substitute.For<IAuditService>();
+        _service = new UserManagementService(_userRepository, _auditService);
+    }
+
+    [Test]
+    public async Task UpdatePermissionLevelAsync_RotatesSecurityStamp()
+    {
+        // Act: modifier is Owner (level 2) downgrading a user to Admin (level 0)
+        await _service.UpdatePermissionLevelAsync("target-user", permissionLevel: 0, modifiedBy: "owner-user", modifierPermissionLevel: 2);
+
+        // Assert
+        await _userRepository.Received(1).UpdatePermissionLevelAsync("target-user", 0, "owner-user", Arg.Any<CancellationToken>());
+        await _userRepository.Received(1).UpdateSecurityStampAsync("target-user", Arg.Any<CancellationToken>());
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj --filter "FullyQualifiedName~UserManagementServiceTests"`
+Expected: FAIL — `UpdateSecurityStampAsync` received 0 calls.
+
+- [ ] **Step 3: Add the stamp rotation**
+
+In `UserManagementService.cs`, immediately after the `UpdatePermissionLevelAsync` repository call (line 52), add:
+
+```csharp
+        // Rotate the security stamp so existing sessions for this user are invalidated
+        // (the permission change takes effect via forced re-login). Mirrors Reset2FaAsync.
+        await userRepository.UpdateSecurityStampAsync(userId, cancellationToken);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj --filter "FullyQualifiedName~UserManagementServiceTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Services/UserManagementService.cs TelegramGroupsAdmin.UnitTests/Services/UserManagementServiceTests.cs
+git commit -F- <<'EOF'
+feat(auth): rotate security stamp on permission change to force re-login
+
+Routes permission changes through the same session-invalidation path as
+password/TOTP changes, closing the only remaining stamp-rotation gap.
+
+Refs #518
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 7: Integration test — end-to-end session revocation
+
+**Files:**
+- Create: `TelegramGroupsAdmin.IntegrationTests/Services/Auth/SessionRevocationTests.cs`
+
+This verifies the validator against a real Postgres user row (the unit tests mock the repo). Follow the `UserRepositoryTests` fixture pattern (`MigrationTestHelper` + `ServiceCollection`).
+
+- [ ] **Step 1: Write the integration test**
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System.Security.Claims;
+using TelegramGroupsAdmin.Auth;
+using TelegramGroupsAdmin.Core.Models;
+using TelegramGroupsAdmin.Data;
+using TelegramGroupsAdmin.IntegrationTests.TestHelpers;
+using TelegramGroupsAdmin.Repositories;
+using TelegramGroupsAdmin.Services.Auth;
+
+namespace TelegramGroupsAdmin.IntegrationTests.Services.Auth;
+
+[TestFixture]
+[Category("Integration")]
+public class SessionRevocationTests
+{
+    private MigrationTestHelper? _testHelper;
+    private IServiceProvider? _serviceProvider;
+
+    [TearDown]
+    public void TearDown()
+    {
+        (_serviceProvider as IDisposable)?.Dispose();
+        _testHelper?.Dispose();
+    }
+
+    private async Task<(IServiceProvider sp, IUserRepository repo)> SetUpAsync()
+    {
+        _testHelper = new MigrationTestHelper();
+        await _testHelper.CreateDatabaseFromEmptyTemplateAsync();
+
+        var services = new ServiceCollection();
+        services.AddDbContextFactory<AppDbContext>(o => o.UseNpgsql(_testHelper.ConnectionString));
+        services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IUserSessionValidator, UserSessionValidator>();
+        _serviceProvider = services.BuildServiceProvider();
+
+        var scope = _serviceProvider.CreateScope();
+        return (_serviceProvider, scope.ServiceProvider.GetRequiredService<IUserRepository>());
+    }
+
+    private static ClaimsPrincipal PrincipalFor(string userId, string stamp) =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, userId),
+            new Claim(CustomClaimTypes.SecurityStamp, stamp)
+        }, "test"));
+
+    [Test]
+    public async Task ValidatorRejectsAfterStampRotation()
+    {
+        var (sp, repo) = await SetUpAsync();
+
+        // Seed an active, verified user. Use the repository's create method;
+        // if the signature differs, adapt to the actual IUserRepository create API.
+        var userId = await SeedActiveUserAsync(repo);
+        var user = await repo.GetByIdAsync(userId);
+        Assert.That(user, Is.Not.Null);
+
+        var validator = sp.CreateScope().ServiceProvider.GetRequiredService<IUserSessionValidator>();
+        var principal = PrincipalFor(userId, user!.SecurityStamp);
+
+        Assert.That(await validator.IsStillValidAsync(principal), Is.True, "fresh session should be valid");
+
+        // Rotate the stamp (simulates password/TOTP/permission change).
+        await repo.UpdateSecurityStampAsync(userId);
+
+        Assert.That(await validator.IsStillValidAsync(principal), Is.False, "session with old stamp must be rejected");
+    }
+
+    [Test]
+    public async Task ValidatorRejectsAfterDisable()
+    {
+        var (sp, repo) = await SetUpAsync();
+        var userId = await SeedActiveUserAsync(repo);
+        var user = await repo.GetByIdAsync(userId);
+
+        var validator = sp.CreateScope().ServiceProvider.GetRequiredService<IUserSessionValidator>();
+        var principal = PrincipalFor(userId, user!.SecurityStamp);
+        Assert.That(await validator.IsStillValidAsync(principal), Is.True);
+
+        await repo.UpdateStatusAsync(userId, UserStatus.Disabled, "admin");
+
+        Assert.That(await validator.IsStillValidAsync(principal), Is.False);
+    }
+
+    // Helper: seed an Active + EmailVerified user and return its id.
+    // Implement using the real IUserRepository creation API (inspect IUserRepository
+    // for the create/add method and required fields; set Status=Active, EmailVerified=true).
+    private static async Task<string> SeedActiveUserAsync(IUserRepository repo)
+    {
+        throw new NotImplementedException(
+            "Implement using the repository's create API — see IUserRepository / UserRepository " +
+            "and existing IntegrationTests seeding for the exact method and required fields.");
+    }
+}
+```
+
+- [ ] **Step 2: Implement `SeedActiveUserAsync` against the real repository API**
+
+Inspect `IUserRepository`/`UserRepository` for the user-creation method and how other integration tests seed users (search `IntegrationTests` for existing user seeding). Replace the `NotImplementedException` body with a real seed that creates an **Active, EmailVerified** user and returns its id. The user must be `Status == Active` so the baseline assertion passes.
+
+- [ ] **Step 3: Run the integration tests (Docker required)**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj --filter "FullyQualifiedName~SessionRevocationTests"`
+Expected: PASS — both `ValidatorRejectsAfterStampRotation` and `ValidatorRejectsAfterDisable`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin.IntegrationTests/Services/Auth/SessionRevocationTests.cs
+git commit -F- <<'EOF'
+test(auth): integration coverage for session revocation (stamp + disable)
+
+Refs #518
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 8: MainLayout — no partial identity + render gate (null contract source)
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Layout/MainLayout.razor`
+
+- [ ] **Step 1: Add an `_authResolved` flag and guard against a missing id**
+
+Replace `OnInitializedAsync` (lines 102-125) with:
+
+```csharp
+    private bool _authResolved;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+        if (user.Identity?.IsAuthenticated ?? false)
+        {
+            _userId = user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+
+            if (string.IsNullOrEmpty(_userId))
+            {
+                // An authenticated principal with no subject id is anomalous (and possible
+                // now that principals are re-issued). Treat as not a usable session rather
+                // than constructing a half-valid identity.
+                Logger.LogWarning("Authenticated principal is missing the NameIdentifier claim; treating as unauthenticated");
+            }
+            else
+            {
+                _isAuthenticated = true;
+                _userEmail = user.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
+
+                var permissionLevel = PermissionLevel.Admin;
+                var permissionClaim = user.FindFirst(CustomClaimTypes.PermissionLevel);
+                if (permissionClaim != null && int.TryParse(permissionClaim.Value, out var level))
+                    permissionLevel = (PermissionLevel)level;
+                _webUser = new WebUserIdentity(_userId, _userEmail, permissionLevel);
+
+                await NotificationState.InitializeAsync(_userId);
+            }
+        }
+
+        _authResolved = true;
+    }
+```
+
+(Note: `_userId!` force-unwrap is gone; `_webUser` is only built with a non-null id.)
+
+- [ ] **Step 2: Gate the body render on `_authResolved`**
+
+Replace the `<MudMainContent>` block (lines 41-45) with:
+
+```razor
+            <MudMainContent>
+                <MudContainer MaxWidth="MaxWidth.ExtraExtraLarge" Class="my-4">
+                    @if (_authResolved)
+                    {
+                        @Body
+                    }
+                    else
+                    {
+                        <div class="d-flex justify-center my-8">
+                            <MudProgressCircular Indeterminate="true" />
+                        </div>
+                    }
+                </MudContainer>
+            </MudMainContent>
+```
+
+- [ ] **Step 3: Verify login/anonymous pages are not regressed by the gate**
+
+Check which layout the login/register/verify pages use. Search:
+
+Run: `rg -n "@layout" TelegramGroupsAdmin/Components/Pages/Login.razor TelegramGroupsAdmin/Components/Pages/Register.razor`
+- If they use a **different** layout (e.g. an empty/auth layout), the gate is irrelevant to them — proceed.
+- If they use `MainLayout`, confirm the gate still renders them: `_authResolved` becomes true after auth resolves to *not authenticated*, so `@Body` (the login form) renders normally after a brief spinner. This is acceptable. Note the finding in the commit message.
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 5: Manually verify no first-render NRE (run the app)**
+
+Run the app (`dotnet run --project TelegramGroupsAdmin`), log in, and load an authorized page that consumes `WebUser` (e.g. `/messages`). Confirm it renders without a `NullReferenceException`. (The render gate guarantees `WebUser` is populated before the page body renders.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Layout/MainLayout.razor
+git commit -F- <<'EOF'
+fix(auth): MainLayout never builds a partial identity + gates body render
+
+Closes the first-render null window for WebUser on authorized pages and stops
+force-unwrapping a possibly-missing NameIdentifier claim. Establishes the
+boundary invariant the null contract relies on.
+
+Refs #464
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 9: Migrate NavMenu.razor to the cascade
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Layout/NavMenu.razor`
+
+- [ ] **Step 1: Replace injection + claim parsing with the cascade**
+
+Remove these top-of-file lines:
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@inject AuthenticationStateProvider AuthStateProvider
+```
+
+(Keep `@using TelegramGroupsAdmin.Auth` only if still referenced elsewhere in the file; otherwise remove it too.)
+
+Replace the `@code` block (the `_isAuthenticated`/`_isGlobalAdminOrOwner` fields and `OnInitializedAsync`) with the cascade + computed flags:
+
+```csharp
+@code {
+    [Inject] private NavigationManager Navigation { get; set; } = null!;
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+
+    private bool _isAuthenticated => WebUser is not null;
+    private bool _isGlobalAdminOrOwner => WebUser?.IsGlobalAdminOrHigher ?? false;
+}
+```
+
+(These are expression-bodied properties — markup context — so they use `?.`/null-coalescing per the null contract. `@if (_isGlobalAdminOrOwner)` markup is unchanged.)
+
+- [ ] **Step 2: Add the `WebUserIdentity` using if needed**
+
+Ensure the file can resolve `WebUserIdentity`. Add at top if absent:
+
+```razor
+@using TelegramGroupsAdmin.Core.Models
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Layout/NavMenu.razor
+git commit -F- <<'EOF'
+refactor(auth): NavMenu reads WebUser cascade instead of AuthStateProvider
+
+Refs #464
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 10: Migrate TagManagement.razor (IsInRole → cascade)
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Shared/Settings/TagManagement.razor`
+
+⚠️ **Authorization-semantics flag:** the current code is `_canEdit = user.IsInRole("Admin") || user.IsInRole("Owner")`. The Role claim is a *single* role equal to the user's exact permission-level display name, so this grants edit to **exactly Admin and exactly Owner — NOT GlobalAdmin**. That is almost certainly a pre-existing bug, but this refactor must **preserve behavior**, not silently change authorization. Reproduce the exact semantics, and surface the bug for a separate decision (do not fix it here).
+
+- [ ] **Step 1: Confirm the role-string ↔ permission-level mapping**
+
+Run: `rg -n "GetDisplayName" TelegramGroupsAdmin --glob '*.cs' | rg -i "permission"`
+Open the `PermissionLevel.GetDisplayName()` implementation and confirm the display strings (e.g. does `Admin` map to `"Admin"`, `Owner` to `"Owner"`). This confirms `IsInRole("Admin")`/`IsInRole("Owner")` correspond to `PermissionLevel.Admin`/`PermissionLevel.Owner` exactly.
+
+- [ ] **Step 2: Replace injection + computation with the cascade (behavior-preserving)**
+
+Remove:
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@inject AuthenticationStateProvider AuthenticationStateProvider
+```
+
+Replace the `_canEdit` field + `OnInitializedAsync` (lines 94-107) with:
+
+```csharp
+@code {
+    private List<TagDefinition> _tags = [];
+    private bool _loading = true;
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+
+    // Preserves prior IsInRole("Admin")||IsInRole("Owner") semantics EXACTLY:
+    // grants edit to Admin and Owner only (NOT GlobalAdmin). See authorization-semantics
+    // flag in the plan — likely a pre-existing bug to be decided separately.
+    private bool _canEdit => WebUser?.PermissionLevel is PermissionLevel.Admin or PermissionLevel.Owner;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadTags();
+    }
+}
+```
+
+Ensure `@using TelegramGroupsAdmin.Core.Models` is present for `WebUserIdentity`/`PermissionLevel`.
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Shared/Settings/TagManagement.razor
+git commit -F- <<'EOF'
+refactor(auth): TagManagement reads WebUser cascade (behavior-preserving)
+
+Reproduces the prior IsInRole("Admin")||IsInRole("Owner") semantics exactly
+(Admin or Owner, not GlobalAdmin). The GlobalAdmin exclusion looks like a
+pre-existing bug and is flagged for a separate decision, not changed here.
+
+Refs #464
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 11: Migrate the user-id consumers (dialogs + content-detection pages)
+
+All four read `ClaimTypes.NameIdentifier` into a `_userId`/`_currentUserId`. Migrate each to the cascade. Per the null contract: these are reusable components (dialogs / shared pages) → **guard, never `!`**. The user-id sinks must not write a null actor.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Shared/BackupPassphraseRotationDialog.razor`
+- Modify: `TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor`
+- Modify: `TelegramGroupsAdmin/Components/Shared/ContentDetection/StopWords.razor`
+- Modify: `TelegramGroupsAdmin/Components/Shared/ContentDetection/TrainingData.razor`
+
+- [ ] **Step 1: BackupPassphraseRotationDialog — cascade + guard**
+
+Remove:
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@inject AuthenticationStateProvider AuthStateProvider
+```
+
+Add the cascade parameter to `@code` (alongside the existing `[CascadingParameter] IMudDialogInstance MudDialog`):
+
+```csharp
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+```
+
+In `StartRotation()`, replace the whole `authState`/`userIdClaim`/`throw`/`_userId = userId` block (lines ~181-199) with a guard:
+
+```csharp
+            if (WebUser is null)
+            {
+                Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+                _isProcessing = false;
+                return;
+            }
+            _userId = WebUser.Id;
+```
+
+Ensure `@using TelegramGroupsAdmin.Core.Models`. The later usage `RotatePassphraseAsync(BackupDirectory, _userId)` (line 266) is unchanged.
+
+- [ ] **Step 2: InviteManagementDialog — cascade + guard**
+
+Remove:
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@inject AuthenticationStateProvider AuthStateProvider
+```
+
+Add to `@code`:
+
+```csharp
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+```
+
+Replace `OnInitializedAsync` (lines 124-135) with:
+
+```csharp
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadInvitesAsync();
+    }
+```
+
+Change the field `private string? _currentUserId;` usage at line 207. Replace:
+
+```csharp
+var success = await InviteService.RevokeInviteAsync(token, _currentUserId!);
+```
+
+with a guarded version (in the enclosing method):
+
+```csharp
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            return;
+        }
+        var success = await InviteService.RevokeInviteAsync(token, WebUser.Id);
+```
+
+Remove the now-unused `_currentUserId` field. Ensure `@using TelegramGroupsAdmin.Core.Models`.
+
+- [ ] **Step 3: StopWords — cascade + guard**
+
+Remove:
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@inject AuthenticationStateProvider AuthStateProvider
+```
+
+Add to `@code`:
+
+```csharp
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+```
+
+Replace `OnInitializedAsync` (lines 138-143) with:
+
+```csharp
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStopWords();
+    }
+```
+
+Remove the `private string? _currentUserId;` field. In the method that builds the `StopWord` (line ~185-191), add a guard before constructing it and use `WebUser.Id` for `AddedBy`:
+
+```csharp
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            return;
+        }
+        var stopWord = new TelegramGroupsAdmin.ContentDetection.Models.StopWord(
+            Id: 0,
+            Word: data.Word.ToLowerInvariant(),
+            Enabled: true,
+            AddedDate: DateTimeOffset.UtcNow,
+            AddedBy: WebUser.Id,
+            Notes: data.Notes
+        );
+```
+
+Ensure `@using TelegramGroupsAdmin.Core.Models`.
+
+- [ ] **Step 4: TrainingData — cascade + guard**
+
+Remove:
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@inject AuthenticationStateProvider AuthStateProvider
+```
+
+Add to `@code`:
+
+```csharp
+    [CascadingParameter] private WebUserIdentity? WebUser { get; set; }
+```
+
+Replace `OnInitializedAsync` (lines ~205-209) with:
+
+```csharp
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+```
+
+Remove the `private string? _currentUserId;` field. There are two sink methods (`AddTrainingSample` ~line 303-310, `EditTrainingSample` ~line 346-347) that pass `_currentUserId`. In each, add a guard at the top of the method and pass `WebUser.Id`:
+
+```csharp
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            return;
+        }
+```
+
+Then change `_currentUserId` → `WebUser.Id` in the `AddManualTrainingSampleAsync(...)` calls. Ensure `@using TelegramGroupsAdmin.Core.Models`.
+
+- [ ] **Step 5: Build to verify all four compile**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded, with no remaining references to `AuthStateProvider` in these files.
+
+- [ ] **Step 6: Verify no stray AuthStateProvider/claim usings remain**
+
+Run: `rg -n "AuthenticationStateProvider|System.Security.Claims" TelegramGroupsAdmin/Components/Shared/BackupPassphraseRotationDialog.razor TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor TelegramGroupsAdmin/Components/Shared/ContentDetection/StopWords.razor TelegramGroupsAdmin/Components/Shared/ContentDetection/TrainingData.razor`
+Expected: no output (all removed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Shared/BackupPassphraseRotationDialog.razor TelegramGroupsAdmin/Components/Shared/InviteManagementDialog.razor TelegramGroupsAdmin/Components/Shared/ContentDetection/StopWords.razor TelegramGroupsAdmin/Components/Shared/ContentDetection/TrainingData.razor
+git commit -F- <<'EOF'
+refactor(auth): migrate user-id consumers to WebUser cascade with guards
+
+Dialogs and content-detection pages read WebUser.Id instead of parsing the
+NameIdentifier claim; each sink guards against a null session so no null actor
+reaches the DB.
+
+Refs #464
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 12: Null-contract cleanup — guard the ToActor() sinks
+
+`WebUser!.ToActor()` appears in two shared components used inside settings pages. Per the null contract, reusable components guard rather than force-unwrap (they could render without the layout gate). Both are in method bodies, so a guard is feasible.
+
+**Files:**
+- Modify: `TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor:605`
+- Modify: `TelegramGroupsAdmin/Components/Shared/ContentDetection/CriticalChecks.razor:245`
+
+- [ ] **Step 1: WelcomeSystemConfig — guard SaveConfig**
+
+In `SaveConfig()` (lines 598-623), replace:
+
+```csharp
+        var actor = WebUser!.ToActor();
+```
+
+with:
+
+```csharp
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            _saving = false;
+            return;
+        }
+        var actor = WebUser.ToActor();
+```
+
+- [ ] **Step 2: CriticalChecks — guard the save**
+
+In the method around line 245, replace:
+
+```csharp
+        var actor = WebUser!.ToActor();
+        await ConfigService.SaveContentDetectionAsync(new ChatIdentity(0, "Global"), _config, actor);
+```
+
+with:
+
+```csharp
+        if (WebUser is null)
+        {
+            Snackbar.Add("Your session could not be verified. Please sign in again.", Severity.Error);
+            return;
+        }
+        var actor = WebUser.ToActor();
+        await ConfigService.SaveContentDetectionAsync(new ChatIdentity(0, "Global"), _config, actor);
+```
+
+(If `Snackbar` is not injected in `CriticalChecks.razor`, check the file — if absent, log via the component's existing error-surfacing mechanism instead; do not introduce a new injection if the file already has an error pattern.)
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build TelegramGroupsAdmin/TelegramGroupsAdmin.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TelegramGroupsAdmin/Components/Shared/WelcomeSystemConfig.razor TelegramGroupsAdmin/Components/Shared/ContentDetection/CriticalChecks.razor
+git commit -F- <<'EOF'
+refactor(auth): guard WebUser!.ToActor() in shared config components
+
+Reusable components can render without the layout gate, so they guard instead
+of force-unwrapping the WebUser cascade.
+
+Refs #464
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Task 13: Full verification pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the whole solution**
+
+Run: `dotnet build TelegramGroupsAdmin.sln`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `dotnet test TelegramGroupsAdmin.UnitTests/TelegramGroupsAdmin.UnitTests.csproj`
+Expected: PASS.
+
+- [ ] **Step 3: Run integration tests (Docker required)**
+
+Run: `dotnet test TelegramGroupsAdmin.IntegrationTests/TelegramGroupsAdmin.IntegrationTests.csproj`
+Expected: PASS.
+
+- [ ] **Step 4: Confirm no AuthStateProvider injection remains outside MainLayout**
+
+Run: `rg -n "@inject AuthenticationStateProvider" TelegramGroupsAdmin`
+Expected: only `Components/Layout/MainLayout.razor`.
+
+- [ ] **Step 5: Manual smoke test (run the app)**
+
+- Log in → land on an authorized page (no NRE).
+- In a second browser/incognito as an Owner, change the first user's permission level → within ~2 minutes the first session's circuit is torn down (redirect to login), or immediately on reload.
+- Disable the first user → same outcome.
+
+- [ ] **Step 6: Final review + push**
+
+Run: `git log --oneline develop..HEAD` to review the commit series, then push the branch:
+
+Run: `git push -u origin feat/auth-cookie-revalidation`
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** validator (Task 3), OnValidatePrincipal (Task 4), revalidating provider (Task 5), stamp claim (Task 2), permission-change stamp rotation (Task 6), #464 six-file migration (Tasks 9-11), null contract source + sinks (Tasks 8, 11, 12), tests (Tasks 3, 6, 7), `.gitignore` (already committed). All spec sections map to a task.
+- **Known adaptation point:** `SeedActiveUserAsync` (Task 7) and the exact fixture `SecurityStamp` source (Task 2 Step 10) depend on the real repository/seed APIs — each step says how to find them. These are integration seams, not placeholders in the design.
+- **Behavior-preservation flag:** TagManagement `IsInRole` semantics (Task 10) are reproduced exactly; the likely GlobalAdmin-exclusion bug is flagged for a separate decision.

--- a/docs/superpowers/specs/2026-06-18-auth-cookie-revalidation-design.md
+++ b/docs/superpowers/specs/2026-06-18-auth-cookie-revalidation-design.md
@@ -1,0 +1,280 @@
+# Auth Cookie Revalidation + WebUserIdentity Cascade Unification — Design
+
+**Date:** 2026-06-18
+**Issues:** #518 (auth cookies never revalidated against the DB), #464 (migrate pages off `AuthenticationStateProvider` to the `WebUserIdentity` cascade)
+**Branch:** `feat/auth-cookie-revalidation`
+
+## Problem
+
+Authentication cookies are issued as 30-day persistent, sliding cookies and are
+never revalidated against the database after sign-in. `UserRecord.SecurityStamp`
+is rotated on sensitive changes (password change/reset, TOTP enable/disable/reset)
+but nothing ever reads it back. There is no `OnValidatePrincipal` /
+`ISecurityStampValidator` wired into the cookie options, so a session's identity
+and permissions are frozen at login time for up to 30 days.
+
+For this app's threat model (few trusted admins, invite-only) the primary
+real-world consequence is **offboarding**: revoking an admin is effectively a soft
+suggestion for up to 30 days rather than an immediate action. The security-stamp
+infrastructure already exists, so the app currently pays the cost of rotating the
+stamp without getting any of the benefit.
+
+Separately (#464), several razor components inject `AuthenticationStateProvider`
+and hand-parse claims to compute permission flags or extract the current user id —
+the same anti-pattern the cascade was meant to replace. The two issues meet at one
+seam: the **permission claim**. This work fixes revalidation *and* unifies all
+pages onto the single `WebUserIdentity` cascade.
+
+## Goals
+
+- A web session reflects the database within a bounded window: disable/delete,
+  password/TOTP change, and permission change all take effect on live sessions
+  instead of lingering for up to 30 days.
+- One place reads identity claims (`MainLayout`); every other component reads the
+  cascaded `WebUserIdentity`.
+- A single, explicit, consistently-applied null-handling contract for the cascade.
+
+## Non-Goals
+
+- Adopting ASP.NET Core Identity / `AddIdentity`. The built-in
+  `SecurityStampValidator` is Identity-specific; this app uses hand-rolled cookie
+  auth, so we wire a custom handler instead.
+- Live, no-relogin permission refresh. A permission change rotates the stamp and
+  forces re-login (see Decision 3) — simpler and routes all sensitive changes
+  through one invalidation path.
+- Distributed-systems patterns (homelab single-instance per project philosophy).
+
+## Decisions (resolved during brainstorming)
+
+1. **Scope:** Do #518 and #464 together.
+2. **Mechanism:** Defense in depth — *both* `CookieAuthenticationEvents.OnValidatePrincipal`
+   (HTTP edge) *and* a `RevalidatingServerAuthenticationStateProvider` (in-circuit timer).
+3. **Permission change:** Rotate `SecurityStamp` on permission change → existing
+   sessions fail the stamp check → forced re-login. One unified invalidation path
+   for password, TOTP, and permission changes. (Drops #518's optional item 4 "live
+   permission refresh".)
+4. **Interval:** ~2 minutes for the in-circuit revalidation timer. (Full-page loads
+   and SignalR reconnects always revalidate via the HTTP-edge handler.)
+5. **Null contract:** Non-null by construction at the boundary (render gate + no
+   partial identity), guard-once in statement contexts, justified `!` / `?.` in
+   expression/markup contexts, fail-closed at sinks. See "Null-Handling Contract".
+
+## Architecture
+
+### Component 1 — Shared session validator (the single rule)
+
+A scoped service is the brain both revalidation mechanisms call, so the rule lives
+in exactly one place and cannot drift between the HTTP and circuit paths.
+
+```
+IUserSessionValidator
+    Task<bool> IsStillValidAsync(ClaimsPrincipal principal, CancellationToken ct)
+```
+
+Logic:
+1. Extract `ClaimTypes.NameIdentifier` and the new security-stamp claim.
+2. If either claim is null/empty → return **false** (fail closed).
+3. Load the user via `IUserRepository.GetByIdAsync(userId, ct)`.
+4. Return **false** if the user is null, `!Status.CanLogin` (Disabled/Deleted), or
+   `SecurityStamp != stampClaim`. Otherwise **true**.
+
+A DB failure during validation is treated as invalid (reject) — fail closed, never
+fail open to a stale session.
+
+### Component 2 — HTTP-edge handler (`OnValidatePrincipal`)
+
+Add `options.Events = new CookieAuthenticationEvents { OnValidatePrincipal = ... }`
+to the `AddCookie` options block in `AddCookieAuthentication`
+(`ServiceCollectionExtensions.cs:71`). On each fire:
+- Resolve `IUserSessionValidator` from `context.HttpContext.RequestServices`.
+- If invalid → `context.RejectPrincipal()` and `await context.HttpContext.SignOutAsync(...)`.
+
+No throttle. This handler only fires on full-page loads and SignalR (re)connection,
+which is infrequent for a Blazor Server app, and `GetByIdAsync` is a single indexed
+primary-key lookup. (The issue's suggested `AuthenticationProperties` throttle is
+deliberately omitted for simplicity at this scale.) This path also protects any
+non-circuit cookie-authed endpoint.
+
+### Component 3 — In-circuit revalidation (`RevalidatingServerAuthenticationStateProvider`)
+
+Replace the plain `ServerAuthenticationStateProvider` registration at
+`ServiceCollectionExtensions.cs:94` with a new subclass:
+
+```
+sealed class RevalidatingUserAuthenticationStateProvider : RevalidatingServerAuthenticationStateProvider
+{
+    protected override TimeSpan RevalidationInterval => TimeSpan.FromMinutes(2);
+    protected override Task<bool> ValidateAuthenticationStateAsync(
+        AuthenticationState state, CancellationToken ct)
+        // create a scope, resolve IUserSessionValidator, call IsStillValidAsync
+}
+```
+
+Returning false tears down the live circuit → redirect to login. This is the piece
+that kills an offboarded admin's *open tab* (the HTTP-edge handler alone would let
+an open tab survive until reload/reconnect). The interval constant lives in
+`AuthenticationConstants`.
+
+### Component 4 — Security-stamp claim (prerequisite)
+
+The stamp must be in the cookie to compare it. Add it in
+`AuthCookieService.CreateClaimsPrincipal` (the single source of truth for cookie
+claims, feeding both the live `SignInAsync` and the test-only `GenerateCookieValue`).
+
+The stamp is **not** added to `WebUserIdentity` — pages and the cascade must not see
+it. Instead the cookie-service methods (`SignInAsync`, `GenerateCookieValue`,
+`CreateClaimsPrincipal`) take the security stamp as an explicit parameter. The login
+call site (`AuthService.LoginAsync`, which already holds the `UserRecord`) passes
+`user.SecurityStamp`. Tests pass any value.
+
+A new claim type (e.g. `CustomClaimTypes.SecurityStamp`) is added.
+
+### Component 5 — Close the permission-change gap
+
+`UserManagementService.UpdatePermissionLevelAsync` (`UserManagementService.cs:17`)
+currently writes the new permission level but does **not** rotate the stamp. Add a
+call to `IUserRepository.UpdateSecurityStampAsync` after the permission write, in the
+same flow. Password change/reset (`AuthService`) and TOTP enable/disable/reset
+(`TotpService`) already rotate the stamp, so this is the only gap. Disable/delete
+need no stamp rotation — the validator's `Status.CanLogin` check catches them
+directly.
+
+### Component 6 — #464 cascade unification
+
+Migrate the remaining components off `@inject AuthenticationStateProvider` to the
+cascaded `[CascadingParameter] WebUserIdentity? WebUser`. `MainLayout` remains the
+*only* claim-parser (the cascade source).
+
+| File | Current | Action |
+|---|---|---|
+| `NavMenu.razor` | reads PermissionLevel claim | → `WebUser?.IsGlobalAdminOrHigher` |
+| `TagManagement.razor` | `IsInRole("Admin")\|\|IsInRole("Owner")` | → cascade flag — **verify exact tier semantics match** before swapping (IsInRole may not equal `IsGlobalAdminOrHigher`) |
+| `BackupPassphraseRotationDialog.razor` | NameIdentifier | → `WebUser?.Id` (guarded) |
+| `InviteManagementDialog.razor` | NameIdentifier | → `WebUser?.Id` (guarded) |
+| `StopWords.razor` | NameIdentifier (`_currentUserId` **unused**) | → **delete dead code** |
+| `TrainingData.razor` | NameIdentifier (`_currentUserId` **unused**) | → **delete dead code** |
+
+After each swap, drop now-unused usings/injects: `@inject AuthenticationStateProvider`,
+`@using Microsoft.AspNetCore.Components.Authorization`, `@using System.Security.Claims`,
+`@using TelegramGroupsAdmin.Auth` (verify no other reference remains before deleting).
+
+## Null-Handling Contract
+
+The cascade can legitimately be null in three situations: (1) the first render of a
+child page before `MainLayout`'s async `OnInitializedAsync` populates `_webUser`;
+(2) an authenticated principal missing the `NameIdentifier` claim (the source
+currently force-unwraps `_userId!`); (3) a reusable component rendered without a
+`MainLayout` ancestor (no cascade supplied). Today the codebase handles this
+inconsistently — some sites guard (`Messages.razor:229`, `BackupBrowser.razor:326`),
+others force-unwrap (`Messages.razor:418/562/794/808`, `WelcomeSystemConfig.razor:605`,
+`MainLayout.razor:117`). The force-unwraps are latent `NullReferenceException`s, and
+adding runtime principal re-issuing widens every null window.
+
+The contract, established by this work:
+
+1. **Source (`MainLayout`) — the precondition that makes everything below valid:**
+   - **No partial identities.** Remove the `_userId!` force-unwrap. If the principal
+     is authenticated but `NameIdentifier` is missing, treat it as not a usable
+     session (leave `_webUser` null, do not render authorized content) and log a
+     warning.
+   - **Render gate.** Do not render `@Body` until auth resolution completes. Net
+     effect: when an authorized page renders, an authenticated user's `WebUser` is
+     guaranteed non-null. *Implementation note:* gate on "auth resolution done", not
+     "is authenticated", so anonymous/login routes still render and the `[Authorize]`
+     redirect still fires. Verify login/anonymous pages are not regressed (check
+     whether they share `MainLayout`).
+
+2. **Statement-body contexts** (methods in `@code`): guard once
+   (`if (WebUser is null) return;`), then use `WebUser` unqualified. C# nullable flow
+   analysis narrows it to non-null, so no `!` is needed and there is no compiler
+   warning. Preferred wherever the syntax allows it.
+
+3. **Expression / markup contexts** where a guard statement is syntactically
+   impossible (attribute bindings, `@()` interpolations, expression-bodied members,
+   ternaries, render fragments):
+   - Use **`?.` + a safe default** when null should degrade gracefully — e.g.
+     `WebUser?.PermissionLevel >= GlobalAdmin` correctly hides an admin affordance
+     when null. (`Messages.razor:89` stays as-is.)
+   - Use **`WebUser!`** when there is no meaningful default and the gate guarantees
+     non-null — it documents the enforced invariant. (`Messages.razor:794` stays `!`.)
+   - The render gate does not *eliminate* `!`; it *legitimizes* it. A `WebUser!`
+     inside a gated `[Authorize]` page in an un-guardable syntactic position is a true
+     statement of a boundary-enforced invariant, not a smell.
+
+4. **Reusable components without the gate guarantee** (`WelcomeSystemConfig`,
+   `BackupBrowser`, the migrated dialogs): these can render outside a gated
+   `MainLayout`, so the invariant does **not** apply. They must **guard or `?.`**,
+   never `!`. `WelcomeSystemConfig.razor:605` `WebUser!.ToActor()` is in a method body
+   → convert to a guard.
+
+5. **Sinks fail closed:**
+   - The server validator rejects null/empty `NameIdentifier` or stamp claims.
+   - Audit-id sinks (`AddedBy` in the StopWords/TrainingData/dialog migrations) are
+     protected by the entry guard, so a null actor can never reach the DB — the
+     operation aborts instead.
+
+**Per-site audit rule for the migration:** for each `WebUser` use, classify it —
+(a) gated page + un-guardable syntax → `!` is OK; (b) gated page + statement body →
+guard; (c) reusable component → guard / `?.` always. We delete the `_userId!` at the
+source and the reusable-component force-unwraps; we keep (now-justified) the
+page-level `!`s in markup/expression positions.
+
+## Error Handling
+
+- Validator DB failure → treat session as invalid (fail closed).
+- Missing/empty identity claims → invalid session.
+- Permission-change stamp rotation shares the existing `UpdatePermissionLevelAsync`
+  transaction/flow; if the permission write succeeds the stamp rotation must also be
+  persisted (single save) so a session can't survive a successful downgrade.
+
+## Testing
+
+- **Unit — `IUserSessionValidator` truth table:** valid; missing user; Disabled;
+  Deleted; stamp mismatch; missing NameIdentifier claim; missing stamp claim. Each
+  asserts the expected valid/invalid result.
+- **Integration — revocation:** sign in (using the `GenerateCookieValue` helper to
+  mint a cookie with a chosen stamp), then in the DB rotate the stamp / disable /
+  delete / change permission, and assert the next validation rejects the session.
+- **Permission change:** assert `UpdatePermissionLevelAsync` rotates the stamp.
+- **Null contract:** a smoke test / manual verification that an authorized page does
+  not NRE on first render and that the render gate does not regress the login page.
+
+## Affected Files
+
+- `TelegramGroupsAdmin/ServiceCollectionExtensions.cs` — add `OnValidatePrincipal`;
+  swap the `AuthenticationStateProvider` registration to the revalidating subclass.
+- `TelegramGroupsAdmin/Constants/AuthenticationConstants.cs` — revalidation-interval
+  constant.
+- `TelegramGroupsAdmin/Services/Auth/AuthCookieService.cs` — add stamp claim; thread
+  the stamp parameter through `SignInAsync` / `GenerateCookieValue` /
+  `CreateClaimsPrincipal`.
+- `TelegramGroupsAdmin/Auth/CustomClaimTypes.cs` — add `SecurityStamp` claim type.
+- `TelegramGroupsAdmin/Services/AuthService.cs` — pass `user.SecurityStamp` at the
+  `LoginAsync` sign-in call site.
+- `TelegramGroupsAdmin/Services/UserManagementService.cs` — rotate stamp in
+  `UpdatePermissionLevelAsync`.
+- New: `IUserSessionValidator` + implementation; `RevalidatingUserAuthenticationStateProvider`.
+- `TelegramGroupsAdmin/Components/Layout/MainLayout.razor` — no partial identity +
+  render gate.
+- `#464` migration: `NavMenu.razor`, `TagManagement.razor`,
+  `BackupPassphraseRotationDialog.razor`, `InviteManagementDialog.razor`,
+  `StopWords.razor`, `TrainingData.razor`.
+- Null-contract cleanup: `WelcomeSystemConfig.razor` (guard `ToActor()`); confirm
+  `Messages.razor` page-level `!`s remain valid under the gate.
+- `.gitignore` — triage-artifact ignores (already committed on this branch).
+
+## Acceptance Criteria
+
+- [ ] Disabling/deleting a web user ends active sessions within the validation
+      interval (open tab) and immediately on next reload/reconnect.
+- [ ] Rotating the security stamp (password change/reset, TOTP enable/disable/reset,
+      permission change) invalidates other sessions.
+- [ ] Permission change forces re-login with fresh claims; no stale elevated access.
+- [ ] Security-stamp claim is added at sign-in and compared on validation; null
+      claims fail closed.
+- [ ] All 6 #464 files read the `WebUserIdentity` cascade; no remaining
+      `AuthenticationStateProvider` injection outside `MainLayout`.
+- [ ] Null contract applied per the per-site audit rule; no force-unwrap that isn't
+      backed by the render-gate invariant; reusable components guard.
+- [ ] No NRE on first render of an authorized page; login/anonymous pages not
+      regressed by the render gate.


### PR DESCRIPTION
Closes #518
Closes #464

## Summary

Makes web sessions reflect the database within a bounded window, and unifies all components onto the single `WebUserIdentity` cascade.

**#518 — DB session revalidation (security):** auth cookies were issued for 30 days and never rechecked, so the `SecurityStamp` was rotated but never read. Now:
- The security stamp is carried as a cookie claim (`AuthCookieService.CreateClaimsPrincipal` — single source of truth).
- A shared, fail-closed `IUserSessionValidator` checks the user exists, is `Active`, and the stamp matches.
- Two mechanisms call it: `CookieAuthenticationEvents.OnValidatePrincipal` (HTTP edge) and a `RevalidatingServerAuthenticationStateProvider` (in-circuit, every 2 min).
- Permission changes now rotate the stamp → forced re-login (one unified invalidation path with password/TOTP changes).

**#464 — cascade unification:** migrated `NavMenu`, `TagManagement`, `BackupPassphraseRotationDialog`, `InviteManagementDialog`, `StopWords`, `TrainingData` off `@inject AuthenticationStateProvider` onto `[CascadingParameter] WebUserIdentity`. `MainLayout` is now the only claim-parser, no longer builds a partial identity, and gates body render on auth resolution (the null-contract boundary). Reusable components guard against null; `TagManagement` behavior preserved exactly (Admin-or-Owner — see note).

Design + plan: `docs/superpowers/specs/2026-06-18-auth-cookie-revalidation-design.md`, `docs/superpowers/plans/2026-06-18-auth-cookie-revalidation.md`.

## Notes / follow-ups

- **`TagManagement` pre-existing bug preserved, not fixed:** `IsInRole("Admin")||IsInRole("Owner")` excludes GlobalAdmin from editing tags. Reproduced exactly to avoid silently changing authorization; worth a separate issue/decision.
- **E2E flake #503 reopened:** a full E2E run surfaced a pre-existing `40P01` deadlock in `SharedE2ETestBase`'s `TRUNCATE` reset (issue #503 was closed but never implemented — reopened with evidence). Unrelated to this feature; the render-gate timing shift just made it more visible. Profile/Settings page-object waits were hardened here to remove the timing-sensitivity this branch introduced.

## Test Plan

- [x] Unit — 2020/2020 (incl. `UserSessionValidator` truth table, permission-change stamp rotation)
- [x] Component (bUnit) — 1057/1057
- [x] Integration (real Postgres) — 689/689 (incl. new `SessionRevocationTests`: stamp rotation + disable revoke a session)
- [x] E2E — 290/291 (new `SessionRevocationE2ETests` prove a live browser session is revoked on stamp rotation + permission change; the 1 failure is the pre-existing #503 TRUNCATE deadlock, passes in isolation)
- [x] `dotnet build TelegramGroupsAdmin.sln` — 0 warnings / 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
